### PR TITLE
DFC-6263, DFC-6242, DFC-6264 validation to error on none keyboard cha…

### DIFF
--- a/src/Dfc.CourseDirectory.Web/ViewComponents/CostDescription/CostDescriptionModel.cs
+++ b/src/Dfc.CourseDirectory.Web/ViewComponents/CostDescription/CostDescriptionModel.cs
@@ -9,6 +9,7 @@ namespace Dfc.CourseDirectory.Web.ViewComponents.CostDescription
     public class CostDescriptionModel
     {
         [MaxLength(255, ErrorMessage = "Cost description must be 255 characters or less")]
+        [RegularExpression(@"[a-zA-Z0-9 \¬\!\£\$\%\^\&\*\(\)_\+\-\=\{\}\[\]\;\:\@\'\#\~\,\<\>\.\?\/\|\`\" + "\"" + @"\\]+", ErrorMessage = "Invalid characters")]
         public string CostDescription { get; set; }
         public string LabelText { get; set; }
         public string HintText { get; set; }

--- a/src/Dfc.CourseDirectory.Web/ViewComponents/CourseName/CourseNameModel.cs
+++ b/src/Dfc.CourseDirectory.Web/ViewComponents/CourseName/CourseNameModel.cs
@@ -10,7 +10,7 @@ namespace Dfc.CourseDirectory.Web.ViewComponents.CourseName
     {
         [Required(AllowEmptyStrings = false, ErrorMessage = "Enter Course Name")]
         [MaxLength(255, ErrorMessage = "The maximum length of Course Name is 255 characters")]
-        [RegularExpression(@"[a-zA-Z0-9 \¬\!\£\$\%\^\&\*\(\)_\+\-\=\{\}\[\]\;\:\@\'\#\~\,\<\>\.\?\/\|\`\" + "\"" + "]+", ErrorMessage = "Invalid characters")]
+        [RegularExpression(@"[a-zA-Z0-9 \¬\!\£\$\%\^\&\*\(\)_\+\-\=\{\}\[\]\;\:\@\'\#\~\,\<\>\.\?\/\|\`\" + "\"" + @"\\]+", ErrorMessage = "Invalid characters")]
         public string CourseName { get; set; }
         public string LabelText { get; set; }
         public string HintText { get; set; }

--- a/src/Dfc.CourseDirectory.Web/ViewComponents/CourseProviderReference/CourseProviderReferenceModel.cs
+++ b/src/Dfc.CourseDirectory.Web/ViewComponents/CourseProviderReference/CourseProviderReferenceModel.cs
@@ -11,7 +11,7 @@ namespace Dfc.CourseDirectory.Web.ViewComponents.CourseProviderReference
     public class CourseProviderReferenceModel
     {
         [MaxLength(255, ErrorMessage = "The maximum length of 'ID' is 255 characters")]
-        [RegularExpression(@"[a-zA-Z0-9 \¬\!\£\$\%\^\&\*\(\)_\+\-\=\{\}\[\]\;\:\@\'\#\~\,\<\>\.\?\/\|\`\" + "\"" + "]+", ErrorMessage = "Invalid characters")]
+        [RegularExpression(@"[a-zA-Z0-9 \¬\!\£\$\%\^\&\*\(\)_\+\-\=\{\}\[\]\;\:\@\'\#\~\,\<\>\.\?\/\|\`\" + "\"" + @"\\]+", ErrorMessage = "Invalid characters")]
         public string CourseProviderReference { get; set; }
         public string LabelText { get; set; }
         public string HintText { get; set; }


### PR DESCRIPTION
DFC-6263, DFC-6242, DFC-6264 validation to error on none keyboard chars like emojis etc. for ID, Course name and Cost description input fields. It also allows the backslash which was missed in previous fixes.

https://skillsfundingagency.atlassian.net/browse/DFC-6263
https://skillsfundingagency.atlassian.net/browse/DFC-6242
https://skillsfundingagency.atlassian.net/browse/DFC-6264