### PR TITLE
NCSD-742: Azure search indexer fix

### DIFF
--- a/Resources/AzureSearch/SearchIndexer.json
+++ b/Resources/AzureSearch/SearchIndexer.json
@@ -9,8 +9,7 @@
                 "sourceFieldName":  "pcd",
                 "targetFieldName":  "pcd",
                 "mappingFunction" : {
-                    "name" : "base64Decode",
-                    "parameters" : { "useHttpServerUtilityUrlTokenDecode" : true }
+                    "name" : "base64Encode"
                 }
             }
         ]


### PR DESCRIPTION
Wrong mapping function used in the Azure search indexer