### PR TITLE
Move active provider resolution into a resource filter

### DIFF
--- a/src/Dfc.CourseDirectory.WebV2/Filters/CurrentProviderResourceFilter.cs
+++ b/src/Dfc.CourseDirectory.WebV2/Filters/CurrentProviderResourceFilter.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using Dfc.CourseDirectory.WebV2.Security;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Dfc.CourseDirectory.WebV2.Filters
+{
+    public class CurrentProviderResourceFilter : IAsyncResourceFilter
+    {
+        public const string RouteValueKey = "providerId";
+
+        public async Task OnResourceExecutionAsync(ResourceExecutingContext context, ResourceExecutionDelegate next)
+        {
+            await TryAssignFeature();
+
+            if (context.Result == null)
+            {
+                await next();
+            }
+
+            async Task TryAssignFeature()
+            {
+                var providerInfoCache = context.HttpContext.RequestServices.GetRequiredService<IProviderInfoCache>();
+                var currentUserProvider = context.HttpContext.RequestServices.GetRequiredService<ICurrentUserProvider>();
+
+                // For Provider {Super}Users the provider comes from their identity token.
+                // For Admin or Helpdesk users there should be a route value indicating the provider.
+                // If Provider {Super}Users specify the route value it's ignored.
+
+                var user = currentUserProvider.GetCurrentUser();
+
+                if (user == null)
+                {
+                    return;
+                }
+
+                Guid providerId;
+
+                var routeProviderId = TryGetProviderIdFromRouteValues();
+
+                if (user.IsDeveloper || user.IsHelpdesk)
+                {
+                    if (!routeProviderId.HasValue)
+                    {
+                        return;
+                    }
+                    else
+                    {
+                        providerId = routeProviderId.Value;
+                    }
+                }
+                else // user.IsProvider == true
+                {
+                    var usersOwnProviderId = user.ProviderId.Value;
+
+                    // Route param, if specified, must match user's own org
+                    if (routeProviderId.HasValue && routeProviderId.Value != usersOwnProviderId)
+                    {
+                        context.Result = new ForbidResult();
+                        return;
+                    }
+
+                    providerId = usersOwnProviderId;
+                }
+
+                var providerInfo = await providerInfoCache.GetProviderInfo(providerId);
+                if (providerInfo != null)
+                {
+                    context.HttpContext.Features.Set(new CurrentProviderFeature(providerInfo));
+                }
+            }
+
+            Guid? TryGetProviderIdFromRouteValues()
+            {
+                var routeValueProvider = new RouteValueProvider(
+                    BindingSource.Path,
+                    context.RouteData.Values);
+
+                var queryStringValueProvider = new QueryStringValueProvider(
+                    BindingSource.Query,
+                    context.HttpContext.Request.Query,
+                    CultureInfo.InvariantCulture);
+
+                var matches = routeValueProvider.GetValue(RouteValueKey).Values
+                    .Concat(queryStringValueProvider.GetValue(RouteValueKey).Values)
+                    .Distinct()
+                    .ToList();
+
+                if (matches.Count == 1)
+                {
+                    if (Guid.TryParse(matches.Single(), out var providerId))
+                    {
+                        return providerId;
+                    }
+                }
+
+                return null;
+            }
+        }
+    }
+
+    public class CurrentProviderFeature
+    {
+        public CurrentProviderFeature(ProviderInfo providerInfo)
+        {
+            ProviderInfo = providerInfo;
+        }
+
+        public ProviderInfo ProviderInfo { get; }
+    }
+}

--- a/src/Dfc.CourseDirectory.WebV2/Filters/RedirectToProviderSelectionActionFilter.cs
+++ b/src/Dfc.CourseDirectory.WebV2/Filters/RedirectToProviderSelectionActionFilter.cs
@@ -40,15 +40,7 @@ namespace Dfc.CourseDirectory.WebV2.Filters
 
             foreach (var p in providerInfoParameters)
             {
-                if (context.ModelState[p.Name]?.Errors.Any(e => e.Exception is ResourceDoesNotExistException) ?? false)
-                {
-                    context.Result = new NotFoundResult();
-                }
-                else if (context.ModelState[p.Name]?.Errors.Any(e => e.Exception is NotAuthorizedException) ?? false)
-                {
-                    context.Result = new ForbidResult();
-                }
-                else if (!context.ActionArguments.TryGetValue(p.Name, out var actionArg) || actionArg == null)
+                if (!context.ActionArguments.TryGetValue(p.Name, out var actionArg) || actionArg == null)
                 {
                     context.Result = new RedirectToActionResult(
                         "Index",

--- a/src/Dfc.CourseDirectory.WebV2/ModelBinding/CurrentProviderModelBinder.cs
+++ b/src/Dfc.CourseDirectory.WebV2/ModelBinding/CurrentProviderModelBinder.cs
@@ -1,11 +1,6 @@
-﻿using System;
-using System.Globalization;
-using System.Linq;
-using System.Security.Claims;
-using System.Threading.Tasks;
-using Dfc.CourseDirectory.WebV2.Security;
+﻿using System.Threading.Tasks;
+using Dfc.CourseDirectory.WebV2.Filters;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace Dfc.CourseDirectory.WebV2.ModelBinding
 {
@@ -15,8 +10,7 @@ namespace Dfc.CourseDirectory.WebV2.ModelBinding
         {
             if (context.Metadata.ModelType == typeof(ProviderInfo))
             {
-                var providerInfoCache = context.Services.GetRequiredService<IProviderInfoCache>();
-                return new CurrentProviderModelBinder(providerInfoCache);
+                return new CurrentProviderModelBinder();
             }
 
             return null;
@@ -25,124 +19,26 @@ namespace Dfc.CourseDirectory.WebV2.ModelBinding
 
     public class CurrentProviderModelBinder : IModelBinder
     {
-        public const string RouteValueKey = "providerId";
-
-        private readonly IProviderInfoCache _providerInfoCache;
-
-        public CurrentProviderModelBinder(IProviderInfoCache providerInfoCache)
-        {
-            _providerInfoCache = providerInfoCache;
-        }
-
-        public async Task BindModelAsync(ModelBindingContext bindingContext)
+        public Task BindModelAsync(ModelBindingContext bindingContext)
         {
             if (bindingContext.ModelType != typeof(ProviderInfo))
             {
                 bindingContext.Result = ModelBindingResult.Failed();
-                return;
+                return Task.CompletedTask;
             }
 
-            // For Provider {Super}Users the provider comes from their identity token.
-            // For Admin or Helpdesk users there should be a route value indicating the provider.
-            // If Provider {Super}Users specify the route value it's ignored.
+            var feature = bindingContext.HttpContext.Features.Get<CurrentProviderFeature>();
 
-            var user = bindingContext.HttpContext.User;
-            var role = user.FindFirst(ClaimTypes.Role).Value;
-
-            Guid providerId;
-
-            var routeProviderId = TryGetProviderIdFromRouteValues();
-
-            if (role == RoleNames.Developer || role == RoleNames.Helpdesk)
+            if (feature == null)
             {
-                if (!routeProviderId.HasValue)
-                {
-                    bindingContext.Result = ModelBindingResult.Failed();
-                    return;
-                }
-                else
-                {
-                    providerId = routeProviderId.Value;
-                }
-            }
-            else if (role == RoleNames.ProviderSuperUser || role == RoleNames.ProviderUser)
-            {
-                var usersOwnProviderId = Guid.Parse(user.FindFirst("ProviderId").Value);
-
-                // Route param, if specified, must match user's own org
-                if (routeProviderId.HasValue && routeProviderId.Value != usersOwnProviderId)
-                {
-                    bindingContext.ModelState.AddModelError(
-                        bindingContext.FieldName,
-                        new NotAuthorizedException(),
-                        bindingContext.ModelMetadata);
-                    bindingContext.Result = ModelBindingResult.Failed();
-                    return;
-                }
-
-                providerId = usersOwnProviderId;
-            }
-            else
-            {
-                bindingContext.Result = ModelBindingResult.Failed();
-                return;
-            }
-
-            var providerInfo = await _providerInfoCache.GetProviderInfo(providerId);
-            if (providerInfo == null)
-            {
-                bindingContext.ModelState.AddModelError(
-                    bindingContext.FieldName,
-                    new ResourceDoesNotExistException(ResourceType.Provider, providerId),
-                    bindingContext.ModelMetadata);
                 bindingContext.Result = ModelBindingResult.Failed();
             }
             else
             {
-                bindingContext.Result = ModelBindingResult.Success(providerInfo);
-                bindingContext.HttpContext.Features.Set(new CurrentProviderFeature(providerInfo));
+                bindingContext.Result = ModelBindingResult.Success(feature.ProviderInfo);
             }
 
-            Guid? TryGetProviderIdFromRouteValues()
-            {
-                var routeValueProvider = new RouteValueProvider(
-                    BindingSource.Path,
-                    bindingContext.ActionContext.RouteData.Values);
-
-                var queryStringValueProvider = new QueryStringValueProvider(
-                    BindingSource.Query,
-                    bindingContext.HttpContext.Request.Query,
-                    CultureInfo.InvariantCulture);
-
-                var matches = routeValueProvider.GetValue(RouteValueKey).Values
-                    .Concat(queryStringValueProvider.GetValue(RouteValueKey).Values)
-                    .Distinct()
-                    .ToList();
-
-                if (matches.Count == 1)
-                {
-                    if (!Guid.TryParse(matches.Single(), out providerId))
-                    {
-                        return null;
-                    }
-                }
-                else
-                {
-                    return null;
-                }
-
-                return providerId;
-            }
+            return Task.CompletedTask;
         }
-    }
-
-    public class CurrentProviderFeature
-    {
-        public CurrentProviderFeature(ProviderInfo providerInfo)
-        {
-            ProviderInfo = providerInfo;
-        }
-
-        public ProviderInfo ProviderInfo { get; }
     }
 }

--- a/src/Dfc.CourseDirectory.WebV2/RedirectToActionResultExtensions.cs
+++ b/src/Dfc.CourseDirectory.WebV2/RedirectToActionResultExtensions.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.Generic;
-using Dfc.CourseDirectory.WebV2.ModelBinding;
+using Dfc.CourseDirectory.WebV2.Filters;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 
@@ -12,7 +12,7 @@ namespace Dfc.CourseDirectory.WebV2
             ProviderInfo providerInfo)
         {
             var routeValues = (IDictionary<string, object>)result.RouteValues ?? new Dictionary<string, object>();
-            routeValues[CurrentProviderModelBinder.RouteValueKey] = providerInfo.ProviderId;
+            routeValues[CurrentProviderResourceFilter.RouteValueKey] = providerInfo.ProviderId;
 
             result.RouteValues = new RouteValueDictionary(routeValues);
 

--- a/src/Dfc.CourseDirectory.WebV2/Security/ClaimsPrincipalCurrentUserProvider.cs
+++ b/src/Dfc.CourseDirectory.WebV2/Security/ClaimsPrincipalCurrentUserProvider.cs
@@ -33,6 +33,11 @@ namespace Dfc.CourseDirectory.WebV2.Security
         {
             var user = _httpContextAccessor.HttpContext.User;
 
+            if (!user.Identity.IsAuthenticated)
+            {
+                return null;
+            }
+
             return MapUserInfoFromPrincipal(user);
         }
     }

--- a/src/Dfc.CourseDirectory.WebV2/ServiceCollectionExtensions.cs
+++ b/src/Dfc.CourseDirectory.WebV2/ServiceCollectionExtensions.cs
@@ -51,6 +51,7 @@ namespace Dfc.CourseDirectory.WebV2
                     options.Conventions.Add(new AddFeaturePropertyModelConvention());
                     options.Conventions.Add(new AuthorizeActionModelConvention());
 
+                    options.Filters.Add(new CurrentProviderResourceFilter());
                     options.Filters.Add(new RedirectToProviderSelectionActionFilter());
                     options.Filters.Add(new VerifyApprenticeshipIdActionFilter());
                     options.Filters.Add(new ResourceDoesNotExistExceptionFilter());

--- a/src/Dfc.CourseDirectory.WebV2/TagHelpers/CurrentProviderFormTagHelper.cs
+++ b/src/Dfc.CourseDirectory.WebV2/TagHelpers/CurrentProviderFormTagHelper.cs
@@ -1,4 +1,4 @@
-﻿using Dfc.CourseDirectory.WebV2.ModelBinding;
+﻿using Dfc.CourseDirectory.WebV2.Filters;
 using Dfc.CourseDirectory.WebV2.Security;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Razor.TagHelpers;
@@ -46,7 +46,7 @@ namespace Dfc.CourseDirectory.WebV2.TagHelpers
 
             var updatedAction = QueryHelpers.AddQueryString(
                 resolvedAction,
-                CurrentProviderModelBinder.RouteValueKey,
+                CurrentProviderResourceFilter.RouteValueKey,
                 currentProviderId.ToString());
 
             output.Attributes.SetAttribute("action", updatedAction);

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FilterTests/RedirectToProviderSelectionActionFilterTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FilterTests/RedirectToProviderSelectionActionFilterTests.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Net;
-using System.Net.Http;
+﻿using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Xunit;
@@ -30,35 +28,6 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FilterTests
             response.EnsureSuccessStatusCode();
             var textResponse = await response.Content.ReadAsStringAsync();
             Assert.Equal("Select Provider", textResponse);
-        }
-
-        [Fact]
-        public async Task ProviderDoesNotExist_ReturnsNotFound()
-        {
-            // Arrange
-            await User.AsDeveloper();
-
-            // Act
-            var response = await _httpClientWithAutoRedirects.GetAsync(
-                $"RedirectToProviderSelectionActionFilterTest?providerId={Guid.NewGuid()}");
-
-            // Assert
-            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
-        }
-
-        [Fact]
-        public async Task ProviderDoesNotMatchUsersOwnProvider_ReturnsForbidden()
-        {
-            // Arrange
-            var providerId = Guid.NewGuid();
-            await User.AsProviderUser(providerId, Models.ProviderType.Both);
-
-            // Act
-            var response = await _httpClientWithAutoRedirects.GetAsync(
-                $"RedirectToProviderSelectionActionFilterTest?providerId={Guid.NewGuid()}");
-
-            // Assert
-            Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
         }
     }
 


### PR DESCRIPTION
Previously it was done in a model binder so wasn't always available.