### PR TITLE
Fix upserting QA status

### DIFF
--- a/src/Dfc.CourseDirectory.Core/DataStore/Sql/QueryHandlers/EnsureApprenticeshipQAStatusSetForProviderHandler.cs
+++ b/src/Dfc.CourseDirectory.Core/DataStore/Sql/QueryHandlers/EnsureApprenticeshipQAStatusSetForProviderHandler.cs
@@ -12,10 +12,13 @@ namespace Dfc.CourseDirectory.Core.DataStore.Sql.QueryHandlers
         public async Task<None> Execute(SqlTransaction transaction, EnsureApprenticeshipQAStatusSetForProvider query)
         {
             var sql = @"
+DECLARE @DefaultStatus INT = 1
+
 MERGE Pttcd.Providers AS target
 USING (SELECT @ProviderId ProviderId) AS source
 ON source.ProviderId = target.ProviderId
-WHEN NOT MATCHED THEN INSERT (ProviderId, ApprenticeshipQAStatus) VALUES (source.ProviderId, 1);";
+WHEN NOT MATCHED THEN INSERT (ProviderId, ApprenticeshipQAStatus) VALUES (source.ProviderId, @DefaultStatus)
+WHEN MATCHED AND target.ApprenticeshipQAStatus IS NULL THEN UPDATE SET ApprenticeshipQAStatus = @DefaultStatus;";
 
             var paramz = new { query.ProviderId };
 


### PR DESCRIPTION
A previous sign in action creates the provider record with a null QA
status. Fix the merge statement to handle a null value as well as
missing row.