### PR TITLE
PTCD-138 Changed the default ProviderType = Both when creating new provider via UKRLP sync + unit tests changes

### DIFF
--- a/src/Dfc.CourseDirectory.WebV2/Helpers/UkrlpSyncHelper.cs
+++ b/src/Dfc.CourseDirectory.WebV2/Helpers/UkrlpSyncHelper.cs
@@ -58,7 +58,7 @@ namespace Dfc.CourseDirectory.WebV2.Helpers
                         DateUpdated = _clock.UtcNow,
                         UpdatedBy = updatedBy,
                         UnitedKingdomProviderReferenceNumber = ukprn.ToString(),
-                        ProviderType = ProviderType.FE, // Set to FE by default
+                        ProviderType = ProviderType.Both, 
                         ProviderContact = upsertCommand.ProviderContact,
                         ProviderName = upsertCommand.ProviderName,
                         ProviderStatus = upsertCommand.ProviderStatus,

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/Helpers/UkrlpSyncHelperTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/Helpers/UkrlpSyncHelperTests.cs
@@ -103,6 +103,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.Helpers
             Assert.True(signInContext.UserInfo.Email == updatedProvider.UpdatedBy);
             Assert.True(ukrlpProviderData.UnitedKingdomProviderReferenceNumber == updatedProvider.UnitedKingdomProviderReferenceNumber);
             Assert.True(ukrlpProviderData.ProviderStatus == updatedProvider.ProviderStatus);
+            Assert.True(updatedProvider.ProviderType == ProviderType.Both);
             Assert.True(ukrlpProviderData.ProviderContact.First().ContactAddress.Locality == updatedProvider.ProviderContact.First().ContactAddress.Locality);
             Assert.True(ukrlpProviderData.ProviderContact.First().ContactPersonalDetails.PersonFamilyName == updatedProvider.ProviderContact.First().ContactPersonalDetails.PersonFamilyName);
         }


### PR DESCRIPTION
Changed the default ProviderType = Both when creating new provider via UKRLP sync