### PR TITLE
remove passed notificationcheck as this is covered by other tests.

### DIFF
--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/NewApprenticeshipProvider/QANotificationsTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/NewApprenticeshipProvider/QANotificationsTests.cs
@@ -19,7 +19,6 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         [InlineData(ApprenticeshipQAStatus.Submitted | ApprenticeshipQAStatus.UnableToComplete, "pttcd-new-apprenticeship-provider__qa-notifications-submitted")]
         [InlineData(ApprenticeshipQAStatus.InProgress, "pttcd-new-apprenticeship-provider__qa-notifications-submitted")]
         [InlineData(ApprenticeshipQAStatus.Failed, "pttcd-new-apprenticeship-provider__qa-notifications-failed")]
-        [InlineData(ApprenticeshipQAStatus.Passed, "pttcd-new-apprenticeship-provider__qa-notifications-passed")]
         public async Task RendersCorrectMessage(ApprenticeshipQAStatus qaStatus, string expectedNotificationId)
         {
             // Arrange


### PR DESCRIPTION
- Remove passed notification check as the passed banner is no visible for providers that have either closed the notification or if the provider has been migrated as passed (without a submission).
