### PR TITLE
ptcd-306 #amended email regex to handle different domains.

### DIFF
--- a/src/Dfc.CourseDirectory.Web/Views/Apprenticeships/Details/Index.cshtml
+++ b/src/Dfc.CourseDirectory.Web/Views/Apprenticeships/Details/Index.cshtml
@@ -57,8 +57,8 @@
             @{
                 var regex = RegexPattern.AllowEverything;
             }
-            @{ var emailRegEx = @"^([a-zA-Z0-9_\-\.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([a-zA-Z0-9\-]+\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\]?)$"; }
-            @{ var telephoneRegEx = @"^(((\+44)? ?(\(0\))? ?)|(0))( ?[0-9]{3,4}){3}?$";}
+            @{ var emailRegEx = @"^([a-zA-Z0-9_\-\.\$\%!#$%&'*+-\/=?^_`{|}~]+)@([a-zA-Z0-9_\-\.]+)\.([a-zA-Z]{2,10})$"; }
+            @{ var telephoneRegEx = @" ^ (((\+44)? ?(\(0\))? ?)|(0))( ?[0-9]{3,4}){3}?$";}
             @{ var websiteRegEx = @"^([-a-zA-Z0-9]{2,256}\.)+[a-z]{2,10}(\/.*)?";}
 
             <div class="govuk-character-count" id="InformationContainer">


### PR DESCRIPTION
ptcd-306 #updated email regex validation to follow https://en.wikipedia.org/wiki/Email_address#RFC_specification a little bit better.

**Valid Email formats tested.**
a-persons-name@se.training
kevin_joy@fdf.uk.com
KEVIN_JOY@esynery-solutions.co.uk
KEVIN$@esyn.uk.com
2@t.com
$@sd.com
.@domain.com
!#$%&'*+-/=?^_`{|}~@madeupdomain.com
kevin'joy@esyn.co.uk
kevin@kevin.com
kevin@domain.me
kevin@domain.ltd
kevin@domain.org
kevin@domain.co
kevin@gov.uk
kevin@test.io
kevin@domain.london
kevin'joy@domain.xyz
kevin@media.media
kevin-joy@domain.com

 **Rejected Email Formats** 
kevin@m.m
:@ds.com
kevin.joy@.com
@fd.com
tesT@192.168.0.1

