### PR TITLE
Commit SQL transction at the end of function execution

### DIFF
--- a/src/Dfc.CourseDirectory.Functions/CommitSqlTransactionFunctionInvocationFilter.cs
+++ b/src/Dfc.CourseDirectory.Functions/CommitSqlTransactionFunctionInvocationFilter.cs
@@ -1,0 +1,38 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Dfc.CourseDirectory.Core.DataStore.Sql;
+using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Dfc.CourseDirectory.Functions
+{
+#pragma warning disable CS0618 // Type or member is obsolete
+    // IFunctionInvocationFilter is not obsolete just not complete - https://github.com/Azure/azure-webjobs-sdk/issues/1284
+    public class CommitSqlTransactionFunctionInvocationFilter : IFunctionInvocationFilter
+    {
+        private readonly FunctionInstanceServicesCatalog _functionInstanceServicesCatalog;
+
+        public CommitSqlTransactionFunctionInvocationFilter(FunctionInstanceServicesCatalog functionInstanceServicesCatalog)
+        {
+            _functionInstanceServicesCatalog = functionInstanceServicesCatalog;
+        }
+
+        public Task OnExecutedAsync(FunctionExecutedContext executedContext, CancellationToken cancellationToken)
+        {
+            var instanceServices = _functionInstanceServicesCatalog.GetFunctionServices(executedContext.FunctionInstanceId);
+
+            var sqlTransactionMarker = instanceServices.GetRequiredService<SqlTransactionMarker>();
+            if (sqlTransactionMarker.GotTransaction)
+            {
+                sqlTransactionMarker.Transaction.Commit();
+                sqlTransactionMarker.OnTransactionCompleted();
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task OnExecutingAsync(FunctionExecutingContext executingContext, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+    }
+#pragma warning restore CS0618 // Type or member is obsolete
+}

--- a/src/Dfc.CourseDirectory.Functions/FunctionInstanceServicesCatalog.cs
+++ b/src/Dfc.CourseDirectory.Functions/FunctionInstanceServicesCatalog.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Azure.WebJobs.Host.Executors;
+
+namespace Dfc.CourseDirectory.Functions
+{
+    public class FunctionInstanceServicesCatalog : IJobActivatorEx
+    {
+        private readonly ConditionalWeakTable<IFunctionInstanceEx, IServiceProvider> _instanceServices;
+        private readonly IJobActivatorEx _innerActivator;
+
+        public FunctionInstanceServicesCatalog(IJobActivator innerActivator)
+        {
+            _instanceServices = new ConditionalWeakTable<IFunctionInstanceEx, IServiceProvider>();
+            _innerActivator = (IJobActivatorEx)innerActivator;
+        }
+
+        public IServiceProvider GetFunctionServices(Guid instanceId) =>
+            _instanceServices.SingleOrDefault(k => k.Key.Id == instanceId).Value;
+
+        T IJobActivatorEx.CreateInstance<T>(IFunctionInstanceEx functionInstance)
+        {
+            _instanceServices.Add(functionInstance, functionInstance.InstanceServices);
+            return _innerActivator.CreateInstance<T>(functionInstance);
+        }
+
+        T IJobActivator.CreateInstance<T>() => _innerActivator.CreateInstance<T>();
+    }
+}

--- a/src/Dfc.CourseDirectory.Functions/Startup.cs
+++ b/src/Dfc.CourseDirectory.Functions/Startup.cs
@@ -5,6 +5,7 @@ using Dfc.CourseDirectory.Core.DataStore.Sql;
 using Dfc.CourseDirectory.Core.ReferenceData.Lars;
 using Dfc.CourseDirectory.Functions;
 using Microsoft.Azure.Functions.Extensions.DependencyInjection;
+using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -30,6 +31,8 @@ namespace Dfc.CourseDirectory.Functions
 
             builder.Services.AddTransient<LarsDataImporter>();
             builder.Services.AddTransient<IClock, FrozenSystemClock>();
+            builder.Services.Decorate<IJobActivator, FunctionInstanceServicesCatalog>();
+            builder.Services.AddSingleton(sp => (FunctionInstanceServicesCatalog)sp.GetRequiredService<IJobActivator>());
 
             IConfiguration GetConfiguration()
             {

--- a/src/Dfc.CourseDirectory.Functions/Startup.cs
+++ b/src/Dfc.CourseDirectory.Functions/Startup.cs
@@ -33,6 +33,9 @@ namespace Dfc.CourseDirectory.Functions
             builder.Services.AddTransient<IClock, FrozenSystemClock>();
             builder.Services.Decorate<IJobActivator, FunctionInstanceServicesCatalog>();
             builder.Services.AddSingleton(sp => (FunctionInstanceServicesCatalog)sp.GetRequiredService<IJobActivator>());
+#pragma warning disable CS0618 // Type or member is obsolete
+            builder.Services.AddSingleton<IFunctionFilter, CommitSqlTransactionFunctionInvocationFilter>();
+#pragma warning restore CS0618 // Type or member is obsolete
 
             IConfiguration GetConfiguration()
             {


### PR DESCRIPTION
Azure Functions' `IFunctionInvocationFilter` doesn't currently expose the `IServiceProvider` used for the instance. This adds an `IJobActivatorEx` decorator that captures the services so they can be looked up later.