### PR TITLE
Fix removing click event from ellipsis in pager (PTCD 22)

### DIFF
--- a/src/Dfc.CourseDirectory.Web/Views/UnRegulatedCourses/UnknownZCode.cshtml
+++ b/src/Dfc.CourseDirectory.Web/Views/UnRegulatedCourses/UnknownZCode.cshtml
@@ -202,7 +202,7 @@
                     });
             };           
             var assignEventsToLarsSearchPagination = function () {
-                var $larsSearchResultPaginationItems = $("#results .pttcd-c-pager");
+                var $larsSearchResultPaginationItems = $(".govuk-link,.pttcd-c-pager__previous-page,.pttcd-c-pager__next-page");
                 $larsSearchResultPaginationItems.on("click",
                     function (e) {
                         e.preventDefault();


### PR DESCRIPTION
Removing click event from ellipsis 
page should not be refreshed if user click on ellipsis