### PR TITLE
PTCD-346 - increase default radius to 30

### DIFF
--- a/src/Dfc.CourseDirectory.Services/ApprenticeshipSettings.cs
+++ b/src/Dfc.CourseDirectory.Services/ApprenticeshipSettings.cs
@@ -4,6 +4,7 @@ namespace Dfc.CourseDirectory.Services
 {
     public class ApprenticeshipSettings : IApprenticeshipSettings
     {
+        public int DefaultRadius { get; set; }
         public int NationalRadius { get; set; }
         public int SubRegionRadius { get; set; }
 

--- a/src/Dfc.CourseDirectory.Services/Interfaces/IApprenticeshipSettings.cs
+++ b/src/Dfc.CourseDirectory.Services/Interfaces/IApprenticeshipSettings.cs
@@ -2,6 +2,7 @@
 {
     public interface IApprenticeshipSettings
     {
+        int DefaultRadius { get; }
         int NationalRadius { get; }
         int SubRegionRadius { get; }
        

--- a/src/Dfc.CourseDirectory.Web/Controllers/ApprenticeshipsController.cs
+++ b/src/Dfc.CourseDirectory.Web/Controllers/ApprenticeshipsController.cs
@@ -666,6 +666,8 @@ namespace Dfc.CourseDirectory.Web.Controllers
 
             if (model.LocationId.HasValue)
             {
+                int RadiusValue = _apprenticeshipSettings.Value.DefaultRadius;
+
                 var venue = _venueService.GetVenueByIdAsync(
                     new GetVenueByIdCriteria(model.LocationId.Value.ToString()));
 
@@ -687,9 +689,9 @@ namespace Dfc.CourseDirectory.Web.Controllers
                     LocationName = venue.Result.Value.VenueName,
                     PostCode = venue.Result.Value.PostCode,
                     Venue = (Venue)venue.Result.Value,
-                    Radius = "10"
+                    Radius = RadiusValue.ToString()
 
-                }, ApprenticeshipLocationType.ClassroomBased));
+            }, ApprenticeshipLocationType.ClassroomBased));
 
 
                 _session.SetObject("selectedApprenticeship", apprenticeship);
@@ -710,7 +712,7 @@ namespace Dfc.CourseDirectory.Web.Controllers
                 apprenticeship.ApprenticeshipLocations = new List<ApprenticeshipLocation>();
             }
 
-            string RadiusValue = "10";
+            int RadiusValue = _apprenticeshipSettings.Value.DefaultRadius;
 
             var venue = _venueService.GetVenueByIdAsync(new GetVenueByIdCriteria(LocationId));
 
@@ -731,7 +733,7 @@ namespace Dfc.CourseDirectory.Web.Controllers
                 LocationName = venue.Result.Value.VenueName,
                 PostCode = venue.Result.Value.PostCode,
                 Venue = (Venue)venue.Result.Value,
-                Radius = "10"
+                Radius = RadiusValue.ToString()
 
             }, ApprenticeshipLocationType.ClassroomBased));
 

--- a/src/Dfc.CourseDirectory.Web/appsettings.json
+++ b/src/Dfc.CourseDirectory.Web/appsettings.json
@@ -32,7 +32,8 @@
     "TemplatePath": "bulkuploadtemplate.csv"
   },
   "ApprenticeshipSettings": {
-    "SubRegionRadius": "10",
+    "DefaultRadius": "30",
+    "SubRegionRadius": "30",
     "NationalRadius": "600"
   },
   "CourseServiceSettings": {

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/NewApprenticeshipProvider/FlowModelInitializerTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/NewApprenticeshipProvider/FlowModelInitializerTests.cs
@@ -278,7 +278,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
             var marketingInfo = "Providing Online training";
             var regions = new List<string> { "123" };
             var contactEmail = "somecontact@nonexistentprovider.com";
-            var radius = 10;
+            var radius = 30;
             var deliveryMode = ApprenticeshipDeliveryMode.BlockRelease;
             var providerId = await TestData.CreateProvider(
                 ukprn: ukprn,


### PR DESCRIPTION
Some observations:
- Radius appsetting is a string, `IOptions<ApprenticeshipSettings>` casts to int, controller subsequently performs a ToString() on the value 🤦 
- SubRegionRadius does not appear to be used right now. Adjusted to match new minimum default radius.
- Config should be moved over to an Azure DevOps configuration using parameters.json substitution.