### PR TITLE
Allow skipping SQL database deployment for tests

### DIFF
--- a/tests/Dfc.CourseDirectory.Testing/DatabaseFixture.cs
+++ b/tests/Dfc.CourseDirectory.Testing/DatabaseFixture.cs
@@ -104,6 +104,13 @@ namespace Dfc.CourseDirectory.Testing
         
         private void DeploySqlDb()
         {
+            if ((Environment.GetEnvironmentVariable("CD_SkipTestSqlDeployment") ?? string.Empty)
+                .Equals("true", StringComparison.OrdinalIgnoreCase))
+            {
+                _messageSink.OnMessage(new DiagnosticMessage("Skipping database deployment"));
+                return;
+            }
+
             var helper = new SqlDeployHelper();
             helper.Deploy(
                 ConnectionString,


### PR DESCRIPTION
By setting the 'CD_SkipTestSqlDeployment' environment variable to true
the database schema will not be updated.

This should help running tests on non-Windows environments.