### PR TITLE
Make dev launch ports consistent

### DIFF
--- a/src/Dfc.CourseDirectory.Web/Properties/launchSettings.json
+++ b/src/Dfc.CourseDirectory.Web/Properties/launchSettings.json
@@ -18,7 +18,7 @@
     "Dfc.CourseDirectory.Web": {
       "commandName": "Project",
       "launchBrowser": true,
-        "applicationUrl": "https://localhost:44345;http://localhost:44345",
+        "applicationUrl": "https://localhost:44345;http://localhost:54034",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }


### PR DESCRIPTION
Launching from `dotnet run` caused a port conflict because it was set to
launch https and http on the same port.