### PR TITLE
PTCD-305 Remove redirect for pending migrations

### DIFF
--- a/src/Dfc.CourseDirectory.Web/Controllers/HomeController.cs
+++ b/src/Dfc.CourseDirectory.Web/Controllers/HomeController.cs
@@ -89,11 +89,6 @@ namespace Dfc.CourseDirectory.Web.Controllers
 
                 IEnumerable<CourseRun> migrationPendingCourses = courses.SelectMany(c => c.CourseRuns).Where(x => x.RecordStatus == RecordStatus.MigrationPending);
 
-                if (migrationPendingCourses.Count() > 0)
-                {
-                    return RedirectToAction("Report", "Migration");
-                }
-
                 return View("../Provider/Dashboard");
             }
         }


### PR DESCRIPTION
The "continue to course directory" link on the migration report ( https://localhost:44345/Migration/Report ) was
redirected back to itself via HomeController/index.

Cathie> The link states the user should go back to the Course Directory
homepage.  Once the user has returned to this page, they can return to
the Migration report via the link in the blue box to resolve the issues
of those courses pending.  The user should be able to add more courses
as required - it could be that they don’t have the required information
to resolve those courses that require fixing, but this should not stop
them from adding/amending other course information. As long as they can
return to the Migration report having logged in/out to resolve these
issues, then it will be fine.

There is no test coverage at the moment, and we have not yet agreed to
retrofit it here so leaving bare for now.

![(PNG Image, 786 × 755 pixels)](https://user-images.githubusercontent.com/19378/85594579-f6523900-b63f-11ea-83bf-603f63db5b62.png)

