### PR TITLE
PTCD-410 - Updated copy and design for course details page

### DIFF
--- a/src/Dfc.CourseDirectory.Web/Controllers/AddCourseController.cs
+++ b/src/Dfc.CourseDirectory.Web/Controllers/AddCourseController.cs
@@ -934,7 +934,6 @@ namespace Dfc.CourseDirectory.Web.Controllers
             var selectVenue = new SelectVenueModel
             {
                 LabelText = "Course location",
-                HintText = "Select all that apply.",
                 AriaDescribedBy = "Select all that apply.",
                 Ukprn = ukprn
             };

--- a/src/Dfc.CourseDirectory.Web/ViewComponents/CourseName/CourseNameModel.cs
+++ b/src/Dfc.CourseDirectory.Web/ViewComponents/CourseName/CourseNameModel.cs
@@ -1,16 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using Microsoft.AspNetCore.Html;
 
 namespace Dfc.CourseDirectory.Web.ViewComponents.CourseName
 {
     public class CourseNameModel
     {
-             public string CourseName { get; set; }
+        public string CourseName { get; set; }
         public string LabelText { get; set; }
-        public string HintText { get; set; }
+        public HtmlString HintText { get; set; }
         public string AriaDescribedBy { get; set; }
     }
 }

--- a/src/Dfc.CourseDirectory.Web/ViewComponents/CourseName/Default.cshtml
+++ b/src/Dfc.CourseDirectory.Web/ViewComponents/CourseName/Default.cshtml
@@ -12,7 +12,7 @@
         <label id="govuk-label-CourseName" class="govuk-label--m"  asp-for="@Model.CourseName">
             @Model.LabelText
         </label>
-        @if (!string.IsNullOrWhiteSpace(Model.HintText))
+        @if (!string.IsNullOrWhiteSpace(Model.HintText.Value))
         {
             <span class="govuk-hint govuk-!-margin-top-3">
                 @Model.HintText
@@ -23,7 +23,7 @@
                val-required-message="Enter course name"
                val-max-length="255"
                val-max-length-message="The maximum length of Course Name is 255 characters"
-               val-regex="@regex" 
+               val-regex="@regex"
                val-regex-message="Course Name contains invalid characters" />
 
     </div>

--- a/src/Dfc.CourseDirectory.Web/Views/AddCourse/AddCourseRun.cshtml
+++ b/src/Dfc.CourseDirectory.Web/Views/AddCourse/AddCourseRun.cshtml
@@ -70,6 +70,10 @@
     }
 }
 
+@section BackLink
+{
+    <pttcd-back-link class="govuk-!-margin-bottom-8 govuk-!-margin-top-0"/>
+}
 
 @*@await Component.InvokeAsync(nameof(Notification), new NotificationModel
 {
@@ -77,7 +81,8 @@
     NotificationMessage = @Model.LearnAimRefTitle + "<br>" + "Level: " + @Model.NotionalNVQLevelv2 + "<br> Awarding organisation: " + @Model.AwardOrgCode + "<br> LARS / QAN: " + @Model.LearnAimRef,
     ClassType = "info-summary"
 })*@
-<h1 class="govuk-heading-l" style="padding-top: 20px;">
+
+<h1 class="govuk-heading-xl">
     Course details
 </h1>
 <p class="govuk-body-l">Use these sections to provide details about this course.</p>
@@ -158,7 +163,7 @@
                         @Model.SelectVenue.HintText
                     </span>
                 </legend>
-                
+
                 <div class="govuk-checkboxes govuk-checkboxes--small" id="SelectVenueCheckBoxes" val-required-message="Select a location">
 
 
@@ -185,9 +190,9 @@
 
                         }
                     }
-                    
+
                 </div>
-              
+
             </fieldset>
         </div>
         <span class="">

--- a/src/Dfc.CourseDirectory.Web/Views/AddCourse/AddCourseRun.cshtml
+++ b/src/Dfc.CourseDirectory.Web/Views/AddCourse/AddCourseRun.cshtml
@@ -20,6 +20,7 @@
 @using StudyMode = Dfc.CourseDirectory.Models.Models.Courses.StudyMode
 @using Dfc.CourseDirectory.Models.Models.Courses
 @using Dfc.CourseDirectory.Models.Models.Venues
+@using Microsoft.AspNetCore.Html
 @{
     ViewData["Title"] = "Add course details";
     Layout = "_Layout_Your_Courses";
@@ -107,7 +108,9 @@
             {
                 CourseName = Model.CourseName,
                 LabelText = "Course name",
-                HintText = "Enter the name of the course you want people to see in the course directory (you can use or overwrite the default name we have created).",
+                HintText = new HtmlString(@"The course name displayed on the National Career Service,
+                                            <a href='https://nationalcareers.service.gov.uk/find-a-course/search'
+                                               target='_blank'>Find a course</a>."),
                 AriaDescribedBy = "Please enter the course name."
             })
         </div>

--- a/src/Dfc.CourseDirectory.Web/Views/AddCourse/AddCourseRun.cshtml
+++ b/src/Dfc.CourseDirectory.Web/Views/AddCourse/AddCourseRun.cshtml
@@ -82,228 +82,232 @@
     ClassType = "info-summary"
 })*@
 
-<h1 class="govuk-heading-xl">
-    Course details
-</h1>
-<p class="govuk-body-l">Use these sections to provide details about this course.</p>
-<form asp-controller="AddCourse" asp-action="AddCourseRun" id="addCourseSection2">
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-xl">
+                                        Course details
+                                        </h1>
+        <p class="govuk-body-l">Use these sections to provide details about this course.</p>
+        <form asp-controller="AddCourse" asp-action="AddCourseRun" id="addCourseSection2">
 
-    <div id="errorsummary" class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="error-summary" style="display: none;">
-        <h2 class="govuk-error-summary__title" id="error-summary-title">
-            There is an issue with this qualification
-        </h2>
-        <div class="govuk-error-summary__body">
-            <ul class="govuk-list govuk-error-summary__list"></ul>
+        <div id="errorsummary" class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="error-summary" style="display: none;">
+            <h2 class="govuk-error-summary__title" id="error-summary-title">
+                There is an issue with this qualification
+            </h2>
+            <div class="govuk-error-summary__body">
+                <ul class="govuk-list govuk-error-summary__list"></ul>
+            </div>
         </div>
-    </div>
 
-    @Html.HiddenFor(x => x.CourseMode)
-    @Html.HiddenFor(x => x.CourseId)
-    @Html.HiddenFor(x => x.CourseRunId)
-    <div id="sectionCourseName">
-        @await Component.InvokeAsync(nameof(CourseName), new CourseNameModel
-    {
-        CourseName = Model.CourseName,
-        LabelText = "Course name",
-        HintText = "Enter the name of the course you want people to see in the course directory (you can use or overwrite the default name we have created).",
-        AriaDescribedBy = "Please enter the course name."
-    })
-    </div>
+        @Html.HiddenFor(x => x.CourseMode)
+        @Html.HiddenFor(x => x.CourseId)
+        @Html.HiddenFor(x => x.CourseRunId)
+        <div id="sectionCourseName">
+            @await Component.InvokeAsync(nameof(CourseName), new CourseNameModel
+            {
+                CourseName = Model.CourseName,
+                LabelText = "Course name",
+                HintText = "Enter the name of the course you want people to see in the course directory (you can use or overwrite the default name we have created).",
+                AriaDescribedBy = "Please enter the course name."
+            })
+        </div>
 
-    <div id="sectionCourseProviderReference">
-        @await Component.InvokeAsync(nameof(CourseProviderReference), new CourseProviderReferenceModel
-    {
-        CourseProviderReference = Model.CourseProviderReference,
-        LabelText = "Your reference",
-        HintText = "Enter a reference that will help you identify this course in your internal systems.",
-        AriaDescribedBy = "Please enter the ID for this course"
-    })
-    </div>
+        <div id="sectionCourseProviderReference">
+            @await Component.InvokeAsync(nameof(CourseProviderReference), new CourseProviderReferenceModel
+            {
+                CourseProviderReference = Model.CourseProviderReference,
+                LabelText = "Your reference",
+                HintText = "Enter a reference that will help you identify this course in your internal systems.",
+                AriaDescribedBy = "Please enter the ID for this course"
+            })
+        </div>
 
-    <div id="sectionDeliveryType">
-        @await Component.InvokeAsync(nameof(DeliveryType), new DeliveryTypeModel
-    {
-        DeliveryMode = Model.DeliveryMode,
-        LabelText = "Delivery mode",
-        HintText = "Select one option.",
-        SecondHintText = "Select how you will deliver this course",
-        AriaDescribedBy = "Select how you will deliver this course"
-    })
-    </div>
+        <div id="sectionDeliveryType">
+            @await Component.InvokeAsync(nameof(DeliveryType), new DeliveryTypeModel
+            {
+                DeliveryMode = Model.DeliveryMode,
+                LabelText = "Delivery mode",
+                HintText = "Select one option.",
+                SecondHintText = "Select how you will deliver this course",
+                AriaDescribedBy = "Select how you will deliver this course"
+            })
+        </div>
 
-    <div id="sectionStartDate">
-        @await Component.InvokeAsync(nameof(AddStartDate), new AddStartDateModel()
-        {
-            StartDateType = Model.StartDateType,
-            Day = Model.Day,
-            Month = Model.Month,
-            Year = Model.Year,
-            DayAriaDescribedBy = "",
-            DayLabelText = "Day",
-            MonthAriaDescribedBy = "",
-            MonthLabelText = "Month",
-            YearAriaDescribedBy = "",
-            YearLabelText = "Year",
-            AriaDescribedBy = "",
-            SpecifiedDateHintText = "",
-            FlexibleDateHintText = "Or select a flexible start date:",
-            LabelText = "Start date",
-            ValPastDateRef = DateTime.Now,
-            ValPastDateMessage = "Start Date cannot be earlier than today’s date"
-        })
-    </div>
-    <div class="govuk-form-group" id="VenueItemsCheckboxList" style="@Model.DeliveryMode.IfNotClassroomBasedDisplayNone()">
-        <div class="govuk-form-group">
-            <fieldset class="govuk-fieldset" id="govuk-label-SelectVenueCheckBoxes">
-                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-                    <h2 class="govuk-fieldset__heading govuk-heading-m">
-                        @Model.SelectVenue.LabelText
-                    </h2>
-                    <span class="govuk-hint govuk-!-margin-top-3">
-                        @Model.SelectVenue.HintText
-                    </span>
-                </legend>
+        <div id="sectionStartDate">
+            @await Component.InvokeAsync(nameof(AddStartDate), new AddStartDateModel()
+            {
+                StartDateType = Model.StartDateType,
+                Day = Model.Day,
+                Month = Model.Month,
+                Year = Model.Year,
+                DayAriaDescribedBy = "",
+                DayLabelText = "Day",
+                MonthAriaDescribedBy = "",
+                MonthLabelText = "Month",
+                YearAriaDescribedBy = "",
+                YearLabelText = "Year",
+                AriaDescribedBy = "",
+                SpecifiedDateHintText = "",
+                FlexibleDateHintText = "Or select a flexible start date:",
+                LabelText = "Start date",
+                ValPastDateRef = DateTime.Now,
+                ValPastDateMessage = "Start Date cannot be earlier than today’s date"
+            })
+        </div>
+        <div class="govuk-form-group" id="VenueItemsCheckboxList" style="@Model.DeliveryMode.IfNotClassroomBasedDisplayNone()">
+            <div class="govuk-form-group">
+                <fieldset class="govuk-fieldset" id="govuk-label-SelectVenueCheckBoxes">
+                    <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+                        <h2 class="govuk-fieldset__heading govuk-heading-m">
+                            @Model.SelectVenue.LabelText
+                        </h2>
+                        <span class="govuk-hint govuk-!-margin-top-3">
+                            @Model.SelectVenue.HintText
+                        </span>
+                    </legend>
 
-                <div class="govuk-checkboxes govuk-checkboxes--small" id="SelectVenueCheckBoxes" val-required-message="Select a location">
-
+                    <div class="govuk-checkboxes govuk-checkboxes--small" id="SelectVenueCheckBoxes" val-required-message="Select a location">
 
 
 
-                    @{ var i = 0; }
-                    @if (Model.SelectVenue.VenueItems.Count() == 1)
+
+                        @{ var i = 0; }
+                        @if (Model.SelectVenue.VenueItems.Count() == 1)
+                        {
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="VenueName-@i" for="VenueName-@i" name="SelectedVenues" type="checkbox" aria-labelledby="VenueNameLabel-@i" value="@Model.SelectVenue.VenueItems.First().Id" checked="checked" onclick="return false;" />
+                                <label id="VenueNameLabel-@i" class="govuk-label govuk-checkboxes__label" for="VenueName-@i" aria-label="VenueName-@i">@Model.SelectVenue.VenueItems.First().VenueName</label>
+                            </div>
+                        }
+                        else
+                        {
+                            foreach (var item in Model.SelectVenue.VenueItems)
+                            {
+                                i++;
+                                <div class="govuk-checkboxes__item">
+                                    <input class="govuk-checkboxes__input" id="VenueName-@i" for="VenueName-@i" name="SelectedVenues" type="checkbox" aria-labelledby="VenueNameLabel-@i" value="@item.Id" @item.Checked.ThenNullableCheck() />
+                                    <label id="VenueNameLabel-@i" class="govuk-label govuk-checkboxes__label" for="SelectedVenues-@i" aria-label="VenueName-@i">@item.VenueName</label>
+                                </div>
+
+
+                            }
+                        }
+
+                    </div>
+
+                </fieldset>
+            </div>
+            <span class="">
+                <a href="#" class="govuk-link--no-visited-state" id="addNewVenue">The course location isn’t shown here</a>
+            </span>
+        </div>
+
+
+
+
+
+
+
+        <div class="govuk-form-group" id="RegionItemsCheckboxList" style="@Model.DeliveryMode.IfNotWorkBasedDisplayNone()">
+            <div id="sectionRegions">
+                @await Component.InvokeAsync(nameof(ChooseRegion), Model.ChooseRegion)
+            </div>
+        </div>
+
+        <div id="sectionUrl">
+            @await Component.InvokeAsync(nameof(UrlInput), new UrlInputModel
+            {
+                Url = Model.Url,
+                LabelText = "External URL",
+                HintText = "Enter the URL for this course on your website. For example, http://www.provider.com/course.",
+                AriaDescribedBy = "Enter the URL for this course"
+            })
+        </div>
+
+        <div id="sectionCost">
+            @await Component.InvokeAsync(nameof(Cost), new CostModel
+            {
+                Cost = Model.Cost,
+                CostDescription = Model.CostDescription,
+                CostLabelText = "Cost",
+                CostHintText = "Enter the cost of the course to the learner.",
+                CostAriaDescribedBy = "Enter the cost in pounds and pence",
+                CostDescriptionLabelText = "Cost description",
+                CostDescriptionHintText = "Enter details related to the cost of this course.",
+                CostDescriptionAriaDescribedBy = "Enter details of related to the cost of this course"
+            })
+        </div>
+
+        <div id="sectionDuration">
+            @await Component.InvokeAsync(nameof(Duration), new DurationModel
+            {
+                DurationLength = Model.DurationLength,
+                DurationUnit = Model.DurationUnit,
+                LabelText = "Duration",
+                HintText = "",
+                AriaDescribedBy = "Select course duration"
+            })
+        </div>
+
+        <div id="FullPartTimeRadioButtons" style="display: none;">
+            @await Component.InvokeAsync(nameof(Dfc.CourseDirectory.Web.ViewComponents.Courses.StudyMode.StudyMode), new StudyModeModel
+            {
+                StudyMode = Model.StudyMode,
+                LabelText = "Study pattern",
+                HintText = "Choose one option."
+            })
+        </div>
+
+        <div id="AttendancePatternRadioButtons" style="display: none;">
+            @await Component.InvokeAsync(nameof(Attendance), new AttendanceModel
+            {
+                AttendanceMode = Model.AttendanceMode,
+                LabelText = "Attendance",
+                HintText = "Choose one option."
+            })
+        </div>
+
+
+
+        @{
+            var lastAddCoursePage = HttpContextAccessor.HttpContext.Session.GetObject<AddCoursePage>
+                ("LastAddCoursePage");
+            var summaryPageLoadedAtLeastOnce = HttpContextAccessor.HttpContext.Session.GetObject<bool>
+                ("SummaryLoadedAtLeastOnce");
+            switch (lastAddCoursePage)
+            {
+                case AddCoursePage.AddCourse:
+                    if (summaryPageLoadedAtLeastOnce)
                     {
-                        <div class="govuk-checkboxes__item">
-                            <input class="govuk-checkboxes__input" id="VenueName-@i" for="VenueName-@i" name="SelectedVenues" type="checkbox" aria-labelledby="VenueNameLabel-@i" value="@Model.SelectVenue.VenueItems.First().Id" checked="checked" onclick="return false;" />
-                            <label id="VenueNameLabel-@i" class="govuk-label govuk-checkboxes__label" for="VenueName-@i" aria-label="VenueName-@i">@Model.SelectVenue.VenueItems.First().VenueName</label>
-                        </div>
+                        <button name="submitButton" type="submit" class="govuk-button" id="publish" value="publish">
+                            Summary
+                        </button>
+                                @*<a class="govuk-link" href="#" id="goToSection1Link">Page 1</a>*@
                     }
                     else
                     {
-                        foreach (var item in Model.SelectVenue.VenueItems)
-                        {
-                            i++;
-                            <div class="govuk-checkboxes__item">
-                                <input class="govuk-checkboxes__input" id="VenueName-@i" for="VenueName-@i" name="SelectedVenues" type="checkbox" aria-labelledby="VenueNameLabel-@i" value="@item.Id" @item.Checked.ThenNullableCheck() />
-                                <label id="VenueNameLabel-@i" class="govuk-label govuk-checkboxes__label" for="SelectedVenues-@i" aria-label="VenueName-@i">@item.VenueName</label>
-                            </div>
-
-
-                        }
+                        <button name="submitButton" type="submit" class="govuk-button" id="publish" value="publish">
+                            Review your changes
+                        </button>
+                                @*<a class="govuk-link" href="#" id="goToSection1Link">Page 1</a>*@
                     }
+                    break;
+                case AddCoursePage.Summary:
+                    <div class="govuk-form-group">
+                        @*id="goToSummary"*@
+                        <button type="submit" class="govuk-button" id="publish" value="publish">
+                            Summary
+                        </button>
 
-                </div>
-
-            </fieldset>
-        </div>
-        <span class="">
-            <a href="#" class="govuk-link--no-visited-state" id="addNewVenue">The course location isn’t shown here</a>
-        </span>
-    </div>
-
-
-
-
-
-
-
-    <div class="govuk-form-group" id="RegionItemsCheckboxList" style="@Model.DeliveryMode.IfNotWorkBasedDisplayNone()">
-        <div id="sectionRegions">
-            @await Component.InvokeAsync(nameof(ChooseRegion), Model.ChooseRegion)
-        </div>
-    </div>
-
-    <div id="sectionUrl">
-        @await Component.InvokeAsync(nameof(UrlInput), new UrlInputModel
-        {
-        Url = Model.Url,
-        LabelText = "External URL",
-        HintText = "Enter the URL for this course on your website. For example, http://www.provider.com/course.",
-        AriaDescribedBy = "Enter the URL for this course"
-        })
-    </div>
-
-    <div id="sectionCost">
-        @await Component.InvokeAsync(nameof(Cost), new CostModel
-        {
-        Cost = Model.Cost,
-        CostDescription = Model.CostDescription,
-        CostLabelText = "Cost",
-        CostHintText = "Enter the cost of the course to the learner.",
-        CostAriaDescribedBy = "Enter the cost in pounds and pence",
-        CostDescriptionLabelText = "Cost description",
-        CostDescriptionHintText = "Enter details related to the cost of this course.",
-        CostDescriptionAriaDescribedBy = "Enter details of related to the cost of this course"
-        })
-    </div>
-
-    <div id="sectionDuration">
-        @await Component.InvokeAsync(nameof(Duration), new DurationModel
-        {
-        DurationLength = Model.DurationLength,
-        DurationUnit = Model.DurationUnit,
-        LabelText = "Duration",
-        HintText = "",
-        AriaDescribedBy = "Select course duration"
-        })
-    </div>
-
-    <div id="FullPartTimeRadioButtons" style="display: none;">
-        @await Component.InvokeAsync(nameof(Dfc.CourseDirectory.Web.ViewComponents.Courses.StudyMode.StudyMode), new StudyModeModel
-        {
-        StudyMode = Model.StudyMode,
-        LabelText = "Study pattern",
-        HintText = "Choose one option."
-        })
-    </div>
-
-    <div id="AttendancePatternRadioButtons" style="display: none;">
-        @await Component.InvokeAsync(nameof(Attendance), new AttendanceModel
-        {
-        AttendanceMode = Model.AttendanceMode,
-        LabelText = "Attendance",
-        HintText = "Choose one option."
-        })
-    </div>
-
-
-
-    @{
-        var lastAddCoursePage = HttpContextAccessor.HttpContext.Session.GetObject<AddCoursePage>
-            ("LastAddCoursePage");
-        var summaryPageLoadedAtLeastOnce = HttpContextAccessor.HttpContext.Session.GetObject<bool>
-            ("SummaryLoadedAtLeastOnce");
-        switch (lastAddCoursePage)
-        {
-            case AddCoursePage.AddCourse:
-                if (summaryPageLoadedAtLeastOnce)
-                {
-                    <button name="submitButton" type="submit" class="govuk-button" id="publish" value="publish">
-                        Summary
-                    </button>
-                    @*<a class="govuk-link" href="#" id="goToSection1Link">Page 1</a>*@
-                }
-                else
-                {
-                    <button name="submitButton" type="submit" class="govuk-button" id="publish" value="publish">
-                        Review your changes
-                    </button>
-                    @*<a class="govuk-link" href="#" id="goToSection1Link">Page 1</a>*@
-                }
-                break;
-            case AddCoursePage.Summary:
-                <div class="govuk-form-group">
-                    @*id="goToSummary"*@
-                    <button type="submit" class="govuk-button" id="publish" value="publish">
-                        Summary
-                    </button>
-
-                    <a class="govuk-link" href="#" id="goToSection1Link">Page 1</a>
-                </div>
-                break;
+                        <a class="govuk-link" href="#" id="goToSection1Link">Page 1</a>
+                    </div>
+                    break;
+            }
         }
-    }
 
-</form>
+        </form>
+    </div>
+</div>
 
 <script>
     (function($) {

--- a/src/Dfc.CourseDirectory.Web/Views/AddCourse/AddCourseRun.cshtml
+++ b/src/Dfc.CourseDirectory.Web/Views/AddCourse/AddCourseRun.cshtml
@@ -120,7 +120,7 @@
             {
                 CourseProviderReference = Model.CourseProviderReference,
                 LabelText = "Your reference",
-                HintText = "Enter a reference that will help you identify this course in your internal systems.",
+                HintText = "A reference that will help you identify this course in your internal systems. This will not be visible to learners.",
                 AriaDescribedBy = "Please enter the ID for this course"
             })
         </div>
@@ -129,7 +129,7 @@
             @await Component.InvokeAsync(nameof(DeliveryType), new DeliveryTypeModel
             {
                 DeliveryMode = Model.DeliveryMode,
-                LabelText = "Delivery mode",
+                LabelText = "Course type",
                 HintText = "Select one option.",
                 SecondHintText = "Select how you will deliver this course",
                 AriaDescribedBy = "Select how you will deliver this course"
@@ -198,7 +198,7 @@
                 </fieldset>
             </div>
             <span class="">
-                <a href="#" class="govuk-link--no-visited-state" id="addNewVenue">The course location isn’t shown here</a>
+                <a href="#" class="govuk-link--no-visited-state" id="addNewVenue">Add another location</a>
             </span>
         </div>
 
@@ -218,8 +218,8 @@
             @await Component.InvokeAsync(nameof(UrlInput), new UrlInputModel
             {
                 Url = Model.Url,
-                LabelText = "External URL",
-                HintText = "Enter the URL for this course on your website. For example, http://www.provider.com/course.",
+                LabelText = "Course webpage",
+                HintText = "The webpage for this course. For example, http://www.provider.com/coursename.",
                 AriaDescribedBy = "Enter the URL for this course"
             })
         </div>
@@ -230,10 +230,10 @@
                 Cost = Model.Cost,
                 CostDescription = Model.CostDescription,
                 CostLabelText = "Cost",
-                CostHintText = "Enter the cost of the course to the learner.",
+                CostHintText = "The cost of the course to the learner.",
                 CostAriaDescribedBy = "Enter the cost in pounds and pence",
                 CostDescriptionLabelText = "Cost description",
-                CostDescriptionHintText = "Enter details related to the cost of this course.",
+                CostDescriptionHintText = "A description of what the cost includes and additional costs to the learner. For example, assessment, exam fees or study materials.",
                 CostDescriptionAriaDescribedBy = "Enter details of related to the cost of this course"
             })
         </div>
@@ -287,7 +287,7 @@
                     else
                     {
                         <button name="submitButton" type="submit" class="govuk-button" id="publish" value="publish">
-                            Review your changes
+                            Continue
                         </button>
                                 @*<a class="govuk-link" href="#" id="goToSection1Link">Page 1</a>*@
                     }

--- a/src/Dfc.CourseDirectory.Web/Views/AddCourse/AddCourseRun.cshtml
+++ b/src/Dfc.CourseDirectory.Web/Views/AddCourse/AddCourseRun.cshtml
@@ -164,9 +164,6 @@
                         <h2 class="govuk-fieldset__heading govuk-heading-m">
                             @Model.SelectVenue.LabelText
                         </h2>
-                        <span class="govuk-hint govuk-!-margin-top-3">
-                            @Model.SelectVenue.HintText
-                        </span>
                     </legend>
 
                     <div class="govuk-checkboxes govuk-checkboxes--small" id="SelectVenueCheckBoxes" val-required-message="Select a location">

--- a/src/Dfc.CourseDirectory.Web/Views/CopyCourseRun/CopyCourseRun.cshtml
+++ b/src/Dfc.CourseDirectory.Web/Views/CopyCourseRun/CopyCourseRun.cshtml
@@ -15,11 +15,12 @@
 @using Dfc.CourseDirectory.Web.ViewComponents.Notification
 @using Dfc.CourseDirectory.Web.ViewComponents.UrlInput
 @using Dfc.CourseDirectory.Web.ViewComponents.Courses.ChooseRegion
+@using Microsoft.AspNetCore.Html
 @using Microsoft.AspNetCore.Http
 @using StudyMode = Dfc.CourseDirectory.Models.Models.Courses.StudyMode
 @model Dfc.CourseDirectory.Web.ViewModels.CopyCourse.CopyCourseRunViewModel
 @{
-    ViewData["Title"] = "Copy course"; 
+    ViewData["Title"] = "Copy course";
     Layout = "_Layout_Your_Courses";
 }
 @inject IHttpContextAccessor HttpContextAccessor
@@ -100,7 +101,7 @@
    {
        CourseName = Model.CourseName,
        LabelText = "Course name",
-       HintText = "This is the name people will see when they search for your course.",
+       HintText = new HtmlString("This is the name people will see when they search for your course."),
        AriaDescribedBy = "Please enter the course name."
    })
     </div>
@@ -308,7 +309,7 @@
             var $radioStartDate = $("#StartDateOptions").govUkRadios();
 
 
-          
+
 
             switch ($radioDeliveryMode.find("input[type='radio']:checked").val()) {
                 case "ClassroomBased":
@@ -354,7 +355,7 @@
             switch ($radioStartDate.find("input[type='radio']:checked").val()) {
             case "SpecifiedStartDate":
             {
-               
+
                 break;
             }
             case "FlexibleStartDate":
@@ -365,7 +366,7 @@
                 $("#Year").val("");
                 break;
             }
-           
+
             }
 
             validate();
@@ -512,7 +513,7 @@
                     validStates.push(false);
 
                 } else if ($duration.find("input").val().indexOf(".") >= 0) {
-                    
+
                     $duration.govUkDurationInput("invalidState", $duration.attr("val-decimal-message"));
                     validStates.push(false);
                 }

--- a/src/Dfc.CourseDirectory.Web/Views/EditCourseRun/EditCourseRun.cshtml
+++ b/src/Dfc.CourseDirectory.Web/Views/EditCourseRun/EditCourseRun.cshtml
@@ -15,12 +15,13 @@
 @using Dfc.CourseDirectory.Web.ViewComponents.Extensions
 @using Dfc.CourseDirectory.Web.ViewComponents.Notification
 @using Dfc.CourseDirectory.Web.ViewComponents.UrlInput
+@using Microsoft.AspNetCore.Html
 @using Microsoft.AspNetCore.Http
 @using StudyMode = Dfc.CourseDirectory.Models.Models.Courses.StudyMode
 @model Dfc.CourseDirectory.Web.ViewModels.EditCourse.EditCourseRunViewModel
 
 @{
-    ViewData["Title"] = "Edit course details"; 
+    ViewData["Title"] = "Edit course details";
     Layout = "_Layout_Your_Courses";
 }
 
@@ -106,7 +107,7 @@
    {
        CourseName = Model.CourseName,
        LabelText = "Course name",
-       HintText = "This is the name people will see when they search for your course.",
+       HintText = new HtmlString("This is the name people will see when they search for your course."),
        AriaDescribedBy = "Please enter the course name."
    })
     </div>
@@ -323,7 +324,7 @@
             var isOnline = false;
             var isWorkBased = false;
 
-           
+
 
             var $specifiedStartDate = $("#SpecifiedStartDate");
             var $flexibleStartDate = $("#FlexibleStartDate");
@@ -349,7 +350,7 @@
                         $attendancePatternRadioButtons.hide();
                         $regionSection.hide();
 
-                        
+
                         $("#govuk-label-start_date").hide();
 
                         break;
@@ -361,7 +362,7 @@
                         isClassroomBased = false;
                         isOnline = false;
                         isWorkBased = true;
-                        
+
                         $regionSection.show();
 
                         if ($flexibleStartDate.prop('checked')) {
@@ -398,7 +399,7 @@
                 //$("#Year").val("");
                 break;
             }
-           
+
             }
 
             if ($national.find("input[type='radio']:checked").val()==="True") {
@@ -688,8 +689,8 @@
 
 
 
-               
-               
+
+
 
                 // attendance
                 $attendance.govUkRadios("validState");
@@ -842,7 +843,7 @@
                             $attendancePattern.prop("checked", true);
                             $studyMode.prop("checked", true);
                             $regionSection.hide();
-                            
+
                             $("#govuk-label-start_date").show();
 
                             break;
@@ -866,7 +867,7 @@
                             break;
                         }
                     case "WorkBased":
-                        { 
+                        {
                             $flexibleStartDate.prop("checked", true);
                             $specifiedStartDate.prop("checked", false);
                             $venueChoice.hide();
@@ -879,7 +880,7 @@
                             $attendancePattern.prop("checked", false);
                             $studyMode.prop("checked", false);
 
-                            
+
                             $("#govuk-label-start_date").hide();
 
                             break;

--- a/src/Dfc.CourseDirectory.Web/Views/Shared/_Layout_Your_Courses.cshtml
+++ b/src/Dfc.CourseDirectory.Web/Views/Shared/_Layout_Your_Courses.cshtml
@@ -36,12 +36,13 @@
 
     <partial name="_GovukHeaderPartial_Your_Courses" />
 
-    <div class=" cd-fullwidth-container  ">
-        <main class="cd-dashboard provider govuk-body" id="main-content" role="main">
+<div class=" cd-fullwidth-container">
+    @RenderSection("BackLink", required: false)
+    <main class="cd-dashboard provider govuk-body" id="main-content" role="main">
 
-            @RenderBody()
-        </main>
-    </div>
+        @RenderBody()
+    </main>
+</div>
 
 
 


### PR DESCRIPTION
As per prototype and change document.

Diff best viewed with whitespace changes off due to re-indentation and whitespace stripping.

The backlink has been moved out of `<main>` because it's more semantically correct (I think) and that's how it is on the Design System example: https://design-system.service.gov.uk/patterns/question-pages/default/index.html

See individual commit messages for detailed changes

# With changes applied:

![Screen Shot 2020-06-29 at 15 57 51-fullpage](https://user-images.githubusercontent.com/19378/86021805-705c3680-ba21-11ea-8ba9-1951f6b8408b.png)
