### PR TITLE
PTCD-410 Updated labels on course details

### DIFF
--- a/src/Dfc.CourseDirectory.Web/Views/AddCourse/AddCourseRun.cshtml
+++ b/src/Dfc.CourseDirectory.Web/Views/AddCourse/AddCourseRun.cshtml
@@ -253,7 +253,7 @@
             @await Component.InvokeAsync(nameof(Dfc.CourseDirectory.Web.ViewComponents.Courses.StudyMode.StudyMode), new StudyModeModel
             {
                 StudyMode = Model.StudyMode,
-                LabelText = "Study pattern",
+                LabelText = "Course hours",
                 HintText = "Choose one option."
             })
         </div>
@@ -262,7 +262,7 @@
             @await Component.InvokeAsync(nameof(Attendance), new AttendanceModel
             {
                 AttendanceMode = Model.AttendanceMode,
-                LabelText = "Attendance",
+                LabelText = "Attendance pattern",
                 HintText = "Choose one option."
             })
         </div>


### PR DESCRIPTION
As per prototype, after discussing with Cathie

Titles changed:

* Course hours
* Attendance pattern

This now matches the summary page

# Updated page

![Screen Shot 2020-06-30 at 16 41 10-fullpage](https://user-images.githubusercontent.com/19378/86146971-bfbd6800-baf0-11ea-8395-e9fa4f019384.png)
