### PR TITLE
Disable AI dependency tracking for Functions app

### DIFF
--- a/src/Dfc.CourseDirectory.Functions/host.json
+++ b/src/Dfc.CourseDirectory.Functions/host.json
@@ -1,4 +1,9 @@
 {
   "version": "2.0",
-  "functionTimeout": "01:00:00"
+  "functionTimeout": "01:00:00",
+  "logging": {
+    "applicationInsights": {
+      "enableDependencyTracking": false
+    }
+  }
 }


### PR DESCRIPTION
Dependency tracking is filling up logs with (expensive) noise and we're losing important logs.