### PR TITLE
Add paging to LARS search results (PTCD-22)

### DIFF
--- a/src/Dfc.CourseDirectory.Web/Controllers/LarsSearchController.cs
+++ b/src/Dfc.CourseDirectory.Web/Controllers/LarsSearchController.cs
@@ -104,6 +104,7 @@ namespace Dfc.CourseDirectory.Web.Controllers
                         items,
                         Request.GetDisplayUrl(),
                         _larsSearchSettings.PageParamName,
+                        requestModel.PageNo,
                         _larsSearchSettings.ItemsPerPage,
                         result.Value.ODataCount ?? 0,
                         filters);

--- a/src/Dfc.CourseDirectory.Web/ViewComponents/LarsSearch/Default.cshtml
+++ b/src/Dfc.CourseDirectory.Web/ViewComponents/LarsSearch/Default.cshtml
@@ -139,13 +139,15 @@
             };
 
             var assignEventsToLarsSearchPagination = function () {
-                var $larsSearchResultPaginationItems = $("#LarsSearchResultContainer .pagination .pagination__item");
-                $larsSearchResultPaginationItems.on("click",
-                    function (e) {
+                $('.pttcd-c-pager a').each(function (i, el) {
+                    var searchEndpoint = $(el).attr('href');
+                    $(el).attr('href', '#');
+
+                    $(el).click(function (e) {
                         e.preventDefault();
-                        var url = $(e.target).attr("href");
-                        makeRequestWithUrl(url, onSucess);
+                        makeRequestWithUrl(searchEndpoint, onSucess);
                     });
+                });
             };
 
             var onSucess = function (data) {

--- a/src/Dfc.CourseDirectory.Web/ViewComponents/LarsSearchResult/Default.cshtml
+++ b/src/Dfc.CourseDirectory.Web/ViewComponents/LarsSearchResult/Default.cshtml
@@ -4,6 +4,7 @@
 @using Microsoft.AspNetCore.Http
 @using Microsoft.AspNetCore.Identity
 @using Microsoft.AspNetCore.Authorization;
+@using Flurl;
 
 @inject IAuthorizationService Authorization
 
@@ -12,6 +13,7 @@
     var providerLogin = await Authorization.AuthorizeAsync(User, "Provider");
 }
 
+@addTagHelper *, Dfc.CourseDirectory.WebV2
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @model Dfc.CourseDirectory.Web.ViewComponents.LarsSearchResult.LarsSearchResultModel;
 
@@ -42,10 +44,10 @@
     else if (!Model.HasErrors) // Model.Items.Any())
     {
         @if (!string.IsNullOrEmpty(@Model.SearchTerm))
-         {
-             <div class="govuk-heading-s lars-search-results govuk-!-font-weight-regular">
-                 Found <span class="govuk-!-font-weight-bold">@Model.TotalCount</span> results for <span class="govuk-!-font-weight-bold">@Model.SearchTerm</span>
-             </div>
+        {
+            <div class="govuk-heading-s lars-search-results govuk-!-font-weight-regular">
+                Found <span class="govuk-!-font-weight-bold">@Model.TotalCount</span> results for <span class="govuk-!-font-weight-bold">@Model.SearchTerm</span>
+            </div>
         }
 
         <div class="govuk-grid-column-one-quarter">
@@ -69,7 +71,7 @@
                         <div class="accordion govuk-heading-s" role="button" tabindex="0">@filter.Title</div>
                         <div class="panel">
                             <fieldset class="govuk-fieldset" id="FilterCheckBoxes_@i">
-                                <legend  class="govuk-visually-hidden">
+                                <legend class="govuk-visually-hidden">
                                     Select @filter.Title Level
                                 </legend>
                                 <div class="govuk-checkboxes govuk-checkboxes--small" id="Filter_@i">
@@ -79,7 +81,7 @@
                                         <div class="govuk-checkboxes__item">
                                             <input class="govuk-checkboxes__input" id="@item.Id" name="@item.Name" type="checkbox" aria-labelledby="Filter_@i" value="@item.Value" @item.IsSelected.ThenCheck()>
                                             <label class="govuk-label govuk-checkboxes__label govuk-!-font-size-14" id="FilterLabel_@item.Id">
-                                                @item.Text 
+                                                @item.Text
                                             </label>
                                         </div>
 
@@ -124,16 +126,7 @@
             </div>
             @if (Model.Items.Any())
             {
-                await Component.InvokeAsync(nameof(Pagination),
-                     new
-                     {
-                         url = Model.Url,
-                         pageParamName = Model.PageParamName,
-                         totalNoOfItems = Model.TotalCount,
-                         itemsPerPage = Model.ItemsPerPage,
-                         noOfPagesToDisplay = 10,
-                         isSliding = true
-                     });
+                <vc:pager current-page=Model.PageNumber get-page-url="@(pageNumber => new Url(Model.Url).SetQueryParam("PageNo", pageNumber))" total-pages=(int)Math.Ceiling((decimal)Model.TotalCount)/Model.ItemsPerPage />
             }
         </div>
 

--- a/src/Dfc.CourseDirectory.Web/ViewComponents/LarsSearchResult/LarsSearchResultModel.cs
+++ b/src/Dfc.CourseDirectory.Web/ViewComponents/LarsSearchResult/LarsSearchResultModel.cs
@@ -14,6 +14,7 @@ namespace Dfc.CourseDirectory.Web.ViewComponents.LarsSearchResult
         public IEnumerable<LarsSearchResultItemModel> Items { get; }
         public string Url { get; }
         public string PageParamName { get; }
+        public int PageNumber { get; }
         public int ItemsPerPage { get; }
         public IEnumerable<LarsSearchFilterModel> Filters { get; }
         public bool HasSelectedFilters => Filters.SelectMany(x => x.Items).Any(x => x.IsSelected);
@@ -36,6 +37,7 @@ namespace Dfc.CourseDirectory.Web.ViewComponents.LarsSearchResult
             IEnumerable<LarsSearchResultItemModel> items,
             string url,
             string pageParamName,
+            int pageNumber,
             int itemsPerPage,
             int totalCount,
             IEnumerable<LarsSearchFilterModel> filters = null)
@@ -53,6 +55,7 @@ namespace Dfc.CourseDirectory.Web.ViewComponents.LarsSearchResult
             Items = items;
             Url = url;
             PageParamName = pageParamName;
+            PageNumber = pageNumber;
             ItemsPerPage = itemsPerPage;
             Filters = filters ?? new LarsSearchFilterModel[] { };
             TotalCount = totalCount;
@@ -66,6 +69,7 @@ namespace Dfc.CourseDirectory.Web.ViewComponents.LarsSearchResult
             yield return OriginalSearchTerm;
             yield return Items;
             yield return Url;
+            yield return PageNumber;
             yield return PageParamName;
             yield return ItemsPerPage;
             yield return Filters;


### PR DESCRIPTION
Note there are a tonne of problems with this page:
- searches are all done client-side with JavaScript;
- paging links don't do the expected thing;
- window not scrolled to top after changing criteria;
- no loading state;
- no error state
- etc...
but this PR doesn't attempt to fix any of them.