### PR TITLE
PTCD-414 - Keep page state on navigate back to qualification

### DIFF
--- a/src/Dfc.CourseDirectory.Web/Startup.cs
+++ b/src/Dfc.CourseDirectory.Web/Startup.cs
@@ -287,7 +287,6 @@ namespace Dfc.CourseDirectory.Web
                   new Microsoft.Net.Http.Headers.CacheControlHeaderValue()
                   {
                       NoCache = true,
-                      NoStore = true,
                       MustRevalidate = true,
                   };
                 context.Response.Headers[Microsoft.Net.Http.Headers.HeaderNames.Vary] =


### PR DESCRIPTION
The `no-store` `cache-control` header was causing the browser to lose the state of the qualification selection pages when navigating back from the following page.

I propose that because Course directory doesn't deal in any sensitive data that we don't need to worry about generated pages being stored in the user's browser cache, which is already reasonably well protected.