### PR TITLE
Handle default(DateTime) when syncing provider records

### DIFF
--- a/src/Dfc.CourseDirectory.Core/DataStore/Sql/Queries/UpsertProvider.cs
+++ b/src/Dfc.CourseDirectory.Core/DataStore/Sql/Queries/UpsertProvider.cs
@@ -18,7 +18,7 @@ namespace Dfc.CourseDirectory.Core.DataStore.Sql.Queries
         public string TradingName { get; set; }
         public string Alias { get; set; }
         public IEnumerable<UpsertProviderContact> Contacts { get; set; }
-        public DateTime UpdatedOn { get; set; }
+        public DateTime? UpdatedOn { get; set; }
         public string UpdatedBy { get; set; }
     }
 

--- a/src/Dfc.CourseDirectory.Core/SqlDataSync.cs
+++ b/src/Dfc.CourseDirectory.Core/SqlDataSync.cs
@@ -46,7 +46,7 @@ namespace Dfc.CourseDirectory.Core
                 CourseDirectoryName = provider.CourseDirectoryName,
                 TradingName = provider.TradingName,
                 Alias = provider.Alias,
-                UpdatedOn = provider.DateUpdated,
+                UpdatedOn = provider.DateUpdated != default ? (DateTime?)provider.DateUpdated : null,
                 UpdatedBy = provider.UpdatedBy,
                 Contacts = provider.ProviderContact.Select(c => new UpsertProviderContact()
                 {


### PR DESCRIPTION
Some Cosmos data has default(DateTime) for the DateUpdated field -
that's not a valid value for a SQL DateTime. Replace those values with
nulls.