### PR TITLE
Fix integration tests for concurrent CI builds

### DIFF
--- a/tests/Dfc.CourseDirectory.Testing/DatabaseTestBase.cs
+++ b/tests/Dfc.CourseDirectory.Testing/DatabaseTestBase.cs
@@ -10,7 +10,7 @@ using Xunit.Abstractions;
 
 namespace Dfc.CourseDirectory.Testing
 {
-    public class DatabaseTestBaseFixture
+    public class DatabaseTestBaseFixture : IDisposable
     {
         public DatabaseTestBaseFixture(IMessageSink messageSink)
         {
@@ -22,6 +22,8 @@ namespace Dfc.CourseDirectory.Testing
         public DatabaseFixture DatabaseFixture { get; }
 
         public IServiceProvider Services { get; }
+
+        public void Dispose() => DatabaseFixture.Dispose();
 
         public void OnTestStarting()
         {


### PR DESCRIPTION
Having multiple builds hitting the CI DB at the same time leads to
errors. Introduce a lock that will limit the concurrency to one.