### PR TITLE
Acquire the lock before deploying database schema

### DIFF
--- a/tests/Dfc.CourseDirectory.Testing/DatabaseFixture.cs
+++ b/tests/Dfc.CourseDirectory.Testing/DatabaseFixture.cs
@@ -34,14 +34,14 @@ namespace Dfc.CourseDirectory.Testing
             _services = services;
             _messageSink = messageSink;
 
-            DeploySqlDb();
-            _sqlCheckpoint = CreateCheckpoint();
-
             _lockConnection = new SqlConnection(ConnectionString);
             _lockConnection.Open();
             _lockTransaction = _lockConnection.BeginTransaction();
 
             AcquireLock();
+
+            DeploySqlDb();
+            _sqlCheckpoint = CreateCheckpoint();
         }
 
         public MutableClock Clock => _services.GetRequiredService<IClock>() as MutableClock;


### PR DESCRIPTION
Both schema deploys and test execution should be protected from
concurrent test runs.