### PR TITLE
PTCD-508 - Add test coverage for apprenticeship bulk upload service

### DIFF
--- a/Dfc.CourseDirectory.Services.Tests/BulkUploadService/Apprenticeship/ApprenticeshipBulkUploadServiceTests.cs
+++ b/Dfc.CourseDirectory.Services.Tests/BulkUploadService/Apprenticeship/ApprenticeshipBulkUploadServiceTests.cs
@@ -37,7 +37,7 @@ namespace Dfc.CourseDirectory.Services.Tests.BulkUploadService.Apprenticeship
             await using var csvStream = new ApprenticeshipCsvBuilder()
                 .WithRow(row => row.WithStandardCode())
                 .WithRow(row => row.WithStandardCode()) // duplicate row isn't valid, but count doesn't currently check that
-                .Build();
+                .BuildStream();
 
             var actualLineCount = _apprenticeshipBulkUploadService.CountCsvLines(csvStream);
 
@@ -446,7 +446,7 @@ namespace Dfc.CourseDirectory.Services.Tests.BulkUploadService.Apprenticeship
             SetupService();
             var apprenticeshipCsvBuilder = new ApprenticeshipCsvBuilder();
             configureCsv?.Invoke(apprenticeshipCsvBuilder);
-            await using var csvStream = apprenticeshipCsvBuilder.Build();
+            await using var csvStream = apprenticeshipCsvBuilder.BuildStream();
 
             // act
             var actualErrors = await _apprenticeshipBulkUploadService.ValidateAndUploadCSV(
@@ -472,7 +472,7 @@ namespace Dfc.CourseDirectory.Services.Tests.BulkUploadService.Apprenticeship
             SetupService();
             var apprenticeshipCsvBuilder = new ApprenticeshipCsvBuilder();
             configureCsv?.Invoke(apprenticeshipCsvBuilder);
-            await using var csvStream = apprenticeshipCsvBuilder.Build();
+            await using var csvStream = apprenticeshipCsvBuilder.BuildStream();
 
             // act
             var actualException = await Record.ExceptionAsync(
@@ -497,7 +497,7 @@ namespace Dfc.CourseDirectory.Services.Tests.BulkUploadService.Apprenticeship
             SetupService();
             var apprenticeshipCsvBuilder = new ApprenticeshipCsvBuilder();
             configureCsv?.Invoke(apprenticeshipCsvBuilder);
-            await using var csvStream = apprenticeshipCsvBuilder.Build();
+            await using var csvStream = apprenticeshipCsvBuilder.BuildStream();
 
             // act
             var actualErrors = await _apprenticeshipBulkUploadService.ValidateAndUploadCSV(

--- a/Dfc.CourseDirectory.Services.Tests/BulkUploadService/Apprenticeship/ApprenticeshipBulkUploadServiceTests.cs
+++ b/Dfc.CourseDirectory.Services.Tests/BulkUploadService/Apprenticeship/ApprenticeshipBulkUploadServiceTests.cs
@@ -1,0 +1,537 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using CsvHelper;
+using Dfc.CourseDirectory.Common;
+using Dfc.CourseDirectory.Core.Models;
+using Dfc.CourseDirectory.Models.Interfaces.Apprenticeships;
+using Dfc.CourseDirectory.Models.Models.Auth;
+using Dfc.CourseDirectory.Models.Models.Venues;
+using Dfc.CourseDirectory.Services.BulkUploadService;
+using Dfc.CourseDirectory.Services.Interfaces;
+using Dfc.CourseDirectory.Services.Interfaces.ApprenticeshipService;
+using Dfc.CourseDirectory.Services.Interfaces.VenueService;
+using Dfc.CourseDirectory.Services.VenueService;
+using Dfc.CourseDirectory.WebV2;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Dfc.CourseDirectory.Services.Tests.BulkUploadService.Apprenticeship
+{
+    public class ApprenticeshipBulkUploadServiceTests
+    {
+        private ApprenticeshipBulkUploadService _apprenticeshipBulkUploadService;
+
+        private readonly AuthUserDetails _authUserDetails = new AuthUserDetails { UKPRN = "666" };
+        private readonly Mock<IApprenticeshipService> _mockApprenticeshipService = new Mock<IApprenticeshipService>();
+        private readonly Mock<IStandardsAndFrameworksCache> _standardsAndFrameworksCacheMock = new Mock<IStandardsAndFrameworksCache>();
+        private readonly Mock<IVenueService> _mockVenueService = new Mock<IVenueService>();
+
+        [Fact]
+        public async void TestCountCsvLines()
+        {
+            SetupDependencies();
+            SetupService();
+            await using var csvStream = new ApprenticeshipCsvBuilder()
+                .WithRow(row => row.WithStandardCode())
+                .WithRow(row => row.WithStandardCode()) // duplicate row isn't valid, but count doesn't currently check that
+                .Build();
+
+            var actualLineCount = _apprenticeshipBulkUploadService.CountCsvLines(csvStream);
+
+            const int headerRowLines = 1;
+            const int dataRowLines = 2;
+            Assert.Equal(headerRowLines + dataRowLines, actualLineCount);
+        }
+
+        [Fact]
+        public async Task TestValidateAndUploadCSV_WithoutFrameworkOrStandard_Throws()
+        {
+            await Run_ThrowsTest<NullReferenceException>(
+                builder => builder
+                    .WithRow(row => row
+                        .With("STANDARD_CODE", "")
+                        .With("STANDARD_VERSION", "")
+                        .With("FRAMEWORK_CODE", "")
+                        .With("FRAMEWORK_PROG_TYPE", "")
+                        .With("FRAMEWORK_PATHWAY_CODE", "")),
+                "Object reference not set to an instance of an object.");
+        }
+
+        [Fact]
+        public async Task TestValidateAndUploadCSV_WithStandardCode_Success()
+        {
+            await Run_SuccessTest(
+                builder => builder
+                    .WithRow(row => row.WithStandardCode()),
+                ValidateSingleApprenticeshipWithNoErrors);
+        }
+
+        [Fact]
+        public async Task TestValidateAndUploadCSV_WithFrameworkCode_Success()
+        {
+            await Run_SuccessTest(
+                builder => builder
+                    .WithRow(row => row.WithFrameworkCode()),
+                ValidateSingleApprenticeshipWithNoErrors);
+        }
+
+        [Fact]
+        public async Task TestValidateAndUploadCSV_WithRegions_Success()
+        {
+            // region values from Legacy\Dfc.CourseDirectory.Models\Models\Regions\SelectRegionModel.cs
+            await Run_SuccessTest(
+                builder => builder
+                    .WithRow(row => row
+                        .WithFrameworkCode()
+                        .With("DELIVERY_METHOD", "Employer")
+                        .With("NATIONAL_DELIVERY", "No")
+                        .With("REGION", "North West;London")
+                        .With("SUB_REGION", "Darlington;Hammersmith and Fulham")),
+                (apprenticeships) =>
+                {
+                    var apprenticeship = ValidateAndReturnSingleApprenticeshipWithNoErrors(apprenticeships);
+                    Assert.Single(apprenticeship.ApprenticeshipLocations);
+                    Assert.Equal(
+                        new List<string>
+                        {
+                            "E12000002", // North West
+                            "E12000007", // London
+                            "E06000002", // Darlington
+                            // todo: where did Hammersmith and Fulham go?
+                        },
+                        apprenticeship.ApprenticeshipLocations.Single().Regions);
+                });
+        }
+
+        [Fact]
+        public async Task TestValidateAndUploadCSV_Success_WithUnixLineEndings()
+        {
+            await Run_SuccessTest(
+                builder => builder
+                    .WithRow(row => row.WithStandardCode())
+                    .WithUnixLineEndings(),
+                ValidateSingleApprenticeshipWithNoErrors);
+        }
+
+        [Fact]
+        public async Task TestValidateAndUploadCSV_Success_WithoutTrailingNewline()
+        {
+            await Run_SuccessTest(
+                builder => builder
+                    .WithRow(row => row.WithStandardCode())
+                    .WithoutTrailingNewline(),
+                ValidateSingleApprenticeshipWithNoErrors);
+        }
+
+        [Fact]
+        public async Task TestValidateAndUploadCSV_InvalidHeader_Throws()
+        {
+            await Run_ThrowsTest<HeaderValidationException>(
+                builder => builder
+                    .WithRow(row => row.WithStandardCode())
+                    .WithInvalidHeader(),
+                "Header with name 'STANDARD_CODE' was not found. If you are expecting some headers" +
+                " to be missing and want to ignore this validation, set the configuration HeaderValidated" +
+                " to null. You can also change the functionality to do something else, like logging the issue.");
+        }
+
+        [Fact]
+        public async Task TestValidateAndUploadCSV_DuplicateRow_Throws()
+        {
+            await Run_ThrowsTest<BadDataException>(
+                builder => builder
+                    .WithRow(row => row.WithStandardCode())
+                    .WithRow(row => row.WithStandardCode()),
+                "Duplicate entries detected on rows 2, and 3.");
+            // todo: test semi-colon separated list of duplicate pairs
+        }
+
+        [Fact]
+        public async Task TestValidateAndUploadCSV_EmptyFile_Throws()
+        {
+            await Run_ThrowsTest<Exception>(
+                builder => builder.EmptyFile(),
+                "File is empty.");
+        }
+
+        [Fact]
+        public async Task TestValidateAndUploadCSV_NoRows_Throws()
+        {
+            await Run_ThrowsTest<Exception>(
+                builder => builder.WithoutRows(),
+                "The selected file is empty");
+        }
+
+        [Fact]
+        public async Task TestValidateAndUploadCSV_ArchiveFailure_Throws()
+        {
+            const string fakedErrorMessage = "failure message from ChangeApprenticeshipStatusesForUKPRNSelection here";
+
+            await Run_ThrowsTest<Exception>(
+                builder => builder.WithRow(),
+                expectedErrorMessage: fakedErrorMessage,
+                additionalMockSetup: () =>
+                {
+                    _mockApprenticeshipService.Setup(m =>
+                            m.ChangeApprenticeshipStatusesForUKPRNSelection(It.IsAny<int>(), It.IsAny<int>(),
+                                It.IsAny<int>()))
+                        .ReturnsAsync(Result.Fail(fakedErrorMessage));
+                });
+        }
+
+        [Fact]
+        public async Task TestValidateAndUploadCSV_WithoutStandardCode_WithStandardVersion_Throws()
+        {
+            await Run_ThrowsTest<BadDataException>(
+                builder => builder
+                    .WithRow(row => row
+                        .With("STANDARD_CODE", "")
+                        .With("STANDARD_VERSION", "1")
+                    ),
+                "Validation error on row 2. Missing Standard Code.");
+        }
+
+        [Fact]
+        public async Task TestValidateAndUploadCSV_StandardCode_NonNumeric_Throws()
+        {
+            await Run_ThrowsTest<FieldValidationException>(
+                builder => builder.WithRow(
+                    row => row.With("STANDARD_CODE", "this-is-not-an-integer")),
+                "Validation error on row 2. Field STANDARD_CODE must be numeric if present.");
+        }
+
+        [Fact]
+        public async Task TestValidateAndUploadCSV_StandardVersion_Blank_Throws()
+        {
+            await Run_ThrowsTest<BadDataException>(
+                builder => builder
+                    .WithRow(row => row.With("STANDARD_CODE","123")),
+                "Validation error on row 2. Missing Standard Version.");
+        }
+
+        [Fact]
+        public async Task TestValidateAndUploadCSV_StandardVersion_NonNumeric_Throws()
+        {
+            await Run_ThrowsTest<FieldValidationException>(
+                builder => builder.WithRow(
+                    row => row.With("STANDARD_VERSION", "this-is-definitely-not-an-integer")),
+                "Validation error on row 2. Field STANDARD_VERSION must be numeric if present.");
+        }
+
+        [Fact]
+        public async Task TestValidateAndUploadCSV_StandardCode_Unknown_Throws()
+        {
+            const int code = 404404;
+            const int version = 9;
+            await Run_ThrowsTest<BadDataException>(
+                builder => builder
+                    .WithRow(row => row
+                        .With("STANDARD_CODE", code.ToString())
+                        .With("STANDARD_VERSION", version.ToString())
+                    ),
+                expectedErrorMessage: "Validation error on row 2. Invalid Standard Code or Version Number. Standard not found.",
+                additionalMockSetup: () =>
+                {
+                    _standardsAndFrameworksCacheMock.Setup(m => m.GetStandard(code,version))
+                        .ReturnsAsync((Standard)null);
+                });
+        }
+
+        [Fact]
+        public async Task TestValidateAndUploadCSV_FrameworkCode_Unknown_Throws()
+        {
+            const int code = 404404;
+            const int type = 44;
+            const int pathway = 4;
+            await Run_ThrowsTest<BadDataException>(
+                builder => builder
+                    .WithRow(row => row
+                        .With("FRAMEWORK_CODE", code.ToString())
+                        .With("FRAMEWORK_PROG_TYPE", type.ToString())
+                        .With("FRAMEWORK_PATHWAY_CODE", pathway.ToString())
+                    ),
+                expectedErrorMessage: "Validation error on row 2. Invalid Framework Code, Prog Type, or Pathway Code. Framework not found.",
+                additionalMockSetup: () =>
+                {
+                    _standardsAndFrameworksCacheMock.Setup(m => m.GetFramework(code, type, pathway))
+                        .ReturnsAsync((Framework)null);
+                });
+        }
+
+        [Fact]
+        public async Task TestValidateAndUploadCSV_FrameworkWithoutCode_Throws()
+        {
+            await Run_ThrowsTest<BadDataException>(
+                builder => builder
+                    .WithRow(row => row
+                        .With("FRAMEWORK_CODE", "")
+                        .With("FRAMEWORK_PROG_TYPE", "101")
+                        .With("FRAMEWORK_PATHWAY_CODE", "101")
+                    ),
+                "Validation error on row 2. Missing Framework Code.");
+        }
+
+        [Fact]
+        public async Task TestValidateAndUploadCSV_FrameworkWithoutType_Throws()
+        {
+            await Run_ThrowsTest<BadDataException>(
+                builder => builder
+                    .WithRow(row => row
+                        .With("FRAMEWORK_CODE", "101")
+                        .With("FRAMEWORK_PROG_TYPE", "")
+                        .With("FRAMEWORK_PATHWAY_CODE", "101")
+                    ),
+                "Validation error on row 2. Missing Prog Type.");
+        }
+
+        [Fact]
+        public async Task TestValidateAndUploadCSV_FrameworkWithoutPathway_Throws()
+        {
+            await Run_ThrowsTest<BadDataException>(
+                builder => builder
+                    .WithRow(row => row
+                        .With("FRAMEWORK_CODE", "101")
+                        .With("FRAMEWORK_PROG_TYPE", "101")
+                        .With("FRAMEWORK_PATHWAY_CODE", "")
+                    ),
+                "Validation error on row 2. Missing Pathway Type.");
+        }
+
+        [Fact]
+        public async Task TestValidateAndUploadCSV_DeliveryMethod_Blank_Throws()
+        {
+            await Run_ThrowsTest<BadDataException>(
+                builder => builder.WithRow(
+                    row => row.With("DELIVERY_METHOD", "   ")),
+                "Validation error on row 2. DELIVERY_METHOD is required.");
+        }
+
+        [Theory]
+        [InlineData("CONTACT_PHONE", "Telephone is required")]
+        [InlineData("CONTACT_EMAIL", "Email is required")]
+        public async Task TestValidateAndUploadCSV_RequiredFieldBlank_ReturnsErrors(string field, string expectedError)
+        {
+            await Run_ReturnsErrorsTest(
+                builder => builder.WithRow(row => row
+                    .WithStandardCode()
+                    .With(field, "")),
+                expectedError);
+        }
+
+        [Theory]
+        [InlineData("APPRENTICESHIP_WEBPAGE", "example.org")]
+        [InlineData("APPRENTICESHIP_WEBPAGE", "http://example.org")]
+        [InlineData("APPRENTICESHIP_WEBPAGE", "https://example.org")]
+        [InlineData("APPRENTICESHIP_WEBPAGE",  "https://xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.org")]
+        [InlineData("CONTACT_URL", "example.org")]
+        [InlineData("CONTACT_URL", "http://example.org")]
+        [InlineData("CONTACT_URL", "https://example.org")]
+        public async Task TestValidateAndUploadCSV_UrlField_Success(string field, string url)
+        {
+            await Run_SuccessTest(
+                builder => builder.WithRow(row => row
+                    .WithStandardCode()
+                    .With(field, url)),
+                ValidateSingleApprenticeshipWithNoErrors);
+        }
+
+        [Theory]
+        [InlineData("APPRENTICESHIP_WEBPAGE", "x@example.org")]
+        [InlineData("APPRENTICESHIP_WEBPAGE", "exampleorg")]
+        [InlineData("APPRENTICESHIP_WEBPAGE", "xxx")]
+        [InlineData("APPRENTICESHIP_WEBPAGE", "x.x")]
+        [InlineData("CONTACT_URL", "x@example.org")]
+        [InlineData("CONTACT_URL", "exampleorg")]
+        [InlineData("CONTACT_URL", "xxx")]
+        [InlineData("CONTACT_URL", "x.x")]
+        public async Task TestValidateAndUploadCSV_UrlFields_Invalid_StoresErrors(string field, string url)
+        {
+            await Run_SuccessTest(
+                builder => builder.WithRow(row => row
+                    .WithStandardCode()
+                    .With(field, url)),
+                apprenticeships =>
+                {
+                    ValidateBulkUploadError(apprenticeships,
+                        field,
+                        $"Validation error on row 2. Field {field} format of URL is incorrect.");
+                });
+        }
+
+        [Theory]
+        [InlineData("APPRENTICESHIP_WEBPAGE")]
+        [InlineData("CONTACT_URL")]
+        public async Task TestValidateAndUploadCSV_UrlFields_TooLong_StoresErrors(string field)
+        {
+            const string longUrl = "https://xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.org";
+            await Run_SuccessTest(
+                builder => builder.WithRow(row => row
+                    .WithStandardCode()
+                    .With(field, longUrl)),
+                apprenticeships =>
+                {
+                    ValidateBulkUploadError(apprenticeships,
+                        field,
+                        $"Validation error on row 2. Field {field} maximum length is 255 characters.");
+                });
+        }
+
+        [Fact]
+        public async Task TestValidateAndUploadCSV_ApprenticeshipInfo_Blank_ReturnsErrors()
+        {
+            await Run_ReturnsErrorsTest(
+                builder => builder.WithRow(row => row
+                    .WithStandardCode()
+                    .With("APPRENTICESHIP_INFORMATION", "")),
+                "Marketing Information is required");
+        }
+
+        [Fact]
+        public async Task TestValidateAndUploadCSV_ApprenticeshipInfo_TooLong_StoresError()
+        {
+            await Run_SuccessTest(
+                builder => builder
+                    .WithRow(row => row
+                        .WithStandardCode()
+                        .With("APPRENTICESHIP_INFORMATION", new string('x', 100000))),
+                apprenticeships =>
+                {
+                    ValidateBulkUploadError(apprenticeships,
+                        "APPRENTICESHIP_INFORMATION",
+                        "Validation error on row 2. Field APPRENTICESHIP_INFORMATION maximum length is 750 characters.");
+                });
+        }
+
+        private void SetupService()
+        {
+            _apprenticeshipBulkUploadService = new ApprenticeshipBulkUploadService(
+                NullLogger<ApprenticeshipBulkUploadService>.Instance, _mockApprenticeshipService.Object,
+                _mockVenueService.Object, _standardsAndFrameworksCacheMock.Object);
+        }
+
+        private void SetupDependencies()
+        {
+            var mockVenue = new Venue
+            {
+                VenueName = ApprenticeshipCsvRowBuilder.DefaultTestVenueName,
+                Status = VenueStatus.Live,
+            };
+
+            _mockApprenticeshipService.Setup(m =>
+                    m.ChangeApprenticeshipStatusesForUKPRNSelection(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()))
+                .ReturnsAsync(Result.Ok());
+
+            _mockVenueService.Setup(m => m.SearchAsync(It.IsAny<IVenueSearchCriteria>()))
+                .ReturnsAsync(Result.Ok<IVenueSearchResult>(new VenueSearchResult(new List<Venue> {mockVenue})));
+
+            _standardsAndFrameworksCacheMock.Setup(m => m.GetStandard(It.IsAny<int>(), It.IsAny<int>()))
+                .ReturnsAsync(new Standard());
+
+            _standardsAndFrameworksCacheMock.Setup(m => m.GetFramework(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()))
+                .ReturnsAsync(new Framework());
+        }
+
+        private async Task Run_SuccessTest(Action<ApprenticeshipCsvBuilder> configureCsv,
+            Action<IList<IApprenticeship>> validateDataPassedToApprenticeshipService)
+        {
+            // arrange
+            SetupDependencies();
+            IList<IApprenticeship> dataPassedToApprenticeshipService = null;
+            _mockApprenticeshipService.Setup(m => m.AddApprenticeships(It.IsAny<IEnumerable<IApprenticeship>>()))
+                .ReturnsAsync(Result.Ok())
+                .Callback<IEnumerable<IApprenticeship>>(x => dataPassedToApprenticeshipService = x.ToList());
+            SetupService();
+            var apprenticeshipCsvBuilder = new ApprenticeshipCsvBuilder();
+            configureCsv?.Invoke(apprenticeshipCsvBuilder);
+            await using var csvStream = apprenticeshipCsvBuilder.Build();
+
+            // act
+            var actualErrors = await _apprenticeshipBulkUploadService.ValidateAndUploadCSV(
+                csvStream, _authUserDetails, updateApprenticeships: true); // todo: toggle updateApprenticeships in test(s)
+
+            // assert
+            var emptyErrorList = new List<string>();
+            Assert.Equal(emptyErrorList, actualErrors);
+            validateDataPassedToApprenticeshipService(dataPassedToApprenticeshipService);
+        }
+
+        private async Task Run_ThrowsTest<TException>(
+                Action<ApprenticeshipCsvBuilder> configureCsv,
+                string expectedErrorMessage,
+                Action additionalMockSetup = null)
+            where TException : Exception
+        {
+            // arrange
+            SetupDependencies();
+            _mockApprenticeshipService.Setup(m => m.AddApprenticeships(It.IsAny<IEnumerable<IApprenticeship>>()))
+                .ReturnsAsync(Result.Ok());
+            additionalMockSetup?.Invoke();
+            SetupService();
+            var apprenticeshipCsvBuilder = new ApprenticeshipCsvBuilder();
+            configureCsv?.Invoke(apprenticeshipCsvBuilder);
+            await using var csvStream = apprenticeshipCsvBuilder.Build();
+
+            // act
+            var actualException = await Record.ExceptionAsync(
+                async () => await _apprenticeshipBulkUploadService.ValidateAndUploadCSV(
+                    csvStream, _authUserDetails, updateApprenticeships: true) // todo: toggle updateApprenticeships in test(s)
+            );
+
+            // assert
+            Assert.NotNull(actualException);
+            Assert.IsType<TException>(actualException);
+            Assert.Equal(expectedErrorMessage, actualException.Message);
+        }
+
+        private async Task<List<IApprenticeship>> Run_ReturnsErrorsTest(Action<ApprenticeshipCsvBuilder> configureCsv, string expectedError)
+        {
+            // arrange
+            SetupDependencies();
+            List<IApprenticeship> dataPassedToApprenticeshipService = null;
+            _mockApprenticeshipService.Setup(m => m.AddApprenticeships(It.IsAny<IEnumerable<IApprenticeship>>()))
+                .ReturnsAsync(Result.Ok())
+                .Callback<IEnumerable<IApprenticeship>>(x => dataPassedToApprenticeshipService = x.ToList());
+            SetupService();
+            var apprenticeshipCsvBuilder = new ApprenticeshipCsvBuilder();
+            configureCsv?.Invoke(apprenticeshipCsvBuilder);
+            await using var csvStream = apprenticeshipCsvBuilder.Build();
+
+            // act
+            var actualErrors = await _apprenticeshipBulkUploadService.ValidateAndUploadCSV(
+                csvStream, _authUserDetails, updateApprenticeships: true); // todo: toggle updateApprenticeships in test(s)
+
+            // assert
+            var expectedErrors = new List<string> {expectedError};
+            Assert.Equal(expectedErrors, actualErrors);
+            return dataPassedToApprenticeshipService;
+        }
+
+        private static void ValidateSingleApprenticeshipWithNoErrors(IList<IApprenticeship> apprenticeships)
+        {
+            ValidateAndReturnSingleApprenticeshipWithNoErrors(apprenticeships);
+        }
+
+        private static IApprenticeship ValidateAndReturnSingleApprenticeshipWithNoErrors(IList<IApprenticeship> apprenticeships)
+        {
+            Assert.Single(apprenticeships);
+            Assert.Null(apprenticeships.Single().ValidationErrors);
+            Assert.Empty(apprenticeships.Single().BulkUploadErrors);
+            return apprenticeships.Single();
+        }
+
+        private static void ValidateBulkUploadError(IList<IApprenticeship> apprenticeships, string fieldName, string expectedError)
+        {
+            Assert.Single(apprenticeships);
+            var apprenticeship = apprenticeships.Single();
+            Assert.Null(apprenticeship.ValidationErrors);
+            Assert.Single(apprenticeship.BulkUploadErrors);
+            var bulkUploadError = apprenticeship.BulkUploadErrors.Single();
+            Assert.Equal(fieldName, bulkUploadError.Header);
+            Assert.Equal(expectedError, bulkUploadError.Error);
+            Assert.Equal(2, bulkUploadError.LineNumber);
+        }
+    }
+}

--- a/Dfc.CourseDirectory.Services.Tests/BulkUploadService/Apprenticeship/ApprenticeshipCsvBuilder.cs
+++ b/Dfc.CourseDirectory.Services.Tests/BulkUploadService/Apprenticeship/ApprenticeshipCsvBuilder.cs
@@ -64,7 +64,7 @@ namespace Dfc.CourseDirectory.Services.Tests.BulkUploadService.Apprenticeship
             return this;
         }
 
-        public Stream Build()
+        public Stream BuildStream()
         {
             return new MemoryStream(Encoding.UTF8.GetBytes(BuildString()));
         }

--- a/Dfc.CourseDirectory.Services.Tests/BulkUploadService/Apprenticeship/ApprenticeshipCsvBuilder.cs
+++ b/Dfc.CourseDirectory.Services.Tests/BulkUploadService/Apprenticeship/ApprenticeshipCsvBuilder.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace Dfc.CourseDirectory.Services.Tests.BulkUploadService.Apprenticeship
+{
+    /// <summary>
+    /// Builder Pattern implementation with fluent api for building arbitrary variations of csv data for testing bulk upload.
+    /// </summary>
+    internal class ApprenticeshipCsvBuilder
+    {
+        private bool _emptyFile;
+        private bool _generateInvalidHeader;
+        private bool _trailingNewline = true;
+        private string _newLine = "\r\n";
+        private readonly List<string> _rows = new List<string>();
+
+        private string CsvHeader()
+        {
+            var csvHeader = string.Join(",", ApprenticeshipCsvStructure.Fields);
+            if (_generateInvalidHeader)
+            {
+                return "modified_first_header_name_" + csvHeader;
+            }
+            return csvHeader;
+        }
+
+        /// <summary>
+        /// Lambda based API for adding rows.
+        /// To add a default valid row:
+        ///   `.WithRow()`
+        /// To add a customised row:
+        ///   `.WithRow(row => row.WithStandardCode("this-is-not-an-integer"))`
+        /// </summary>
+        public ApprenticeshipCsvBuilder WithRow(Action<ApprenticeshipCsvRowBuilder> configureRow = null)
+        {
+            var csvRowBuilder = new ApprenticeshipCsvRowBuilder();
+            configureRow?.Invoke(csvRowBuilder);
+            _rows.Add(csvRowBuilder.Build());
+            return this;
+        }
+
+        public ApprenticeshipCsvBuilder WithoutRows()
+        {
+            // This method isn't strictly necessary, you can just add no rows,
+            // but it makes the intent of the caller more explicit.
+
+            _rows.Clear();
+            return this;
+        }
+
+        public ApprenticeshipCsvBuilder WithUnixLineEndings()
+        {
+            _newLine = "\n";
+            return this;
+        }
+
+        public ApprenticeshipCsvBuilder WithoutTrailingNewline()
+        {
+            _trailingNewline = false;
+            return this;
+        }
+
+        public ApprenticeshipCsvBuilder WithInvalidHeader()
+        {
+            _generateInvalidHeader = true;
+            return this;
+        }
+
+        public ApprenticeshipCsvBuilder EmptyFile()
+        {
+            _emptyFile = true;
+            return this;
+        }
+
+        public Stream Build()
+        {
+            return new MemoryStream(Encoding.UTF8.GetBytes(BuildString()));
+        }
+
+        private string BuildString()
+        {
+            if (_emptyFile)
+            {
+                return "";
+            }
+
+            var sb = new StringBuilder();
+            sb.Append(CsvHeader());
+            sb.Append(_newLine);
+            sb.Append(string.Join(_newLine, _rows));
+            if (_trailingNewline)
+            {
+                sb.Append(_newLine);
+            }
+
+            return sb.ToString();
+        }
+    }
+}

--- a/Dfc.CourseDirectory.Services.Tests/BulkUploadService/Apprenticeship/ApprenticeshipCsvBuilder.cs
+++ b/Dfc.CourseDirectory.Services.Tests/BulkUploadService/Apprenticeship/ApprenticeshipCsvBuilder.cs
@@ -16,16 +16,6 @@ namespace Dfc.CourseDirectory.Services.Tests.BulkUploadService.Apprenticeship
         private string _newLine = "\r\n";
         private readonly List<string> _rows = new List<string>();
 
-        private string CsvHeader()
-        {
-            var csvHeader = string.Join(",", ApprenticeshipCsvStructure.Fields);
-            if (_generateInvalidHeader)
-            {
-                return "modified_first_header_name_" + csvHeader;
-            }
-            return csvHeader;
-        }
-
         /// <summary>
         /// Lambda based API for adding rows.
         /// To add a default valid row:
@@ -87,7 +77,7 @@ namespace Dfc.CourseDirectory.Services.Tests.BulkUploadService.Apprenticeship
             }
 
             var sb = new StringBuilder();
-            sb.Append(CsvHeader());
+            sb.Append(CreateCsvHeader());
             sb.Append(_newLine);
             sb.Append(string.Join(_newLine, _rows));
             if (_trailingNewline)
@@ -96,6 +86,16 @@ namespace Dfc.CourseDirectory.Services.Tests.BulkUploadService.Apprenticeship
             }
 
             return sb.ToString();
+        }
+
+        private string CreateCsvHeader()
+        {
+            var csvHeader = string.Join(",", ApprenticeshipCsvStructure.Fields);
+            if (_generateInvalidHeader)
+            {
+                return "modified_first_header_name_" + csvHeader;
+            }
+            return csvHeader;
         }
     }
 }

--- a/Dfc.CourseDirectory.Services.Tests/BulkUploadService/Apprenticeship/ApprenticeshipCsvRowBuilder.cs
+++ b/Dfc.CourseDirectory.Services.Tests/BulkUploadService/Apprenticeship/ApprenticeshipCsvRowBuilder.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Dfc.CourseDirectory.Services.Tests.BulkUploadService.Apprenticeship
+{
+    /// <summary>
+    /// Builder Pattern implementation with fluent api for building arbitrary csv row data for bulk upload testing
+    /// </summary>
+    internal class ApprenticeshipCsvRowBuilder
+    {
+        public const string DefaultTestVenueName = "A Test Venue";
+
+        private readonly Dictionary<string, string> _values = new Dictionary<string, string>(
+            ApprenticeshipCsvStructure.Fields.Select(
+                fieldName => new KeyValuePair<string, string>(fieldName, "")));
+
+        public ApprenticeshipCsvRowBuilder()
+        {
+            SetValidDefaultValues();
+        }
+
+        public ApprenticeshipCsvRowBuilder With(string field, string value)
+        {
+            if (!_values.ContainsKey(field))
+            {
+                throw new ArgumentOutOfRangeException($"Unknown field '{field}'");
+            }
+
+            _values[field] = value;
+            return this;
+        }
+
+        public ApprenticeshipCsvRowBuilder WithStandardCode()
+        {
+            return With("STANDARD_CODE", "122").With("STANDARD_VERSION", "1");
+        }
+
+        public ApprenticeshipCsvRowBuilder WithFrameworkCode()
+        {
+            return With("FRAMEWORK_CODE", "487").With("FRAMEWORK_PROG_TYPE", "21").With("FRAMEWORK_PATHWAY_CODE", "1");
+        }
+
+        public string Build()
+        {
+            return string.Join(",",
+                ApprenticeshipCsvStructure.Fields.Select(
+                    fieldName => _values[fieldName]));
+        }
+
+        private void SetValidDefaultValues()
+        {
+            With("ACROSS_ENGLAND", "No");
+            With("APPRENTICESHIP_INFORMATION", "description number 1");
+            With("CONTACT_EMAIL", "info@example.co.uk");
+            With("CONTACT_PHONE", "1414960001");
+            With("DELIVERY_METHOD", "Both");
+            With("DELIVERY_MODE", "Employer");
+            With("RADIUS", "100");
+            With("VENUE", DefaultTestVenueName);
+        }
+    }
+}

--- a/Dfc.CourseDirectory.Services.Tests/BulkUploadService/Apprenticeship/ApprenticeshipCsvRowBuilder.cs
+++ b/Dfc.CourseDirectory.Services.Tests/BulkUploadService/Apprenticeship/ApprenticeshipCsvRowBuilder.cs
@@ -24,7 +24,7 @@ namespace Dfc.CourseDirectory.Services.Tests.BulkUploadService.Apprenticeship
         {
             if (!_values.ContainsKey(field))
             {
-                throw new ArgumentOutOfRangeException($"Unknown field '{field}'");
+                throw new ArgumentOutOfRangeException(field, $"Unknown field '{field}'.");
             }
 
             _values[field] = value;

--- a/Dfc.CourseDirectory.Services.Tests/BulkUploadService/Apprenticeship/ApprenticeshipCsvRowBuilder.cs
+++ b/Dfc.CourseDirectory.Services.Tests/BulkUploadService/Apprenticeship/ApprenticeshipCsvRowBuilder.cs
@@ -12,8 +12,7 @@ namespace Dfc.CourseDirectory.Services.Tests.BulkUploadService.Apprenticeship
         public const string DefaultTestVenueName = "A Test Venue";
 
         private readonly Dictionary<string, string> _values = new Dictionary<string, string>(
-            ApprenticeshipCsvStructure.Fields.Select(
-                fieldName => new KeyValuePair<string, string>(fieldName, "")));
+            ApprenticeshipCsvStructure.Fields.ToDictionary(fieldName => fieldName, _ => ""));
 
         public ApprenticeshipCsvRowBuilder()
         {

--- a/Dfc.CourseDirectory.Services.Tests/BulkUploadService/Apprenticeship/ApprenticeshipCsvStructure.cs
+++ b/Dfc.CourseDirectory.Services.Tests/BulkUploadService/Apprenticeship/ApprenticeshipCsvStructure.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+
+namespace Dfc.CourseDirectory.Services.Tests.BulkUploadService.Apprenticeship
+{
+    internal static class ApprenticeshipCsvStructure
+    {
+        public static readonly List<string> Fields = new List<string>
+        {
+            "STANDARD_CODE",
+            "STANDARD_VERSION",
+            "FRAMEWORK_CODE",
+            "FRAMEWORK_PROG_TYPE",
+            "FRAMEWORK_PATHWAY_CODE",
+            "APPRENTICESHIP_INFORMATION",
+            "APPRENTICESHIP_WEBPAGE",
+            "CONTACT_EMAIL",
+            "CONTACT_PHONE",
+            "CONTACT_URL",
+            "DELIVERY_METHOD",
+            "VENUE",
+            "RADIUS",
+            "DELIVERY_MODE",
+            "ACROSS_ENGLAND",
+            "NATIONAL_DELIVERY",
+            "REGION",
+            "SUB_REGION",
+        };
+    }
+}

--- a/Dfc.CourseDirectory.Services.Tests/BulkUploadService/Apprenticeship/ApprenticeshipCsvStructure.cs
+++ b/Dfc.CourseDirectory.Services.Tests/BulkUploadService/Apprenticeship/ApprenticeshipCsvStructure.cs
@@ -4,7 +4,7 @@ namespace Dfc.CourseDirectory.Services.Tests.BulkUploadService.Apprenticeship
 {
     internal static class ApprenticeshipCsvStructure
     {
-        public static readonly List<string> Fields = new List<string>
+        public static readonly IReadOnlyList<string> Fields = new List<string>
         {
             "STANDARD_CODE",
             "STANDARD_VERSION",

--- a/Dfc.CourseDirectory.Services.Tests/Dfc.CourseDirectory.Services.Tests.csproj
+++ b/Dfc.CourseDirectory.Services.Tests/Dfc.CourseDirectory.Services.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+        <PackageReference Include="Moq" Version="4.14.5" />
+        <PackageReference Include="xunit" Version="2.4.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+        <PackageReference Include="coverlet.collector" Version="1.2.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\src\Dfc.CourseDirectory.Services\Dfc.CourseDirectory.Services.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/Dfc.CourseDirectory.sln
+++ b/Dfc.CourseDirectory.sln
@@ -34,6 +34,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Dfc.CourseDirectory.Core.Te
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Dfc.CourseDirectory.Web.Tests", "tests\Dfc.CourseDirectory.Web.Tests\Dfc.CourseDirectory.Web.Tests.csproj", "{3E624726-E241-462A-9C07-4C0A3FCD41D6}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dfc.CourseDirectory.Services.Tests", "Dfc.CourseDirectory.Services.Tests\Dfc.CourseDirectory.Services.Tests.csproj", "{F734371F-3DE2-4B40-8654-5EBB167D7432}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -88,6 +90,10 @@ Global
 		{3E624726-E241-462A-9C07-4C0A3FCD41D6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3E624726-E241-462A-9C07-4C0A3FCD41D6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3E624726-E241-462A-9C07-4C0A3FCD41D6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F734371F-3DE2-4B40-8654-5EBB167D7432}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F734371F-3DE2-4B40-8654-5EBB167D7432}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F734371F-3DE2-4B40-8654-5EBB167D7432}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F734371F-3DE2-4B40-8654-5EBB167D7432}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -98,6 +104,7 @@ Global
 		{1ABC0C0E-7FC6-4AFD-B5D3-16968304AE0F} = {260DB60D-49B4-4B94-A6E8-53069B9FC1BB}
 		{37C43756-89CC-46FC-A397-2A68740DD08C} = {260DB60D-49B4-4B94-A6E8-53069B9FC1BB}
 		{3E624726-E241-462A-9C07-4C0A3FCD41D6} = {260DB60D-49B4-4B94-A6E8-53069B9FC1BB}
+		{F734371F-3DE2-4B40-8654-5EBB167D7432} = {260DB60D-49B4-4B94-A6E8-53069B9FC1BB}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0079CB89-A4F8-4056-BBC0-FDFBF72BC50C}

--- a/src/Dfc.CourseDirectory.Models/Models/Auth/AuthUserDetails.cs
+++ b/src/Dfc.CourseDirectory.Models/Models/Auth/AuthUserDetails.cs
@@ -39,6 +39,9 @@ namespace Dfc.CourseDirectory.Models.Models.Auth
             ProviderType = providerType;
             ProviderID = providerId;
         }
+
+        public AuthUserDetails() { }
+
         protected override IEnumerable<object> GetEqualityComponents()
         {
             yield return UserId;

--- a/src/Dfc.CourseDirectory.Models/Models/Venues/Venue.cs
+++ b/src/Dfc.CourseDirectory.Models/Models/Venues/Venue.cs
@@ -29,7 +29,7 @@ namespace Dfc.CourseDirectory.Models.Models.Venues
         [JsonIgnore]
         public int VenueID { get; }
         [JsonProperty("VENUE_NAME")]
-        public string VenueName { get; }
+        public string VenueName { get; set; }
         [JsonProperty("PROV_VENUE_ID", Required = Required.AllowNull)]
         [JsonIgnore]
         public string ProvVenueID { get; }
@@ -215,6 +215,7 @@ namespace Dfc.CourseDirectory.Models.Models.Venues
             DateUpdated = dateUpdated;
         }
 
+        public Venue() { }
 
         protected override IEnumerable<object> GetEqualityComponents()
         {


### PR DESCRIPTION
These are "characterization tests" to show the current behaviour of the
system without introducing modifications, with a view to being able to
confidently change and refactor the code later.

* Add parameterless constructor to data objects to simplify testing.
* Make venue name settable so we can use an object initializer.

Written by Tim, with some pairing from James & James.

This is not complete coverage, there is plenty more to do (some todos in the PR), but it's a good start, and I think worth getting in as-is as a base for extending as desired.

Areas that need more work:

* testing exactly what is passed on to the next link in the chain
* what does the background upload process do, does it share the code?
* testing of any transformations made on the way through

![Selection_20200721-02-0](https://user-images.githubusercontent.com/19378/88050669-2f060500-cb4f-11ea-8209-488fe75d0f04.png)
