### PR TITLE
Release the integration test DB lock for MVC-based tests

### DIFF
--- a/tests/Dfc.CourseDirectory.WebV2.Tests/CourseDirectoryApplicationFactory.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/CourseDirectoryApplicationFactory.cs
@@ -54,6 +54,14 @@ namespace Dfc.CourseDirectory.WebV2.Tests
 
         public TestUserInfo User => Services.GetRequiredService<TestUserInfo>();
 
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                DatabaseFixture.Dispose();
+            }
+        }
+
         public void OnTestStarting()
         {
             DatabaseFixture.OnTestStarting();


### PR DESCRIPTION
This should actually fix the flaky CI runs