### PR TITLE
[PTCD-528] Refactor apprenticeship bulk upload controller

### DIFF
--- a/src/Dfc.CourseDirectory.Web/Controllers/BulkUploadApprenticeshipsController.cs
+++ b/src/Dfc.CourseDirectory.Web/Controllers/BulkUploadApprenticeshipsController.cs
@@ -142,7 +142,7 @@ namespace Dfc.CourseDirectory.Web.Controllers
                     return View(new BulkUploadViewModel {errors = new[] {errorMessage}});
                 }
 
-                await using var ms = new MemoryStream(); // todo: await-using to dispose of stream. Needs test fix.
+                await using var ms = new MemoryStream();
                 bulkUploadFile.CopyTo(ms);
 
                 if (Validate.isBinaryStream(ms))

--- a/src/Dfc.CourseDirectory.Web/Controllers/BulkUploadApprenticeshipsController.cs
+++ b/src/Dfc.CourseDirectory.Web/Controllers/BulkUploadApprenticeshipsController.cs
@@ -145,11 +145,13 @@ namespace Dfc.CourseDirectory.Web.Controllers
                 await using var ms = new MemoryStream();
                 bulkUploadFile.CopyTo(ms);
 
+                ms.Position = 0;
                 if (Validate.isBinaryStream(ms))
                 {
                     return View(new BulkUploadViewModel {errors = new[] {"Invalid file content."}});
                 }
 
+                ms.Position = 0;
                 var csvLineCount = _apprenticeshipBulkUploadService.CountCsvLines(ms);
 
                 bool processInline = (csvLineCount <= _blobService.InlineProcessingThreshold);
@@ -167,6 +169,7 @@ namespace Dfc.CourseDirectory.Web.Controllers
 
                 if (!processInline)
                 {
+                    ms.Position = 0;
                     await _blobService.UploadFileAsync(
                         $"{UKPRN.ToString()}/Apprenticeship Bulk Upload/Files/{bulkUploadFileNewName}", ms);
                 }

--- a/tests/Dfc.CourseDirectory.Web.Tests/Controllers/BulkUploadApprenticeshipsControllerTests.cs
+++ b/tests/Dfc.CourseDirectory.Web.Tests/Controllers/BulkUploadApprenticeshipsControllerTests.cs
@@ -72,7 +72,8 @@ namespace Dfc.CourseDirectory.Web.Tests.Controllers
             _mockBlobStorageService.Setup(
                     m => m.UploadFileAsync(It.IsRegex(filePathPattern), It.IsAny<Stream>()))
                 .Returns(Task.CompletedTask)
-                .Callback((string _, Stream stream) => streamPassedThrough = IsOriginalStream(csvData, stream));
+                .Callback(
+                    (string _, Stream stream) => streamPassedThrough = StreamContainsOriginalData(stream, csvData));
 
             // act
             var result = await _bulkUploadApprenticeshipsController.Index(_mockFormFile.Object);
@@ -178,12 +179,12 @@ namespace Dfc.CourseDirectory.Web.Tests.Controllers
             VerifyNotUploaded();
         }
 
-        private static bool IsOriginalStream(string originalCsv, Stream stream)
+        private static bool StreamContainsOriginalData(Stream stream, string originalData)
         {
             stream.Position = 0;
             var reader = new StreamReader(stream);
             var actualCsv = reader.ReadToEnd();
-            return originalCsv == actualCsv;
+            return originalData == actualCsv;
         }
 
         private BulkUploadApprenticeshipsController BuildController()

--- a/tests/Dfc.CourseDirectory.Web.Tests/Controllers/BulkUploadApprenticeshipsControllerTests.cs
+++ b/tests/Dfc.CourseDirectory.Web.Tests/Controllers/BulkUploadApprenticeshipsControllerTests.cs
@@ -181,7 +181,6 @@ namespace Dfc.CourseDirectory.Web.Tests.Controllers
 
         private static bool StreamContainsOriginalData(Stream stream, string originalData)
         {
-            stream.Position = 0;
             var reader = new StreamReader(stream);
             var actualCsv = reader.ReadToEnd();
             return originalData == actualCsv;


### PR DESCRIPTION
* Whitespace code cleanup.
* Reduce nesting by using early-return.
* Dispose of stream correctly, adjust test to verify stream during call to mock instead of verify where it is already disposed.

This patch reduces the "cognitive complexity" of the Index action from 31 to 10 as measured by https://plugins.jetbrains.com/plugin/12024-cognitivecomplexity/

There's more we could do on this but we're moving on to other tasks for now.

## Complexity

### Before

![upload controller complexity - before](https://user-images.githubusercontent.com/19378/88796326-57b67c00-d199-11ea-93d2-8a41d570607a.png)

### After

![upload controller complexity - after](https://user-images.githubusercontent.com/19378/88796344-5f762080-d199-11ea-9b30-de595513b307.png)

