### PR TITLE
PTCD-528 Remove windows-specific dead code from "bulk upload processing" notice

### DIFF
--- a/src/Dfc.CourseDirectory.Web/ViewComponents/BackgroundBulkUploadNotification/Default.cshtml
+++ b/src/Dfc.CourseDirectory.Web/ViewComponents/BackgroundBulkUploadNotification/Default.cshtml
@@ -1,8 +1,4 @@
-﻿@using Dfc.CourseDirectory.Common.Settings
-@using Dfc.CourseDirectory.Services.Interfaces.ProviderService
-@using Dfc.CourseDirectory.Services.ProviderService
-@using Dfc.CourseDirectory.Web.Helpers
-@using Microsoft.Extensions.Options
+﻿@using Dfc.CourseDirectory.Services.Interfaces.ProviderService
 @using Dfc.CourseDirectory.Web.ViewComponents.Notification
 @using Microsoft.AspNetCore.Authorization
 @using Microsoft.AspNetCore.Http
@@ -13,35 +9,11 @@
 @inject IAuthorizationService Authorization
 @inject IHttpContextAccessor HttpContextAccessor
 @inject IProviderService providerService
-
-
-
 @{
-    string datestamp = string.Empty;
-    string timestamp = string.Empty;
-    string dateCombined = string.Empty;
-    if (Model.BulkUploadBackgroundStartTimestamp.HasValue)
-    {
-        datestamp = Model.BulkUploadBackgroundStartTimestamp.Value.ToString("dd MMM yyyy");
-        timestamp = Model.BulkUploadBackgroundStartTimestamp.Value.ToString("HH:mm");
-
-        TimeZoneInfo tzi = TimeZoneInfo.FindSystemTimeZoneById("GMT Standard Time");
-
-        DateTime gmt =Model.BulkUploadBackgroundStartTimestamp.Value.ToUniversalTime();
-
-        DateTime dt2 = TimeZoneInfo.ConvertTimeFromUtc(gmt, tzi);
-        dateCombined= dt2.ToString("dd MMM yyyy HH:mm");
-        //model.FileUploadedDate = dt2.ToString("dd MMM yyyy HH:mm");
-    }
-
-    System.Text.StringBuilder message = new System.Text.StringBuilder
-        ($"Your bulk upload is in progress and may take a few minutes. Continue to refresh this page.Do not add a new course or another bulk upload during this process.Once your bulk upload is complete you will receive a notification to publish your courses.");
-    
-   
     @await Component.InvokeAsync(nameof(Notification), new NotificationModel
     {
         NotificationTitle = "Bulk upload processing",
         ClassType = "info-summary",
-        NotificationMessage = message.ToString()
+        NotificationMessage = "Your bulk upload is in progress and may take a few minutes. Continue to refresh this page. Do not add a new course or another bulk upload during this process. Once your bulk upload is complete you will receive a notification to publish your courses.",
     })
 }


### PR DESCRIPTION
* The code was not in use so can safely be removed.
* The removed call to `FindSystemTimeZoneById()` fails on linux due to a different timezone list. See https://dejanstojanovic.net/aspnet/2018/july/differences-in-time-zones-in-net-core-on-windows-and-linux-host-os/
* Added missing spaces after full stops in message.

Tripped over this while troubleshooting an unrelated bulk upload issue.