### PR TITLE
PTCD-506 Fix Apprenticeships Guidance Link

### DIFF
--- a/src/Dfc.CourseDirectory.Web/Views/Apprenticeships/Details/Index.cshtml
+++ b/src/Dfc.CourseDirectory.Web/Views/Apprenticeships/Details/Index.cshtml
@@ -76,7 +76,7 @@
                         Apprenticeship information for employers
                     </label>
                     <span class="govuk-hint">
-                        Give information for employers about how you deliver this specific apprenticeship training. For useful advice on how to fill out this section go to the <a href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/746087/course_directory_provider_portal_user_guide_v7.pdf" target="_blank">guidance</a>
+                        Give information for employers about how you deliver this specific apprenticeship training. For useful advice on how to fill out this section go to the <a href="https://www.gov.uk/government/publications/find-apprenticeship-training-how-to-submit-data" target="_blank">guidance</a>
                     </span>
                     <textarea class="govuk-textarea" asp-for="@Model.Information" rows="5" id="info" aria-labelledby="govuk-label-Information"></textarea>
                 </div>

--- a/src/Dfc.CourseDirectory.Web/Views/EditApprenticeship/EditApprenticeship.cshtml
+++ b/src/Dfc.CourseDirectory.Web/Views/EditApprenticeship/EditApprenticeship.cshtml
@@ -61,7 +61,7 @@
                         Apprenticeship information for employers
                     </label>
                     <span class="govuk-hint">
-                        Give information for employers about how you deliver this specific apprenticeship training. For useful advice on how to fill out this section go to the <a href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/746087/course_directory_provider_portal_user_guide_v7.pdf" target="_blank">guidance</a>
+                        Give information for employers about how you deliver this specific apprenticeship training. For useful advice on how to fill out this section go to the <a href="https://www.gov.uk/government/publications/find-apprenticeship-training-how-to-submit-data" target="_blank">guidance</a>
                     </span>
                     <textarea class="govuk-textarea" asp-for="@Model.Information" rows="5" id="info" aria-labelledby="govuk-label-Information"></textarea>
                 </div>

--- a/src/Dfc.CourseDirectory.WebV2/Features/NewApprenticeshipProvider/ApprenticeshipDetails.cshtml
+++ b/src/Dfc.CourseDirectory.WebV2/Features/NewApprenticeshipProvider/ApprenticeshipDetails.cshtml
@@ -25,7 +25,7 @@
             <govuk-character-count-label>Apprenticeship information</govuk-character-count-label>
             <govuk-character-count-hint>
                 Give information for employers about how you deliver this specific apprenticeship training.
-                For useful advice on how to fill out this section go to the <a class="govuk-link" href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/746087/course_directory_provider_portal_user_guide_v7.pdf" rel="noreferrer" target="_blank">guidance</a>.
+                For useful advice on how to fill out this section go to the <a class="govuk-link" href="https://www.gov.uk/government/publications/find-apprenticeship-training-how-to-submit-data" rel="noreferrer" target="_blank">guidance</a>.
             </govuk-character-count-hint>
         </govuk-character-count>
     </pttcd-rich-text-editor>


### PR DESCRIPTION
Updated apprenticeships guidance link for Apprenticeship details, edit apprenticeship and new apprenticeship provider

Change from https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/746087/course_directory_provider_portal_user_guide_v7.pdf to https://www.gov.uk/government/publications/find-apprenticeship-training-how-to-submit-data