### PR TITLE
PTCD-424 Fix CopyCourseRun Qualification Details Bug

### DIFF
--- a/src/Dfc.CourseDirectory.Web/Views/CopyCourseRun/CopyCourseRun.cshtml
+++ b/src/Dfc.CourseDirectory.Web/Views/CopyCourseRun/CopyCourseRun.cshtml
@@ -71,7 +71,7 @@
         <pttcd-notification title="Qualification details">
             <ul class="govuk-list govuk-!-margin-bottom-0">
                 <li><span class="govuk-!-font-weight-bold">LARS/QAN:</span> @Model.LearnAimRef</li>
-                <li><span class="govuk-!-font-weight-bold">Qualification name:</span> @Model.CourseName</li>
+                <li><span class="govuk-!-font-weight-bold">Qualification name:</span> @Model.LearnAimRefTitle</li>
                 <li><span class="govuk-!-font-weight-bold">Qualification level:</span> @Model.NotionalNVQLevelv2</li>
                 <li><span class="govuk-!-font-weight-bold">Awarding organisation:</span> @Model.AwardOrgCode</li>
             </ul>


### PR DESCRIPTION
Fix CopyCourseRun Qualification Details notification - Qualification name bug

The "Qualification name" field was referencing the incorrect model value.