### PR TITLE
Rationalise Provider Context

### DIFF
--- a/src/Dfc.CourseDirectory.Web/Controllers/ProviderSearchController.cs
+++ b/src/Dfc.CourseDirectory.Web/Controllers/ProviderSearchController.cs
@@ -247,15 +247,11 @@ namespace Dfc.CourseDirectory.Web.Controllers
         [Authorize(Policy = "ElevatedUserRole")]
         public async Task<IActionResult> SearchProvider(
             int UKPRN,
-            [FromServices] IProviderInfoCache providerInfoCache)
+            [FromServices] IProviderInfoCache providerInfoCache,
+            [FromServices] IProviderContextProvider providerContextProvider)
         {
-            if (HttpContext.Features.Get<ProviderContextFeature>() == null)
-            {
-                var providerId = await providerInfoCache.GetProviderIdForUkprn(UKPRN);
-                var providerInfo = await providerInfoCache.GetProviderInfo(providerId.Value);
-
-                HttpContext.Features.Set(new ProviderContextFeature(providerInfo));
-            }
+            var providerInfo = await providerInfoCache.GetProviderInfoForUkprn(UKPRN);
+            providerContextProvider.SetProviderContext(providerInfo);
 
             _session.SetInt32("UKPRN", UKPRN);
             return View("../Provider/Dashboard");

--- a/src/Dfc.CourseDirectory.Web/Controllers/ProviderSearchController.cs
+++ b/src/Dfc.CourseDirectory.Web/Controllers/ProviderSearchController.cs
@@ -251,7 +251,7 @@ namespace Dfc.CourseDirectory.Web.Controllers
             [FromServices] IProviderContextProvider providerContextProvider)
         {
             var providerInfo = await providerInfoCache.GetProviderInfoForUkprn(UKPRN);
-            providerContextProvider.SetProviderContext(providerInfo);
+            providerContextProvider.SetProviderContext(new ProviderContext(providerInfo));
 
             _session.SetInt32("UKPRN", UKPRN);
             return View("../Provider/Dashboard");

--- a/src/Dfc.CourseDirectory.Web/RestrictApprenticeshipQAStatusAttribute.cs
+++ b/src/Dfc.CourseDirectory.Web/RestrictApprenticeshipQAStatusAttribute.cs
@@ -1,11 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Dfc.CourseDirectory.WebV2;
 using Dfc.CourseDirectory.Core.DataStore.Sql;
 using Dfc.CourseDirectory.Core.DataStore.Sql.Queries;
-using Dfc.CourseDirectory.WebV2.HttpContextFeatures;
 using Dfc.CourseDirectory.Core.Models;
+using Dfc.CourseDirectory.WebV2;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Extensions.DependencyInjection;
@@ -35,14 +34,15 @@ namespace Dfc.CourseDirectory.Web
                 return;
             }
 
-            var providerContextFeature = context.HttpContext.Features.Get<ProviderContextFeature>();
+            var providerContextProvider = context.HttpContext.RequestServices.GetRequiredService<IProviderContextProvider>();
+            var providerInfo = await providerContextProvider.GetProviderContext();
 
-            if (providerContextFeature == null)
+            if (providerInfo == null)
             {
                 throw new InvalidOperationException("No provider context set.");
             }
 
-            var providerId = providerContextFeature.ProviderInfo.ProviderId;
+            var providerId = providerInfo.ProviderId;
 
             var sqlQueryDispatcher = context.HttpContext.RequestServices.GetRequiredService<ISqlQueryDispatcher>();
 

--- a/src/Dfc.CourseDirectory.Web/RestrictApprenticeshipQAStatusAttribute.cs
+++ b/src/Dfc.CourseDirectory.Web/RestrictApprenticeshipQAStatusAttribute.cs
@@ -35,14 +35,14 @@ namespace Dfc.CourseDirectory.Web
             }
 
             var providerContextProvider = context.HttpContext.RequestServices.GetRequiredService<IProviderContextProvider>();
-            var providerInfo = await providerContextProvider.GetProviderContext();
+            var providerContext = await providerContextProvider.GetProviderContext();
 
-            if (providerInfo == null)
+            if (providerContext == null)
             {
                 throw new InvalidOperationException("No provider context set.");
             }
 
-            var providerId = providerInfo.ProviderId;
+            var providerId = providerContext.ProviderInfo.ProviderId;
 
             var sqlQueryDispatcher = context.HttpContext.RequestServices.GetRequiredService<ISqlQueryDispatcher>();
 

--- a/src/Dfc.CourseDirectory.Web/ViewComponents/Dashboard/Dashboard.cs
+++ b/src/Dfc.CourseDirectory.Web/ViewComponents/Dashboard/Dashboard.cs
@@ -225,7 +225,7 @@ namespace Dfc.CourseDirectory.Web.ViewComponents.Dashboard
 
                 if (actualModel.QAFeatureIsEnabled)
                 {
-                    var providerId = ViewContext.HttpContext.Features.Get<ProviderContextFeature>().ProviderInfo.ProviderId;
+                    var providerId = ViewContext.HttpContext.Features.Get<ProviderContextFeature>().ProviderContext.ProviderInfo.ProviderId;
 
                     actualModel.ProviderQACurrentStatus = await _sqlQueryDispatcher.ExecuteQuery(
                         new GetProviderApprenticeshipQAStatus()

--- a/src/Dfc.CourseDirectory.Web/Views/Shared/_GovukHeaderPartial_Your_Courses.cshtml
+++ b/src/Dfc.CourseDirectory.Web/Views/Shared/_GovukHeaderPartial_Your_Courses.cshtml
@@ -15,7 +15,7 @@
 @inject Dfc.CourseDirectory.WebV2.IProviderContextProvider ProviderContextProvider
 
 @{
-    var providerContext = ProviderContextProvider.GetProviderContext();
+    var providerContext = await ProviderContextProvider.GetProviderContext();
     var currentUser = CurrentUserProvider.GetCurrentUser();
 }
 

--- a/src/Dfc.CourseDirectory.Web/Views/Shared/_GovukHeaderPartial_Your_Courses.cshtml
+++ b/src/Dfc.CourseDirectory.Web/Views/Shared/_GovukHeaderPartial_Your_Courses.cshtml
@@ -36,7 +36,7 @@
             {
                 @if (currentUser.IsProvider)
                 {
-                    <vc:provider-top-nav provider-info="@providerContext" />
+                    <vc:provider-top-nav provider-info="@providerContext.ProviderInfo" />
                 }
                 else
                 {
@@ -67,6 +67,6 @@
 @if (currentUser != null && !currentUser.IsProvider && providerContext != null)
 {
     <div class="govuk-body govuk-!-margin-bottom-6 cd-fullwidth-container">
-        <vc:admin-provider-context-nav provider-info="@providerContext" />
+        <vc:admin-provider-context-nav provider-info="@providerContext.ProviderInfo" />
     </div>
 }

--- a/src/Dfc.CourseDirectory.WebV2/Features/IRequiresProviderContextController.cs
+++ b/src/Dfc.CourseDirectory.WebV2/Features/IRequiresProviderContextController.cs
@@ -2,6 +2,6 @@
 {
     public interface IRequiresProviderContextController
     {
-        ProviderInfo ProviderContext { get; set; }
+        ProviderContext ProviderContext { get; set; }
     }
 }

--- a/src/Dfc.CourseDirectory.WebV2/Features/IRequiresProviderContextController.cs
+++ b/src/Dfc.CourseDirectory.WebV2/Features/IRequiresProviderContextController.cs
@@ -1,7 +1,0 @@
-﻿namespace Dfc.CourseDirectory.WebV2.Features
-{
-    public interface IRequiresProviderContextController
-    {
-        ProviderContext ProviderContext { get; set; }
-    }
-}

--- a/src/Dfc.CourseDirectory.WebV2/Features/NewApprenticeshipProvider/NewApprenticeshipProviderController.cs
+++ b/src/Dfc.CourseDirectory.WebV2/Features/NewApprenticeshipProvider/NewApprenticeshipProviderController.cs
@@ -28,7 +28,7 @@ namespace Dfc.CourseDirectory.WebV2.Features.NewApprenticeshipProvider
 
         public MptxInstanceContext<FlowModel> Flow { get; set; }
 
-        public ProviderInfo ProviderContext { get; set; }
+        public ProviderContext ProviderContext { get; set; }
 
         [MptxAction]
         [HttpGet("add-apprenticeship-classroom-location")]
@@ -37,7 +37,7 @@ namespace Dfc.CourseDirectory.WebV2.Features.NewApprenticeshipProvider
             var childFlow = mptxManager.CreateInstance<ClassroomLocation.FlowModel, ClassroomLocation.IFlowModelCallback>(
                 Flow.InstanceId,
                 ClassroomLocation.FlowModel.Add(
-                    ProviderContext.ProviderId,
+                    ProviderContext.ProviderInfo.ProviderId,
                     cancelable: (Flow.State.ApprenticeshipClassroomLocations?.Count ?? 0) > 0),
                 contextItems: new Dictionary<string, object>()
                 {
@@ -56,7 +56,7 @@ namespace Dfc.CourseDirectory.WebV2.Features.NewApprenticeshipProvider
         [HttpGet("apprenticeship-details")]
         public async Task<IActionResult> ApprenticeshipDetails()
         {
-            var query = new ApprenticeshipDetails.Query() { ProviderId = ProviderContext.ProviderId };
+            var query = new ApprenticeshipDetails.Query() { ProviderId = ProviderContext.ProviderInfo.ProviderId };
             return await _mediator.SendAndMapResponse(query, vm => View(vm));
         }
 
@@ -64,7 +64,7 @@ namespace Dfc.CourseDirectory.WebV2.Features.NewApprenticeshipProvider
         [HttpPost("apprenticeship-details")]
         public async Task<IActionResult> ApprenticeshipDetails(ApprenticeshipDetails.Command command)
         {
-            command.ProviderId = ProviderContext.ProviderId;
+            command.ProviderId = ProviderContext.ProviderInfo.ProviderId;
             return await _mediator.SendAndMapResponse(
                 command,
                 response => response.Match<IActionResult>(
@@ -82,7 +82,7 @@ namespace Dfc.CourseDirectory.WebV2.Features.NewApprenticeshipProvider
         [HttpGet("apprenticeship-employer-locations")]
         public async Task<IActionResult> ApprenticeshipEmployerLocations()
         {
-            var query = new ApprenticeshipEmployerLocations.Query() { ProviderId = ProviderContext.ProviderId };
+            var query = new ApprenticeshipEmployerLocations.Query() { ProviderId = ProviderContext.ProviderInfo.ProviderId };
             return await _mediator.SendAndMapResponse(
                 query,
                 response => View(response));
@@ -92,7 +92,7 @@ namespace Dfc.CourseDirectory.WebV2.Features.NewApprenticeshipProvider
         [HttpPost("apprenticeship-employer-locations")]
         public async Task<IActionResult> ApprenticeshipEmployerLocations(ApprenticeshipEmployerLocations.Command command)
         {
-            command.ProviderId = ProviderContext.ProviderId;
+            command.ProviderId = ProviderContext.ProviderInfo.ProviderId;
             return await _mediator.SendAndMapResponse(
                 command,
                 response => response.Match<IActionResult>(
@@ -111,7 +111,7 @@ namespace Dfc.CourseDirectory.WebV2.Features.NewApprenticeshipProvider
         [HttpGet("apprenticeship-employer-locations-regions")]
         public async Task<IActionResult> ApprenticeshipEmployerLocationsRegions()
         {
-            var query = new ApprenticeshipEmployerLocationsRegions.Query() { ProviderId = ProviderContext.ProviderId };
+            var query = new ApprenticeshipEmployerLocationsRegions.Query() { ProviderId = ProviderContext.ProviderInfo.ProviderId };
             return await _mediator.SendAndMapResponse(query, command => View(command));
         }
 
@@ -119,7 +119,7 @@ namespace Dfc.CourseDirectory.WebV2.Features.NewApprenticeshipProvider
         [HttpPost("apprenticeship-employer-locations-regions")]
         public async Task<IActionResult> ApprenticeshipEmployerLocationsRegions(ApprenticeshipEmployerLocationsRegions.Command command)
         {
-            command.ProviderId = ProviderContext.ProviderId;
+            command.ProviderId = ProviderContext.ProviderInfo.ProviderId;
             return await _mediator.SendAndMapResponse(
                 command,
                 response => response.Match<IActionResult>(
@@ -137,7 +137,7 @@ namespace Dfc.CourseDirectory.WebV2.Features.NewApprenticeshipProvider
         [HttpGet("apprenticeship-locations")]
         public async Task<IActionResult> ApprenticeshipLocations()
         {
-            var query = new ApprenticeshipLocations.Query() { ProviderId = ProviderContext.ProviderId };
+            var query = new ApprenticeshipLocations.Query() { ProviderId = ProviderContext.ProviderInfo.ProviderId };
             return await _mediator.SendAndMapResponse(
                 query,
                 response => View(response));
@@ -147,7 +147,7 @@ namespace Dfc.CourseDirectory.WebV2.Features.NewApprenticeshipProvider
         [HttpPost("apprenticeship-locations")]
         public async Task<IActionResult> ApprenticeshipLocations(ApprenticeshipLocations.Command command)
         {
-            command.ProviderId = ProviderContext.ProviderId;
+            command.ProviderId = ProviderContext.ProviderInfo.ProviderId;
             return await _mediator.SendAndMapResponse(
                 command,
                 response => response.Match<IActionResult>(
@@ -163,7 +163,7 @@ namespace Dfc.CourseDirectory.WebV2.Features.NewApprenticeshipProvider
         [HttpGet("apprenticeship-confirmation")]
         public async Task<IActionResult> ApprenticeshipSummary()
         {
-            var query = new ApprenticeshipSummary.Query() { ProviderId = ProviderContext.ProviderId };
+            var query = new ApprenticeshipSummary.Query() { ProviderId = ProviderContext.ProviderInfo.ProviderId };
             return await _mediator.SendAndMapResponse(
                 query,
                 response => response.Match(
@@ -175,7 +175,7 @@ namespace Dfc.CourseDirectory.WebV2.Features.NewApprenticeshipProvider
         [HttpPost("apprenticeship-confirmation")]
         public async Task<IActionResult> ApprenticeshipSummaryConfirmation()
         {
-            var command = new ApprenticeshipSummary.CompleteCommand() { ProviderId = ProviderContext.ProviderId };
+            var command = new ApprenticeshipSummary.CompleteCommand() { ProviderId = ProviderContext.ProviderInfo.ProviderId };
             return await _mediator.SendAndMapResponse(
                 command,
                 response => response.Match(
@@ -199,7 +199,7 @@ namespace Dfc.CourseDirectory.WebV2.Features.NewApprenticeshipProvider
             var childFlow = mptxManager.CreateInstance<ClassroomLocation.FlowModel, ClassroomLocation.IFlowModelCallback>(
                 Flow.InstanceId,
                 ClassroomLocation.FlowModel.Edit(
-                    ProviderContext.ProviderId,
+                    ProviderContext.ProviderInfo.ProviderId,
                     location.VenueId,
                     location.Radius,
                     location.DeliveryModes
@@ -225,7 +225,7 @@ namespace Dfc.CourseDirectory.WebV2.Features.NewApprenticeshipProvider
                 Flow.InstanceId,
                 new FindStandardOrFramework.FlowModel()
                 {
-                    ProviderId = ProviderContext.ProviderId
+                    ProviderId = ProviderContext.ProviderInfo.ProviderId
                 },
                 contextItems: new Dictionary<string, object>()
                 {
@@ -246,7 +246,7 @@ namespace Dfc.CourseDirectory.WebV2.Features.NewApprenticeshipProvider
             [FromServices] MptxManager mptxManager,
             [FromServices] FlowModelInitializer initializer)
         {
-            var flowModel = await initializer.Initialize(ProviderContext.ProviderId);
+            var flowModel = await initializer.Initialize(ProviderContext.ProviderInfo.ProviderId);
             var flow = mptxManager.CreateInstance(flowModel);
             return RedirectToAction(nameof(ProviderDetail))
                 .WithMptxInstanceId(flow);
@@ -256,7 +256,7 @@ namespace Dfc.CourseDirectory.WebV2.Features.NewApprenticeshipProvider
         [HttpGet("provider-detail")]
         public async Task<IActionResult> ProviderDetail()
         {
-            var query = new ProviderDetail.Query() { ProviderId = ProviderContext.ProviderId };
+            var query = new ProviderDetail.Query() { ProviderId = ProviderContext.ProviderInfo.ProviderId };
             return await _mediator.SendAndMapResponse(query, vm => View(vm));
         }
 
@@ -264,7 +264,7 @@ namespace Dfc.CourseDirectory.WebV2.Features.NewApprenticeshipProvider
         [HttpPost("provider-detail")]
         public async Task<IActionResult> ProviderDetail(ProviderDetail.Command command)
         {
-            command.ProviderId = ProviderContext.ProviderId;
+            command.ProviderId = ProviderContext.ProviderInfo.ProviderId;
             return await _mediator.SendAndMapResponse(
                 command,
                 response => response.Match<IActionResult>(
@@ -278,25 +278,25 @@ namespace Dfc.CourseDirectory.WebV2.Features.NewApprenticeshipProvider
         [HttpGet("provider-detail-confirmation")]
         public async Task<IActionResult> ProviderDetailConfirmation()
         {
-            var query = new ProviderDetail.ConfirmationQuery() { ProviderId = ProviderContext.ProviderId };
+            var query = new ProviderDetail.ConfirmationQuery() { ProviderId = ProviderContext.ProviderInfo.ProviderId };
             return await _mediator.SendAndMapResponse(query, vm => View(vm));
         }
 
         [MptxAction]
         [HttpPost("provider-detail-confirmation")]
         public async Task<IActionResult> ProviderDetailConfirmation(
-            ProviderInfo providerInfo,
+            ProviderContext providerContext,
             ProviderDetail.ConfirmationCommand command)
         {
-            command.ProviderId = providerInfo.ProviderId;
+            command.ProviderId = providerContext.ProviderInfo.ProviderId;
             return await _mediator.SendAndMapResponse(
                 command,
                 success => Flow.State.ApprenticeshipId.HasValue ?
                     RedirectToAction(nameof(ApprenticeshipSummary))
-                        .WithProviderContext(providerInfo)
+                        .WithProviderContext(providerContext)
                         .WithMptxInstanceId(Flow) :
                     RedirectToAction(nameof(FindStandardOrFramework))
-                        .WithProviderContext(providerInfo)
+                        .WithProviderContext(providerContext)
                         .WithMptxInstanceId(Flow));
         }
 
@@ -305,7 +305,7 @@ namespace Dfc.CourseDirectory.WebV2.Features.NewApprenticeshipProvider
             [LocalUrl] string returnUrl,
             HidePassedNotification.Command command)
         {
-            command.ProviderId = ProviderContext.ProviderId;
+            command.ProviderId = ProviderContext.ProviderInfo.ProviderId;
             return await _mediator.SendAndMapResponse(command,
                 success => Redirect(returnUrl));
         }

--- a/src/Dfc.CourseDirectory.WebV2/Features/NewApprenticeshipProvider/QANotificationsViewComponent.cs
+++ b/src/Dfc.CourseDirectory.WebV2/Features/NewApprenticeshipProvider/QANotificationsViewComponent.cs
@@ -24,7 +24,7 @@ namespace Dfc.CourseDirectory.WebV2.Features.NewApprenticeshipProvider
 
         public async Task<IViewComponentResult> InvokeAsync()
         {
-            var providerId = (await _providerContextProvider.GetProviderContext()).ProviderId;
+            var providerId = (await _providerContextProvider.GetProviderContext()).ProviderInfo.ProviderId;
 
             var qaStatus = await _sqlQueryDispatcher.ExecuteQuery(
                 new GetProviderApprenticeshipQAStatus()

--- a/src/Dfc.CourseDirectory.WebV2/Features/NewApprenticeshipProvider/QANotificationsViewComponent.cs
+++ b/src/Dfc.CourseDirectory.WebV2/Features/NewApprenticeshipProvider/QANotificationsViewComponent.cs
@@ -24,7 +24,7 @@ namespace Dfc.CourseDirectory.WebV2.Features.NewApprenticeshipProvider
 
         public async Task<IViewComponentResult> InvokeAsync()
         {
-            var providerId = _providerContextProvider.GetProviderContext().ProviderId;
+            var providerId = (await _providerContextProvider.GetProviderContext()).ProviderId;
 
             var qaStatus = await _sqlQueryDispatcher.ExecuteQuery(
                 new GetProviderApprenticeshipQAStatus()

--- a/src/Dfc.CourseDirectory.WebV2/Features/Providers/ProvidersController.cs
+++ b/src/Dfc.CourseDirectory.WebV2/Features/Providers/ProvidersController.cs
@@ -14,12 +14,12 @@ namespace Dfc.CourseDirectory.WebV2.Features.Providers
             _mediator = mediator;
         }
 
-        public ProviderInfo ProviderContext { get; set; }
+        public ProviderContext ProviderContext { get; set; }
 
         [HttpGet("info")]
         public async Task<IActionResult> EditProviderInfo()
         {
-            var query = new EditProviderInfo.Query() { ProviderId = ProviderContext.ProviderId };
+            var query = new EditProviderInfo.Query() { ProviderId = ProviderContext.ProviderInfo.ProviderId };
             return await _mediator.SendAndMapResponse(
                 query,
                 response => response.Match(
@@ -30,7 +30,7 @@ namespace Dfc.CourseDirectory.WebV2.Features.Providers
         [HttpPost("info")]
         public async Task<IActionResult> EditProviderInfo(EditProviderInfo.Command command)
         {
-            command.ProviderId = ProviderContext.ProviderId;
+            command.ProviderId = ProviderContext.ProviderInfo.ProviderId;
             return await _mediator.SendAndMapResponse(
                 command,
                 response => response.Match<IActionResult>(

--- a/src/Dfc.CourseDirectory.WebV2/Features/Providers/ProvidersController.cs
+++ b/src/Dfc.CourseDirectory.WebV2/Features/Providers/ProvidersController.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace Dfc.CourseDirectory.WebV2.Features.Providers
 {
     [Route("providers")]
-    public class ProvidersController : Controller, IRequiresProviderContextController
+    public class ProvidersController : Controller
     {
         private readonly IMediator _mediator;
 
@@ -14,12 +14,10 @@ namespace Dfc.CourseDirectory.WebV2.Features.Providers
             _mediator = mediator;
         }
 
-        public ProviderContext ProviderContext { get; set; }
-
         [HttpGet("info")]
-        public async Task<IActionResult> EditProviderInfo()
+        public async Task<IActionResult> EditProviderInfo(ProviderContext providerContext)
         {
-            var query = new EditProviderInfo.Query() { ProviderId = ProviderContext.ProviderInfo.ProviderId };
+            var query = new EditProviderInfo.Query() { ProviderId = providerContext.ProviderInfo.ProviderId };
             return await _mediator.SendAndMapResponse(
                 query,
                 response => response.Match(
@@ -28,14 +26,16 @@ namespace Dfc.CourseDirectory.WebV2.Features.Providers
         }
 
         [HttpPost("info")]
-        public async Task<IActionResult> EditProviderInfo(EditProviderInfo.Command command)
+        public async Task<IActionResult> EditProviderInfo(
+            EditProviderInfo.Command command,
+            ProviderContext providerContext)
         {
-            command.ProviderId = ProviderContext.ProviderInfo.ProviderId;
+            command.ProviderId = providerContext.ProviderInfo.ProviderId;
             return await _mediator.SendAndMapResponse(
                 command,
                 response => response.Match<IActionResult>(
                     errors => this.ViewFromErrors(errors),
-                    success => RedirectToAction("Details", "Provider").WithProviderContext(ProviderContext)));
+                    success => RedirectToAction("Details", "Provider").WithProviderContext(providerContext)));
         }
     }
 }

--- a/src/Dfc.CourseDirectory.WebV2/Filters/ProviderContextResourceFilter.cs
+++ b/src/Dfc.CourseDirectory.WebV2/Filters/ProviderContextResourceFilter.cs
@@ -72,7 +72,8 @@ namespace Dfc.CourseDirectory.WebV2.Filters
                 var providerInfo = await providerInfoCache.GetProviderInfo(providerId);
                 if (providerInfo != null)
                 {
-                    providerContextProvider.SetProviderContext(providerInfo);
+                    var providerContext = new ProviderContext(providerInfo);
+                    providerContextProvider.SetProviderContext(providerContext);
                 }
             }
 

--- a/src/Dfc.CourseDirectory.WebV2/Filters/RedirectToProviderSelectionActionFilter.cs
+++ b/src/Dfc.CourseDirectory.WebV2/Filters/RedirectToProviderSelectionActionFilter.cs
@@ -41,8 +41,8 @@ namespace Dfc.CourseDirectory.WebV2.Filters
                 return;
             }
 
-            var hasProviderInfoParameter = context.ActionDescriptor.Parameters
-                .Where(p => p.ParameterType == typeof(ProviderInfo))
+            var hasProviderContextParameter = context.ActionDescriptor.Parameters
+                .Where(p => p.ParameterType == typeof(ProviderContext))
                 .Any();
 
             var isRequiresProviderContextController = context.Controller is IRequiresProviderContextController;
@@ -51,7 +51,7 @@ namespace Dfc.CourseDirectory.WebV2.Filters
                 controllerActionDescriptor.MethodInfo.GetCustomAttribute<RequiresProviderContextAttribute>() != null ||
                 isRequiresProviderContextController;
 
-            if (hasProviderInfoParameter || requiresProviderContext)
+            if (hasProviderContextParameter || requiresProviderContext)
             {
                 var providerContextProvider = context.HttpContext.RequestServices.GetRequiredService<IProviderContextProvider>();
                 var providerContext = await providerContextProvider.GetProviderContext();

--- a/src/Dfc.CourseDirectory.WebV2/Filters/RedirectToProviderSelectionActionFilter.cs
+++ b/src/Dfc.CourseDirectory.WebV2/Filters/RedirectToProviderSelectionActionFilter.cs
@@ -1,21 +1,13 @@
 ﻿using System;
 using System.Linq;
-using System.Reflection;
 using System.Threading.Tasks;
-using Dfc.CourseDirectory.WebV2.Features;
 using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Dfc.CourseDirectory.WebV2.Filters
 {
-    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false)]
-    public class AllowNoProviderContextAttribute : Attribute
-    {
-    }
-
     public class RedirectToProviderSelectionActionFilter : IAsyncActionFilter, IOrderedFilter
     {
         public RedirectToProviderSelectionActionFilter()
@@ -26,30 +18,17 @@ namespace Dfc.CourseDirectory.WebV2.Filters
 
         public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
         {
-            var controllerActionDescriptor = context.ActionDescriptor as ControllerActionDescriptor;
-
-            if (controllerActionDescriptor == null)
-            {
-                await next();
-                return;
-            }
-
-            if (controllerActionDescriptor.MethodInfo.GetCustomAttribute<AllowNoProviderContextAttribute>() != null ||
-                controllerActionDescriptor.ControllerTypeInfo.GetCustomAttribute<AllowNoProviderContextAttribute>() != null)
-            {
-                await next();
-                return;
-            }
+            // If the action has a parameter of type ProviderContext and/or
+            // the controller/action is decorated with RequiresProviderContextAttribute then we consider
+            // provider context to be required.
+            // If it's not set then redirect to the provider selection UI.
 
             var hasProviderContextParameter = context.ActionDescriptor.Parameters
                 .Where(p => p.ParameterType == typeof(ProviderContext))
                 .Any();
 
-            var isRequiresProviderContextController = context.Controller is IRequiresProviderContextController;
-
-            var requiresProviderContext =
-                controllerActionDescriptor.MethodInfo.GetCustomAttribute<RequiresProviderContextAttribute>() != null ||
-                isRequiresProviderContextController;
+            var requiresProviderContext = hasProviderContextParameter ||
+                context.ActionDescriptor.Properties.ContainsKey(typeof(RequiresProviderContextMarker));
 
             if (hasProviderContextParameter || requiresProviderContext)
             {
@@ -63,10 +42,6 @@ namespace Dfc.CourseDirectory.WebV2.Filters
                         "SearchProvider",
                         new { returnUrl = context.HttpContext.Request.GetEncodedUrl() });
                     return;
-                }
-                else if (isRequiresProviderContextController)
-                {
-                    ((IRequiresProviderContextController)context.Controller).ProviderContext = providerContext;
                 }
             }
 

--- a/src/Dfc.CourseDirectory.WebV2/Filters/VerifyApprenticeshipIdActionFilter.cs
+++ b/src/Dfc.CourseDirectory.WebV2/Filters/VerifyApprenticeshipIdActionFilter.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Linq;
-using System.Net;
 using System.Reflection;
 using System.Threading.Tasks;
 using Dfc.CourseDirectory.WebV2.HttpContextFeatures;
@@ -48,6 +47,8 @@ namespace Dfc.CourseDirectory.WebV2.Filters
             }
 
             var providerOwnershipCache = context.HttpContext.RequestServices.GetRequiredService<IProviderOwnershipCache>();
+            var providerContextProvider = context.HttpContext.RequestServices.GetRequiredService<IProviderContextProvider>();
+
             var providerId = await providerOwnershipCache.GetProviderForApprenticeship((Guid)apprenticeshipId);
 
             if (!providerId.HasValue)
@@ -73,7 +74,7 @@ namespace Dfc.CourseDirectory.WebV2.Filters
                         var providerInfo = await providerInfoCache.GetProviderInfo(providerId.Value);
                         context.ActionArguments[p.Name] = providerInfo;
 
-                        context.HttpContext.Features.Set(new ProviderContextFeature(providerInfo));
+                        providerContextProvider.SetProviderContext(providerInfo);
                     }
                     else if (boundValue.ProviderId != providerId.Value)
                     {

--- a/src/Dfc.CourseDirectory.WebV2/HttpContextFeatures/ProviderContextFeature.cs
+++ b/src/Dfc.CourseDirectory.WebV2/HttpContextFeatures/ProviderContextFeature.cs
@@ -4,16 +4,11 @@ namespace Dfc.CourseDirectory.WebV2.HttpContextFeatures
 {
     public class ProviderContextFeature
     {
-        public ProviderContextFeature(ProviderInfo providerInfo)
+        public ProviderContextFeature(ProviderContext providerContext)
         {
-            if (providerInfo == null)
-            {
-                throw new ArgumentNullException(nameof(providerInfo));
-            }
-
-            ProviderInfo = providerInfo;
+            ProviderContext = providerContext ?? throw new ArgumentNullException(nameof(providerContext));
         }
 
-        public ProviderInfo ProviderInfo { get; }
+        public ProviderContext ProviderContext { get; }
     }
 }

--- a/src/Dfc.CourseDirectory.WebV2/IProviderContextProvider.cs
+++ b/src/Dfc.CourseDirectory.WebV2/IProviderContextProvider.cs
@@ -4,7 +4,7 @@ namespace Dfc.CourseDirectory.WebV2
 {
     public interface IProviderContextProvider
     {
-        Task<ProviderInfo> GetProviderContext();
-        void SetProviderContext(ProviderInfo providerInfo);
+        Task<ProviderContext> GetProviderContext();
+        void SetProviderContext(ProviderContext providerContext);
     }
 }

--- a/src/Dfc.CourseDirectory.WebV2/IProviderContextProvider.cs
+++ b/src/Dfc.CourseDirectory.WebV2/IProviderContextProvider.cs
@@ -1,7 +1,10 @@
-﻿namespace Dfc.CourseDirectory.WebV2
+﻿using System.Threading.Tasks;
+
+namespace Dfc.CourseDirectory.WebV2
 {
     public interface IProviderContextProvider
     {
-        ProviderInfo GetProviderContext();
+        Task<ProviderInfo> GetProviderContext();
+        void SetProviderContext(ProviderInfo providerInfo);
     }
 }

--- a/src/Dfc.CourseDirectory.WebV2/ModelBinding/ProviderContextModelBinder.cs
+++ b/src/Dfc.CourseDirectory.WebV2/ModelBinding/ProviderContextModelBinder.cs
@@ -1,6 +1,6 @@
 ﻿using System.Threading.Tasks;
-using Dfc.CourseDirectory.WebV2.HttpContextFeatures;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Dfc.CourseDirectory.WebV2.ModelBinding
 {
@@ -19,26 +19,27 @@ namespace Dfc.CourseDirectory.WebV2.ModelBinding
 
     public class CurrentProviderModelBinder : IModelBinder
     {
-        public Task BindModelAsync(ModelBindingContext bindingContext)
+        public async Task BindModelAsync(ModelBindingContext bindingContext)
         {
             if (bindingContext.ModelType != typeof(ProviderInfo))
             {
                 bindingContext.Result = ModelBindingResult.Failed();
-                return Task.CompletedTask;
+                return;
             }
 
-            var feature = bindingContext.HttpContext.Features.Get<ProviderContextFeature>();
+            var providerContextProvider = bindingContext.HttpContext.RequestServices.GetRequiredService<IProviderContextProvider>();
+            var providerInfo = await providerContextProvider.GetProviderContext();
 
-            if (feature == null)
+            if (providerInfo == null)
             {
                 bindingContext.Result = ModelBindingResult.Failed();
             }
             else
             {
-                bindingContext.Result = ModelBindingResult.Success(feature.ProviderInfo);
+                bindingContext.Result = ModelBindingResult.Success(providerInfo);
             }
 
-            return Task.CompletedTask;
+            return;
         }
     }
 }

--- a/src/Dfc.CourseDirectory.WebV2/ModelBinding/ProviderContextModelBinder.cs
+++ b/src/Dfc.CourseDirectory.WebV2/ModelBinding/ProviderContextModelBinder.cs
@@ -8,7 +8,7 @@ namespace Dfc.CourseDirectory.WebV2.ModelBinding
     {
         public IModelBinder GetBinder(ModelBinderProviderContext context)
         {
-            if (context.Metadata.ModelType == typeof(ProviderInfo))
+            if (context.Metadata.ModelType == typeof(ProviderContext))
             {
                 return new CurrentProviderModelBinder();
             }
@@ -21,7 +21,7 @@ namespace Dfc.CourseDirectory.WebV2.ModelBinding
     {
         public async Task BindModelAsync(ModelBindingContext bindingContext)
         {
-            if (bindingContext.ModelType != typeof(ProviderInfo))
+            if (bindingContext.ModelType != typeof(ProviderContext))
             {
                 bindingContext.Result = ModelBindingResult.Failed();
                 return;

--- a/src/Dfc.CourseDirectory.WebV2/ProviderContext.cs
+++ b/src/Dfc.CourseDirectory.WebV2/ProviderContext.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace Dfc.CourseDirectory.WebV2
+{
+    public class ProviderContext
+    {
+        public ProviderContext(ProviderInfo providerInfo)
+        {
+            ProviderInfo = providerInfo ?? throw new ArgumentNullException(nameof(providerInfo));
+        }
+
+        public ProviderInfo ProviderInfo { get; }
+    }
+}

--- a/src/Dfc.CourseDirectory.WebV2/ProviderContextProvider.cs
+++ b/src/Dfc.CourseDirectory.WebV2/ProviderContextProvider.cs
@@ -69,6 +69,16 @@ namespace Dfc.CourseDirectory.WebV2
             }
 
             var httpContext = _httpContextAccessor.HttpContext;
+
+            var currentContextFeature = httpContext.Features.Get<ProviderContextFeature>();
+
+            if (currentContextFeature != null &&
+                currentContextFeature.ProviderContext.ProviderInfo.ProviderId != providerContext.ProviderInfo.ProviderId)
+            {
+                throw new InvalidOperationException(
+                    $"Provider context has already been set for another provider: '{currentContextFeature.ProviderContext.ProviderInfo.ProviderId}'.");
+            }
+
             httpContext.Features.Set(new ProviderContextFeature(providerContext));
         }
     }

--- a/src/Dfc.CourseDirectory.WebV2/ProviderContextProvider.cs
+++ b/src/Dfc.CourseDirectory.WebV2/ProviderContextProvider.cs
@@ -1,4 +1,7 @@
-﻿using Dfc.CourseDirectory.WebV2.HttpContextFeatures;
+﻿using System;
+using System.Threading.Tasks;
+using Dfc.CourseDirectory.WebV2.HttpContextFeatures;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 
 namespace Dfc.CourseDirectory.WebV2
@@ -6,17 +9,60 @@ namespace Dfc.CourseDirectory.WebV2
     public class ProviderContextProvider : IProviderContextProvider
     {
         private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly IWebHostEnvironment _env;
+        private readonly IProviderInfoCache _providerInfoCache;
 
-        public ProviderContextProvider(IHttpContextAccessor httpContextAccessor)
+        public ProviderContextProvider(
+            IHttpContextAccessor httpContextAccessor,
+            IWebHostEnvironment env,
+            IProviderInfoCache providerInfoCache)
         {
             _httpContextAccessor = httpContextAccessor;
+            _env = env;
+            _providerInfoCache = providerInfoCache;
         }
 
-        public ProviderInfo GetProviderContext()
+        public async Task<ProviderInfo> GetProviderContext()
         {
             var httpContext = _httpContextAccessor.HttpContext;
             var feature = httpContext.Features.Get<ProviderContextFeature>();
-            return feature?.ProviderInfo;
+
+            if (feature != null)
+            {
+                return feature.ProviderInfo;
+            }
+
+            if (!_env.IsTesting())
+            {
+                // Legacy page support - old pages use UKPRN in session for holding onto provider
+                // so look for that as a fallback.
+                // N.B. It's disabled for tests so that new features (i.e. those that have test coverage)
+                // are required to use new mechanism.
+
+                var ukprn = httpContext.Session.GetInt32("UKPRN");
+                if (ukprn.HasValue)
+                {
+                    var providerId = await _providerInfoCache.GetProviderIdForUkprn(ukprn.Value);
+
+                    if (providerId != null)
+                    {
+                        return await _providerInfoCache.GetProviderInfo(providerId.Value);
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        public void SetProviderContext(ProviderInfo providerInfo)
+        {
+            if (providerInfo == null)
+            {
+                throw new ArgumentNullException(nameof(providerInfo));
+            }
+
+            var httpContext = _httpContextAccessor.HttpContext;
+            httpContext.Features.Set(new ProviderContextFeature(providerInfo));
         }
     }
 }

--- a/src/Dfc.CourseDirectory.WebV2/ProviderInfoCacheExtensions.cs
+++ b/src/Dfc.CourseDirectory.WebV2/ProviderInfoCacheExtensions.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Dfc.CourseDirectory.WebV2
+{
+    public static class ProviderInfoCacheExtensions
+    {
+        public static async Task<ProviderInfo> GetProviderInfoForUkprn(this IProviderInfoCache providerInfoCache, int ukprn)
+        {
+            if (providerInfoCache == null)
+            {
+                throw new ArgumentNullException(nameof(providerInfoCache));
+            }
+
+            var providerId = await providerInfoCache.GetProviderIdForUkprn(ukprn);
+
+            if (providerId == null)
+            {
+                return null;
+            }
+
+            return await providerInfoCache.GetProviderInfo(providerId.Value);
+        }
+    }
+}

--- a/src/Dfc.CourseDirectory.WebV2/RedirectToActionResultExtensions.cs
+++ b/src/Dfc.CourseDirectory.WebV2/RedirectToActionResultExtensions.cs
@@ -9,10 +9,10 @@ namespace Dfc.CourseDirectory.WebV2
     {
         public static RedirectToActionResult WithProviderContext(
             this RedirectToActionResult result,
-            ProviderInfo providerInfo)
+            ProviderContext providerContext)
         {
             var routeValues = (IDictionary<string, object>)result.RouteValues ?? new Dictionary<string, object>();
-            routeValues[ProviderContextResourceFilter.RouteValueKey] = providerInfo.ProviderId;
+            routeValues[ProviderContextResourceFilter.RouteValueKey] = providerContext.ProviderInfo.ProviderId;
 
             result.RouteValues = new RouteValueDictionary(routeValues);
 

--- a/src/Dfc.CourseDirectory.WebV2/RequiresProviderContextAttribute.cs
+++ b/src/Dfc.CourseDirectory.WebV2/RequiresProviderContextAttribute.cs
@@ -1,9 +1,34 @@
 ﻿using System;
+using Microsoft.AspNetCore.Mvc.ApplicationModels;
 
 namespace Dfc.CourseDirectory.WebV2
 {
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
-    public class RequiresProviderContextAttribute : Attribute
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false)]
+    public sealed class RequiresProviderContextAttribute : Attribute, IActionModelConvention, IControllerModelConvention
     {
+        private void AddMetadataToAction(ActionModel action)
+        {
+            action.Properties.Add(typeof(RequiresProviderContextMarker), RequiresProviderContextMarker.Instance);
+        }
+
+        void IActionModelConvention.Apply(ActionModel action)
+        {
+            AddMetadataToAction(action);
+        }
+
+        void IControllerModelConvention.Apply(ControllerModel controller)
+        {
+            foreach (var action in controller.Actions)
+            {
+                AddMetadataToAction(action);
+            }
+        }
+    }
+
+    public sealed class RequiresProviderContextMarker
+    {
+        private RequiresProviderContextMarker() { }
+
+        public static RequiresProviderContextMarker Instance { get; } = new RequiresProviderContextMarker();
     }
 }

--- a/src/Dfc.CourseDirectory.WebV2/SharedViews/_V2LayoutProviderContext.cshtml
+++ b/src/Dfc.CourseDirectory.WebV2/SharedViews/_V2LayoutProviderContext.cshtml
@@ -4,7 +4,7 @@
 @{
     Layout = "_V2LayoutCore";
 
-    var providerContext = ProviderContextProvider.GetProviderContext();
+    var providerContext = await ProviderContextProvider.GetProviderContext();
     var currentUser = CurrentUserProvider.GetCurrentUser();
 }
 

--- a/src/Dfc.CourseDirectory.WebV2/SharedViews/_V2LayoutProviderContext.cshtml
+++ b/src/Dfc.CourseDirectory.WebV2/SharedViews/_V2LayoutProviderContext.cshtml
@@ -13,7 +13,7 @@
     {
         @if (currentUser.IsProvider)
         {
-            <vc:provider-top-nav provider-info="@providerContext" />
+            <vc:provider-top-nav provider-info="@providerContext.ProviderInfo" />
         }
         else
         {
@@ -27,7 +27,7 @@
     {
         @* FIXME: Move this class into component when legacy views don't need it *@
         <div class="govuk-width-container">
-            <vc:admin-provider-context-nav provider-info="@providerContext" />
+            <vc:admin-provider-context-nav provider-info="@providerContext.ProviderInfo" />
         </div>
     }
 }

--- a/src/Dfc.CourseDirectory.WebV2/TagHelpers/AppendProviderContextTagHelperComponent.cs
+++ b/src/Dfc.CourseDirectory.WebV2/TagHelpers/AppendProviderContextTagHelperComponent.cs
@@ -36,7 +36,7 @@ namespace Dfc.CourseDirectory.WebV2.TagHelpers
                 throw new InvalidOperationException("No active provider context.");
             }
 
-            var providerId = providerContext.ProviderId;
+            var providerId = providerContext.ProviderInfo.ProviderId;
 
             // If the user is a provider user, no need to do anything since context is resolved from claims
             var currentUser = _currentUserProvider.GetCurrentUser();

--- a/src/Dfc.CourseDirectory.WebV2/TagHelpers/AppendProviderContextTagHelperComponent.cs
+++ b/src/Dfc.CourseDirectory.WebV2/TagHelpers/AppendProviderContextTagHelperComponent.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Dfc.CourseDirectory.WebV2.Filters;
 using Dfc.CourseDirectory.WebV2.Security;
 using Microsoft.AspNetCore.Mvc.Rendering;
@@ -22,14 +23,14 @@ namespace Dfc.CourseDirectory.WebV2.TagHelpers
             _providerContextProvider = providerContextProvider;
         }
 
-        public override void Process(TagHelperContext context, TagHelperOutput output)
+        public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
         {
             if (!output.Attributes.ContainsName(AttributeName))
             {
                 return;
             }
 
-            var providerContext = _providerContextProvider.GetProviderContext();
+            var providerContext = await _providerContextProvider.GetProviderContext();
             if (providerContext == null)
             {
                 throw new InvalidOperationException("No active provider context.");

--- a/src/Dfc.CourseDirectory.WebV2/UrlExtensions.cs
+++ b/src/Dfc.CourseDirectory.WebV2/UrlExtensions.cs
@@ -13,7 +13,7 @@ namespace Dfc.CourseDirectory.WebV2
         public static Url WithMptxInstanceId(this Url url, string instanceId) =>
             url.SetQueryParam(Constants.InstanceIdQueryParameter, instanceId);
 
-        public static Url WithProviderContext(this Url url, ProviderInfo providerInfo) =>
-            url.SetQueryParam(ProviderContextResourceFilter.RouteValueKey, providerInfo.ProviderId);
+        public static Url WithProviderContext(this Url url, ProviderContext providerContext) =>
+            url.SetQueryParam(ProviderContextResourceFilter.RouteValueKey, providerContext.ProviderInfo.ProviderId);
     }
 }

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FilterTests/ProviderContextResourceFilterTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FilterTests/ProviderContextResourceFilterTests.cs
@@ -69,9 +69,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FilterTests
             var response = await HttpClient.GetAsync($"currentprovideractionfiltertests/from-route/{providerId}?providerId={Guid.NewGuid()}");
 
             // Assert
-            response.EnsureSuccessStatusCode();
-            var responseJson = JToken.Parse(await response.Content.ReadAsStringAsync());
-            Assert.Equal(JTokenType.Null, responseJson.Type);
+            Assert.False(response.IsSuccessStatusCode);
         }
 
         [Theory]
@@ -86,9 +84,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FilterTests
             var response = await HttpClient.GetAsync($"currentprovideractionfiltertests?providerId=");
 
             // Assert
-            response.EnsureSuccessStatusCode();
-            var responseJson = JToken.Parse(await response.Content.ReadAsStringAsync());
-            Assert.Equal(JTokenType.Null, responseJson.Type);
+            Assert.False(response.IsSuccessStatusCode);
         }
 
         [Theory]
@@ -152,20 +148,16 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FilterTests
             var response = await HttpClient.GetAsync($"currentprovideractionfiltertests?providerId={Guid.NewGuid()}");
 
             // Assert
-            response.EnsureSuccessStatusCode();
-            var responseJson = JToken.Parse(await response.Content.ReadAsStringAsync());
-            Assert.Equal(JTokenType.Null, responseJson.Type);
+            Assert.False(response.IsSuccessStatusCode);
         }
     }
 
     public class ProviderContextModelBinderTestController : Controller
     {
         [HttpGet("currentprovideractionfiltertests")]
-        [AllowNoProviderContext]  // Prevent filter from modifying response
         public IActionResult Get(ProviderContext providerContext) => Json(providerContext);
 
         [HttpGet("currentprovideractionfiltertests/from-route/{providerId}")]
-        [AllowNoProviderContext]  // Prevent filter from modifying response
         public IActionResult GetFromRoute(ProviderContext providerContext) => Json(providerContext);
     }
 }

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FilterTests/ProviderContextResourceFilterTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FilterTests/ProviderContextResourceFilterTests.cs
@@ -31,7 +31,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FilterTests
             // Assert
             response.EnsureSuccessStatusCode();
             var responseJson = JToken.Parse(await response.Content.ReadAsStringAsync());
-            Assert.True(Guid.TryParse(responseJson["providerId"].ToString(), out var boundProviderId), "Binding failed.");
+            Assert.True(Guid.TryParse(responseJson["providerInfo"]["providerId"].ToString(), out var boundProviderId), "Binding failed.");
             Assert.Equal(providerId, boundProviderId);
         }
 
@@ -51,7 +51,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FilterTests
             // Assert
             response.EnsureSuccessStatusCode();
             var responseJson = JToken.Parse(await response.Content.ReadAsStringAsync());
-            Assert.True(Guid.TryParse(responseJson["providerId"].ToString(), out var boundProviderId), "Binding failed.");
+            Assert.True(Guid.TryParse(responseJson["providerInfo"]["providerId"].ToString(), out var boundProviderId), "Binding failed.");
             Assert.Equal(providerId, boundProviderId);
         }
 
@@ -106,7 +106,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FilterTests
             // Assert
             response.EnsureSuccessStatusCode();
             var responseJson = JToken.Parse(await response.Content.ReadAsStringAsync());
-            Assert.True(Guid.TryParse(responseJson["providerId"].ToString(), out var boundProviderId), "Binding failed.");
+            Assert.True(Guid.TryParse(responseJson["providerInfo"]["providerId"].ToString(), out var boundProviderId), "Binding failed.");
             Assert.Equal(providerId, boundProviderId);
         }
 
@@ -162,10 +162,10 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FilterTests
     {
         [HttpGet("currentprovideractionfiltertests")]
         [AllowNoProviderContext]  // Prevent filter from modifying response
-        public IActionResult Get(ProviderInfo providerInfo) => Json(providerInfo);
+        public IActionResult Get(ProviderContext providerContext) => Json(providerContext);
 
         [HttpGet("currentprovideractionfiltertests/from-route/{providerId}")]
         [AllowNoProviderContext]  // Prevent filter from modifying response
-        public IActionResult GetFromRoute(ProviderInfo providerInfo) => Json(providerInfo);
+        public IActionResult GetFromRoute(ProviderContext providerContext) => Json(providerContext);
     }
 }

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FilterTests/RedirectToProviderSelectionActionFilterTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FilterTests/RedirectToProviderSelectionActionFilterTests.cs
@@ -2,7 +2,6 @@
 using System.Net.Http;
 using System.Threading.Tasks;
 using Dfc.CourseDirectory.Testing;
-using Dfc.CourseDirectory.WebV2.Features;
 using Microsoft.AspNetCore.Mvc;
 using Xunit;
 
@@ -43,39 +42,6 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FilterTests
             Assert.Equal(HttpStatusCode.Found, response.StatusCode);
             Assert.Equal("/SearchProvider", UrlHelper.StripQueryParams(response.Headers.Location.OriginalString));
         }
-
-        [Fact]
-        public async Task ControllerImplementingIRequiresProviderContextControllerWithNoContext_ReturnsRedirectToSelectProviderView()
-        {
-            // Arrange
-            await User.AsDeveloper();
-
-            // Act
-            var response = await HttpClient.GetAsync(
-                "RedirectToProviderSelectionActionFilterTest2");
-
-            // Assert
-            Assert.Equal(HttpStatusCode.Found, response.StatusCode);
-            Assert.Equal("/SearchProvider", UrlHelper.StripQueryParams(response.Headers.Location.OriginalString));
-        }
-
-        [Fact]
-        public async Task ControllerImplementingIRequiresProviderContextController_HasProviderContextInjected()
-        {
-            // Arrange
-            var providerId = await TestData.CreateProvider();
-
-            await User.AsDeveloper();
-
-            // Act
-            var response = await HttpClient.GetAsync(
-                $"RedirectToProviderSelectionActionFilterTest2?providerId={providerId}");
-
-            // Assert
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            var textResponse = await response.Content.ReadAsStringAsync();
-            Assert.Equal(providerId.ToString(), textResponse);
-        }
     }
 
     public class RedirectToProviderSelectionActionFilterTestController : Controller
@@ -86,13 +52,5 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FilterTests
         [HttpGet("RedirectToProviderSelectionActionFilterTest/without-parameter")]
         [RequiresProviderContext]
         public IActionResult GetWithoutParameter() => Ok("Yay");
-    }
-
-    public class RedirectToProviderSelectionActionFilterTestController2 : Controller, IRequiresProviderContextController
-    {
-        public ProviderContext ProviderContext { get; set; }
-
-        [HttpGet("RedirectToProviderSelectionActionFilterTest2")]
-        public IActionResult Get() => Content(ProviderContext.ProviderInfo.ProviderId.ToString());
     }
 }

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FilterTests/RedirectToProviderSelectionActionFilterTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FilterTests/RedirectToProviderSelectionActionFilterTests.cs
@@ -44,7 +44,6 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FilterTests
             Assert.Equal("/SearchProvider", UrlHelper.StripQueryParams(response.Headers.Location.OriginalString));
         }
 
-
         [Fact]
         public async Task ControllerImplementingIRequiresProviderContextControllerWithNoContext_ReturnsRedirectToSelectProviderView()
         {

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FilterTests/RedirectToProviderSelectionActionFilterTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FilterTests/RedirectToProviderSelectionActionFilterTests.cs
@@ -81,7 +81,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FilterTests
     public class RedirectToProviderSelectionActionFilterTestController : Controller
     {
         [HttpGet("RedirectToProviderSelectionActionFilterTest")]
-        public IActionResult Get(ProviderInfo providerInfo) => Ok("Yay");
+        public IActionResult Get(ProviderContext providerContext) => Ok("Yay");
 
         [HttpGet("RedirectToProviderSelectionActionFilterTest/without-parameter")]
         [RequiresProviderContext]
@@ -90,9 +90,9 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FilterTests
 
     public class RedirectToProviderSelectionActionFilterTestController2 : Controller, IRequiresProviderContextController
     {
-        public ProviderInfo ProviderContext { get; set; }
+        public ProviderContext ProviderContext { get; set; }
 
         [HttpGet("RedirectToProviderSelectionActionFilterTest2")]
-        public IActionResult Get() => Content(ProviderContext.ProviderId.ToString());
+        public IActionResult Get() => Content(ProviderContext.ProviderInfo.ProviderId.ToString());
     }
 }

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FilterTests/VerifyApprenticeshipIdAttributeTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FilterTests/VerifyApprenticeshipIdAttributeTests.cs
@@ -3,7 +3,6 @@ using System.Net;
 using System.Threading.Tasks;
 using Dfc.CourseDirectory.WebV2.Filters;
 using Microsoft.AspNetCore.Mvc;
-using Moq;
 using Newtonsoft.Json.Linq;
 using Xunit;
 
@@ -60,7 +59,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FilterTests
             // Assert
             response.EnsureSuccessStatusCode();
             var responseJson = JToken.Parse(await response.Content.ReadAsStringAsync());
-            Assert.True(int.TryParse(responseJson["ukprn"].ToString(), out var boundUkprn), "Binding failed.");
+            Assert.True(int.TryParse(responseJson["providerInfo"]["ukprn"].ToString(), out var boundUkprn), "Binding failed.");
             Assert.Equal(ukprn, boundUkprn);
         }
 
@@ -107,7 +106,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FilterTests
         public IActionResult Get([ApprenticeshipId] Guid apprenticeshipId) => Ok();
 
         [HttpGet("filtertests/verifyapprenticeshipidattributetests/withproviderinfo/{apprenticeshipId}")]
-        public IActionResult GetWithProviderInfo([ApprenticeshipId] Guid apprenticeshipId, ProviderInfo providerInfo) => Json(providerInfo);
+        public IActionResult GetWithProviderInfo([ApprenticeshipId] Guid apprenticeshipId, ProviderContext providerContext) => Json(providerContext);
 
         [HttpGet("filtertests/verifyapprenticeshipidattributetests/overridenstatus/{apprenticeshipId}")]
         public IActionResult GetWithOverridenStatus([ApprenticeshipId(DoesNotExistResponseStatusCode = 400)] Guid apprenticeshipId) => Ok();

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/RedirectToActionResultExtensionsTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/RedirectToActionResultExtensionsTests.cs
@@ -33,9 +33,10 @@ namespace Dfc.CourseDirectory.WebV2.Tests
     public class RedirectToActionResultExtensionsTestController : Controller
     {
         [HttpGet("redirecttoactionresultextensionstestcontroller/first")]
-        public IActionResult First(ProviderInfo providerInfo) => RedirectToAction("Second").WithProviderContext(providerInfo);
+        public IActionResult First(ProviderContext providerContext) =>
+            RedirectToAction("Second").WithProviderContext(providerContext);
 
         [HttpGet("redirecttoactionresultextensionstestcontroller/second")]
-        public IActionResult Second(ProviderInfo providerInfo) => Json(providerInfo);
+        public IActionResult Second(ProviderContext providerContext) => Json(providerContext.ProviderInfo);
     }
 }


### PR DESCRIPTION
Provider Context is conceptually the 'current provider'. The legacy views use the `UKPRN` in Session for storing this; v2 bits can use a `providerId` query parameter, a `providerId` route value or the provider ID can be extracted from whatever entity is being acted upon (e.g. a Course).

This PR removes some of the inconsistencies and ties up some lose ends around the current usage. A separate PR will follow that removes the `VerifyApprenticeshipId` attributes & filters and replaces it with something in line with what we do for courses (i.e. a MediatR behavior).

- Use IProviderContextProvider everywhere for getting/setting provider context.
- Move the session-based fallback into IProviderContextProvider
- Remove IRequiresProviderContextController (it was a convenience that brings more confusion than good)
- Set the provider context when authorizing access to a course. (Guarantees that the provider context set matches the provider for the course).