### PR TITLE
Exclude unrelated LearningDeliveryCategory records

### DIFF
--- a/tests/Dfc.CourseDirectory.Core.Tests/ReferenceDataTests/LarsDataImporterTests.cs
+++ b/tests/Dfc.CourseDirectory.Core.Tests/ReferenceDataTests/LarsDataImporterTests.cs
@@ -48,7 +48,7 @@ namespace Dfc.CourseDirectory.Core.Tests.ReferenceDataTests
                 (await CountSqlRows("LARS.Category")).Should().Be(44);
                 (await CountSqlRows("LARS.LearnAimRefType")).Should().Be(122);
                 (await CountSqlRows("LARS.LearningDelivery")).Should().Be(117730);
-                (await CountSqlRows("LARS.LearningDeliveryCategory")).Should().Be(82221);
+                (await CountSqlRows("LARS.LearningDeliveryCategory")).Should().Be(82200);
                 (await CountSqlRows("LARS.SectorSubjectAreaTier1")).Should().Be(17);
                 (await CountSqlRows("LARS.SectorSubjectAreaTier2")).Should().Be(67);
             }


### PR DESCRIPTION
This PR is for discussion of an additional change to #1636 that's already in QA.

---

Wondering whether to "just do this" to fix up the join table. Penny for your thoughts.

`LearningDeliveryCategory` appears to be a join table between `Category` and `LearningDelivery`.

* Filter out records that don't have matches in either of the related tables.
* Add log of number excluded

Narahari pointed out that this table is including records that have no match in related tables due to filtering.

