### PR TITLE
Fix nav to show 'Your apprenticeships training' for app-only providers

### DIFF
--- a/src/Dfc.CourseDirectory.WebV2/SharedViews/Components/AdminProviderContextNav.cshtml
+++ b/src/Dfc.CourseDirectory.WebV2/SharedViews/Components/AdminProviderContextNav.cshtml
@@ -20,7 +20,7 @@
                 Your locations
             </a>
         </li>
-        @if (Model.ProviderContext.ProviderType == ProviderType.Both && enableApprenticeshipBulkUpload)
+        @if (Model.ProviderContext.ProviderType.HasFlag(ProviderType.Apprenticeships))
         {
             <li class="pttcd-subnav__item@(currentController == "Apprenticeships" ? " govuk-header__navigation-item--active" : null)">
                 <a asp-action="WhatWouldYouLikeToDo" asp-controller="Apprenticeships" class="pttcd-subnav__item__link">

--- a/src/Dfc.CourseDirectory.WebV2/SharedViews/Components/ProviderTopNav.cshtml
+++ b/src/Dfc.CourseDirectory.WebV2/SharedViews/Components/ProviderTopNav.cshtml
@@ -21,7 +21,7 @@
                 Your locations
             </a>
         </li>
-        @if (Model.ProviderContext.ProviderType == ProviderType.Both && enableApprenticeshipBulkUpload)
+        @if (Model.ProviderContext.ProviderType.HasFlag(ProviderType.Apprenticeships))
         {
             <li class="govuk-header__navigation-item@(currentController == "Apprenticeships" ? " govuk-header__navigation-item--active" : null)">
                 <a asp-action="WhatWouldYouLikeToDo" asp-controller="Apprenticeships" class="govuk-header__link">
@@ -39,7 +39,6 @@
         }
         @if (Model.ProviderContext.ProviderType == ProviderType.Both && enableApprenticeshipBulkUpload)
         {
-
             <li class="govuk-header__navigation-item@(currentController == "BulkUpload" || currentController == "BulkUploadApprenticeships" ? " govuk-header__navigation-item--active" : null)">
                 <a asp-action="LandingOptions" asp-controller="BulkUpload" class="govuk-header__link">
                     Bulk upload

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/LayoutTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/LayoutTests.cs
@@ -147,11 +147,12 @@ namespace Dfc.CourseDirectory.WebV2.Tests
             Assert.Equal("Migration reports", topLevelLinks[4].label);
             Assert.Equal("Sign out", topLevelLinks[5].label);
 
-            Assert.Equal(3, subNavLinks.Count);
+            Assert.Equal(4, subNavLinks.Count);
             Assert.Equal("Home", subNavLinks[0].label);
             Assert.Equal("Your locations", subNavLinks[1].label);
-            Assert.Equal("Bulk upload", subNavLinks[2].label);
-            Assert.Equal("/BulkUploadApprenticeships", subNavLinks[2].href);
+            Assert.Equal("Your apprenticeships training", subNavLinks[2].label);
+            Assert.Equal("Bulk upload", subNavLinks[3].label);
+            Assert.Equal("/BulkUploadApprenticeships", subNavLinks[3].href);
         }
 
         [Theory]
@@ -248,12 +249,13 @@ namespace Dfc.CourseDirectory.WebV2.Tests
             var topLevelLinks = GetTopLevelNavLinks(doc);
             var subNavLinks = GetSubNavLinks(doc);
 
-            Assert.Equal(4, topLevelLinks.Count);
+            Assert.Equal(5, topLevelLinks.Count);
             Assert.Equal("Home", topLevelLinks[0].label);
             Assert.Equal("Your locations", topLevelLinks[1].label);
-            Assert.Equal("Bulk upload", topLevelLinks[2].label);
-            Assert.Equal("/BulkUploadApprenticeships", topLevelLinks[2].href);
-            Assert.Equal("Sign out", topLevelLinks[3].label);
+            Assert.Equal("Your apprenticeships training", topLevelLinks[2].label);
+            Assert.Equal("Bulk upload", topLevelLinks[3].label);
+            Assert.Equal("/BulkUploadApprenticeships", topLevelLinks[3].href);
+            Assert.Equal("Sign out", topLevelLinks[4].label);
 
             Assert.Equal(0, subNavLinks.Count);
         }


### PR DESCRIPTION
Previously link was only shown for Both providers if bulk upload is enabled (copy/paste error).