### PR TITLE
Always configure user-secrets for the function apps

### DIFF
--- a/src/Dfc.CourseDirectory.Functions/Properties/launchSettings.json
+++ b/src/Dfc.CourseDirectory.Functions/Properties/launchSettings.json
@@ -1,10 +1,7 @@
 {
   "profiles": {
     "Dfc.CourseDirectory.Functions": {
-      "commandName": "Project",
-      "environmentVariables": {
-        "ENVIRONMENT": "Development"
-      }
+      "commandName": "Project"
     }
   }
 }

--- a/src/Dfc.CourseDirectory.Functions/Startup.cs
+++ b/src/Dfc.CourseDirectory.Functions/Startup.cs
@@ -19,8 +19,6 @@ namespace Dfc.CourseDirectory.Functions
     {
         public override void Configure(IFunctionsHostBuilder builder)
         {
-            var environment = Environment.GetEnvironmentVariable("ENVIRONMENT") ?? "Production";
-
             var configuration = GetConfiguration();
             builder.Services.AddSingleton(configuration);
 

--- a/src/Dfc.CourseDirectory.Functions/Startup.cs
+++ b/src/Dfc.CourseDirectory.Functions/Startup.cs
@@ -25,7 +25,7 @@ namespace Dfc.CourseDirectory.Functions
             builder.Services.AddSingleton(configuration);
 
             builder.Services.AddSqlDataStore(configuration.GetConnectionString("DefaultConnection"));
-			
+
             builder.Services.AddCosmosDbDataStore(
                 endpoint: new Uri(configuration["CosmosDbSettings:EndpointUri"]),
                 key: configuration["CosmosDbSettings:PrimaryKey"]);
@@ -48,12 +48,8 @@ namespace Dfc.CourseDirectory.Functions
                 var baseConfig = sp.GetRequiredService<IConfiguration>();
 
                 var configBuilder = new ConfigurationBuilder()
-                    .AddConfiguration(baseConfig);
-
-                if (environment.Equals(Environments.Development, StringComparison.OrdinalIgnoreCase))
-                {
-                    configBuilder.AddUserSecrets(typeof(Startup).Assembly);
-                }
+                    .AddConfiguration(baseConfig)
+                    .AddUserSecrets(typeof(Startup).Assembly);
 
                 return configBuilder.Build();
             }


### PR DESCRIPTION
# Context

1. [The existing code ensures user-secrets are only loaded in "development mode" with an `if` block](https://github.com/SkillsFundingAgency/dfc-coursedirectory/blob/8087a00da81db05debb3b507d7ad6b429aad200b/src/Dfc.CourseDirectory.Functions/Startup.cs#L53).
1. Because we are not in aspnet, there is no built-in hosting context development mode, so the existing code simulates the behaviour through an environment variable.
1. [Environment variable `ENVIRONMENT=Development` is configured in launchSettings](https://github.com/SkillsFundingAgency/dfc-coursedirectory/blob/ede11036db0f96f2e1357033dcd0c580bc6ea828/src/Dfc.CourseDirectory.Functions/Properties/launchSettings.json#L5-L7)
1. Visual Studio uses `launchSettings.json`
1. The [Azure Functions CLI](https://docs.microsoft.com/en-us/azure/azure-functions/functions-run-local?tabs=linux%2Ccsharp%2Cbash#start) does not read `launchsettings.json` when run with `func host start` as per the documentation.
1.  As a result user-secrets are silently not loaded by default with the CLI.
1. When you set a required configuration value with `user-secrets set` the app mysteriously continues to fail.

It's a significant logical jump from a missing setting to finding the `if` block that means the settings are being ignored.

The need for environment variable `ENVIRONMENT=Development`  has cost me quite a few hours of head-scratching now.

# Current failure mode

Without the settings for the functions configured you get this error:
```
[09/09/2020 13:30:08] A host error has occurred during startup operation '8ae35b21-0bc7-4455-ae90-43a271bb2070'.
[09/09/2020 13:30:08] System.Private.Uri: Value cannot be null.  (Parameter 'uriString').
```

Which does not lead one to consider that the user-secrets might be disabled or how that might be happening.

# Workaround

Without this patch you have to remember to start the function as follows:

```bash
ENVIRONMENT=development func host start --csharp
```

# This patch

* Marginally reduces the complexity of the code and behaviour.
* Makes the project marginally easier to work with.