### PR TITLE
PTCD-439 AzureCognitiveSearchClient Implementation with Provider Search

### DIFF
--- a/src/Dfc.CourseDirectory.Core/Dfc.CourseDirectory.Core.csproj
+++ b/src/Dfc.CourseDirectory.Core/Dfc.CourseDirectory.Core.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Search.Documents" Version="11.1.1" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.4.4" />
     <PackageReference Include="CsvHelper" Version="15.0.2" />
     <PackageReference Include="Dapper" Version="2.0.30" />

--- a/src/Dfc.CourseDirectory.Core/Search/AzureSearch/AzureSearchClient.cs
+++ b/src/Dfc.CourseDirectory.Core/Search/AzureSearch/AzureSearchClient.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Azure.Search.Documents;
+
+namespace Dfc.CourseDirectory.Core.Search.AzureSearch
+{
+    public class AzureSearchClient<TQuery, TResult> : ISearchClient<TQuery, TResult>
+        where TQuery : IAzureSearchQuery
+    {
+        private readonly SearchClient _client;
+
+        public AzureSearchClient(SearchClient client)
+        {
+            _client = client ?? throw new ArgumentNullException(nameof(client));
+        }
+
+        public async Task<SearchResult<TResult>> Search(TQuery query)
+        {
+            if (query == null)
+            {
+                throw new ArgumentNullException(nameof(query));
+            }
+
+            var generatedQuery = query.GenerateSearchQuery();
+
+            var searchResults = await _client.SearchAsync<TResult>(generatedQuery.SearchText, generatedQuery.Options);
+
+            return new SearchResult<TResult>
+            {
+                Results = searchResults.Value.GetResults().Select(r => r.Document).ToArray(),
+                Facets = searchResults.Value.Facets?.ToDictionary(f => f.Key, f => (IReadOnlyDictionary<object, long?>)f.Value.ToDictionary(ff => ff.Value, ff => ff.Count)),
+                TotalCount = searchResults.Value.TotalCount
+            };
+        }
+    }
+}

--- a/src/Dfc.CourseDirectory.Core/Search/AzureSearch/AzureSearchQueryBuilder.cs
+++ b/src/Dfc.CourseDirectory.Core/Search/AzureSearch/AzureSearchQueryBuilder.cs
@@ -1,0 +1,151 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Azure.Search.Documents;
+using Azure.Search.Documents.Models;
+
+namespace Dfc.CourseDirectory.Core.Search.AzureSearch
+{
+    public class AzureSearchQueryBuilder
+    {
+        private string _searchText;
+        private SearchMode? _searchMode;
+        private IList<string> _searchFields;
+        private IList<string> _facets;
+        private IList<string> _filters;
+        private IList<string> _orderBy;
+        private string _scoringProfile;
+        private int? _size;
+        private int? _skip;
+        private bool? _includeTotalCount;
+
+        public AzureSearchQueryBuilder(string searchText)
+        {
+            _searchText = searchText;
+            _searchFields = new List<string>();
+            _facets = new List<string>();
+            _filters = new List<string>();
+            _orderBy = new List<string>();
+        }
+
+        public AzureSearchQueryBuilder WithSearchMode(SearchMode? searchMode)
+        {
+            _searchMode = searchMode;
+            return this;
+        }
+
+        public AzureSearchQueryBuilder WithSearchFields(params string[] searchFields)
+        {
+            foreach (var searchField in searchFields)
+            {
+                _searchFields.Add(searchField);
+            }
+            
+            return this;
+        }
+
+        public AzureSearchQueryBuilder WithFacets(params string[] facets)
+        {
+            foreach (var facet in facets)
+            {
+                _facets.Add(facet);
+            }
+
+            return this;
+        }
+
+        public AzureSearchQueryBuilder WithSearchInFilter(string variable, IEnumerable<string> values, char delimiter = '|')
+        {
+            if (string.IsNullOrWhiteSpace(variable))
+            {
+                throw new ArgumentNullException(nameof(variable));
+            }
+
+            if (values?.Any() ?? false)
+            {
+                if (values.Any(v => v.Contains(delimiter)))
+                {
+                    throw new ArgumentException($"{nameof(values)} cannot contain {nameof(delimiter)} '{delimiter}'.", nameof(values));
+                }
+
+                _filters.Add($"search.in({variable}, '{string.Join(delimiter, values)}', '{delimiter}')");
+            }
+
+            return this;
+        }
+
+        public AzureSearchQueryBuilder WithOrderBy(params string[] orderBys)
+        {
+            foreach (var orderBy in orderBys)
+            {
+                _orderBy.Add(orderBy);
+            }
+
+            return this;
+        }
+
+        public AzureSearchQueryBuilder WithScoringProfile(string scoringProfile)
+        {
+            _scoringProfile = scoringProfile;
+            return this;
+        }
+
+        public AzureSearchQueryBuilder WithSize(int? size)
+        {
+            if (size <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(size), size, $"{nameof(size)} must be greated than zero.");
+            }
+
+            _size = size;
+            return this;
+        }
+
+        public AzureSearchQueryBuilder WithSkip(int? skip)
+        {
+            if (skip <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(skip), skip, $"{nameof(skip)} must be greated than zero.");
+            }
+
+            _skip = skip;
+            return this;
+        }
+
+        public AzureSearchQueryBuilder WithIncludeTotalCount(bool? includeTotalCount = true)
+        {
+            _includeTotalCount = includeTotalCount;
+            return this;
+        }
+
+        public (string SearchText, SearchOptions Options) Build()
+        {
+            var options = new SearchOptions
+            {
+                SearchMode = _searchMode,
+                Filter = string.Join(" AND ", _filters),
+                ScoringProfile = _scoringProfile,
+                Size = _size,
+                Skip = _skip,
+                IncludeTotalCount = _includeTotalCount
+            };
+
+            foreach (var searchField in _searchFields)
+            {
+                options.SearchFields.Add(searchField);
+            }
+
+            foreach (var facet in _facets)
+            {
+                options.Facets.Add(facet);
+            }
+
+            foreach (var orderBy in _orderBy)
+            {
+                options.OrderBy.Add(orderBy);
+            }
+
+            return (!string.IsNullOrWhiteSpace(_searchText) ? _searchText : "*", options);
+        }
+    }
+}

--- a/src/Dfc.CourseDirectory.Core/Search/AzureSearch/IAzureSearchQuery.cs
+++ b/src/Dfc.CourseDirectory.Core/Search/AzureSearch/IAzureSearchQuery.cs
@@ -1,0 +1,9 @@
+﻿using Azure.Search.Documents;
+
+namespace Dfc.CourseDirectory.Core.Search.AzureSearch
+{
+    public interface IAzureSearchQuery
+    {
+        (string SearchText, SearchOptions Options) GenerateSearchQuery();
+    }
+}

--- a/src/Dfc.CourseDirectory.Core/Search/AzureSearch/ServiceCollectionExtensions.cs
+++ b/src/Dfc.CourseDirectory.Core/Search/AzureSearch/ServiceCollectionExtensions.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using Azure;
+using Azure.Search.Documents;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Dfc.CourseDirectory.Core.Search.AzureSearch
+{
+    public static class ServiceCollectionExtensions
+    {
+        public static IServiceCollection AddAzureSearchClient<TQuery, TResult>(this IServiceCollection services, Uri endpoint, string key, string indexName)
+            where TQuery : IAzureSearchQuery
+        {
+            services.AddSingleton<ISearchClient<TQuery, TResult>>(s =>
+                new AzureSearchClient<TQuery, TResult>(
+                    new SearchClient(endpoint, indexName, new AzureKeyCredential(key))));
+
+            return services;
+        }
+    }
+}

--- a/src/Dfc.CourseDirectory.Core/Search/ISearchClient.cs
+++ b/src/Dfc.CourseDirectory.Core/Search/ISearchClient.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace Dfc.CourseDirectory.Core.Search
+{
+    public interface ISearchClient<TQuery, TResult>
+    {
+        Task<SearchResult<TResult>> Search(TQuery query);
+    }
+}

--- a/src/Dfc.CourseDirectory.Core/Search/Models/Provider.cs
+++ b/src/Dfc.CourseDirectory.Core/Search/Models/Provider.cs
@@ -1,0 +1,29 @@
+﻿using System;
+
+namespace Dfc.CourseDirectory.Core.Search.Models
+{
+    public class Provider
+    {
+        public Guid Id { get; set; }
+
+        public string Name { get; set; }
+
+        public string Postcode { get; set; }
+
+        public string Town { get; set; }
+
+        public string Region { get; set; }
+
+        public string UKPRN { get; set; }
+
+        public int Status { get; set; }
+
+        public string ProviderStatus { get; set; }
+
+        public string CourseDirectoryName { get; set; }
+
+        public string TradingName { get; set; }
+
+        public string ProviderAlias { get; set; }
+    }
+}

--- a/src/Dfc.CourseDirectory.Core/Search/ProviderSearchQuery.cs
+++ b/src/Dfc.CourseDirectory.Core/Search/ProviderSearchQuery.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Azure.Search.Documents;
+using Azure.Search.Documents.Models;
+using Dfc.CourseDirectory.Core.Search.AzureSearch;
+using Dfc.CourseDirectory.Core.Search.Models;
+
+namespace Dfc.CourseDirectory.Core.Search
+{
+    public class ProviderSearchQuery : IAzureSearchQuery
+    {
+        private const int DefaultSize = 20;
+
+        public string SearchText { get; set; }
+
+        public IEnumerable<string> Towns { get; set; }
+
+        public int? Size { get; set; }
+
+        public (string SearchText, SearchOptions Options) GenerateSearchQuery()
+        {
+            return new AzureSearchQueryBuilder($"{SearchText?.Trim()}*")
+                .WithSearchMode(SearchMode.All)
+                .WithSearchInFilter(nameof(Provider.Town), Towns?.Distinct())
+                .WithSize(Size ?? DefaultSize)
+                .Build();
+        }
+    }
+}

--- a/src/Dfc.CourseDirectory.Core/Search/SearchResult.cs
+++ b/src/Dfc.CourseDirectory.Core/Search/SearchResult.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+
+namespace Dfc.CourseDirectory.Core.Search
+{
+    public class SearchResult<TResult>
+    {
+        public IReadOnlyCollection<TResult> Results { get; set; }
+
+        public IReadOnlyDictionary<string, IReadOnlyDictionary<object, long?>> Facets { get; set; }
+
+        public long? TotalCount { get; set; }
+    }
+}

--- a/tests/Dfc.CourseDirectory.Core.Tests/Search/AzureSearch/AzureSearchClientTests.cs
+++ b/tests/Dfc.CourseDirectory.Core.Tests/Search/AzureSearch/AzureSearchClientTests.cs
@@ -1,0 +1,111 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure;
+using Azure.Search.Documents;
+using Azure.Search.Documents.Models;
+using Dfc.CourseDirectory.Core.Search.AzureSearch;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Dfc.CourseDirectory.Core.Tests.Search.AzureSearch
+{
+    public class AzureSearchClientTests
+    {
+        private readonly Mock<SearchClient> _searchClient;
+        private readonly AzureSearchClient<IAzureSearchQuery, object> _client;
+
+        public AzureSearchClientTests()
+        {
+            _searchClient = new Mock<SearchClient>();
+            _client = new AzureSearchClient<IAzureSearchQuery, object>(_searchClient.Object);
+        }
+
+        [Fact]
+        public async Task Search_GeneratesQuery_ReturnsExpectedResults()
+        {
+            var capturedSearchText = default(string);
+            var capturedSearchOptions = default(SearchOptions);
+
+            var searchResults = SearchModelFactory.SearchResults(
+                new[]
+                {
+                    SearchModelFactory.SearchResult<object>("TestResult1", 1.23, null),
+                    SearchModelFactory.SearchResult<object>("TestResult2", 2.34, null),
+                    SearchModelFactory.SearchResult<object>("TestResult3", 3.45, null)
+                },
+                3,
+                new Dictionary<string, IList<FacetResult>>
+                {
+                    {
+                        "TestFacet1",
+                        new List<FacetResult>
+                        {
+                            SearchModelFactory.FacetResult(12, new Dictionary<string, object> { { "value", "TestFacetValue1" } }),
+                            SearchModelFactory.FacetResult(34, new Dictionary<string, object> { { "value", "TestFacetValue2" } }),
+                            SearchModelFactory.FacetResult(56, new Dictionary<string, object> { { "value", "TestFacetValue3" } })
+                        }
+                    },
+                    {
+                        "TestFacet2",
+                        new List<FacetResult>
+                        {
+                            SearchModelFactory.FacetResult(78, new Dictionary<string, object> { { "value", "TestFacetValue4" } }),
+                            SearchModelFactory.FacetResult(90, new Dictionary<string, object> { { "value", "TestFacetValue5" } })
+                        }
+                    }
+                },
+                null,
+                null);
+
+            var response = new Mock<Response<SearchResults<object>>>();
+            response.Setup(s => s.Value)
+                .Returns(searchResults);
+
+            _searchClient.Setup(s => s.SearchAsync<object>(It.IsAny<string>(), It.IsAny<SearchOptions>(), It.IsAny<CancellationToken>()))
+                .Callback<string, SearchOptions, CancellationToken>((s, o, ct) =>
+                {
+                    capturedSearchText = s;
+                    capturedSearchOptions = o;
+                })
+                .ReturnsAsync(response.Object);
+
+            var searchText = "TestSearchText";
+            var searchOptions = new SearchOptions();
+
+            var query = new Mock<IAzureSearchQuery>();
+            query.Setup(s => s.GenerateSearchQuery())
+                .Returns((searchText, searchOptions));
+
+            var result = await _client.Search(query.Object);
+
+            capturedSearchText.Should().Be(searchText);
+            capturedSearchOptions.Should().Be(searchOptions);
+
+            result.Should().NotBeNull();
+            result.Results.Should().BeEquivalentTo(new[] { "TestResult1", "TestResult2", "TestResult3" });
+            result.Facets.Should().BeEquivalentTo(new Dictionary<string, Dictionary<string, long?>>
+            {
+                {
+                    "TestFacet1",
+                    new Dictionary<string, long?>
+                    {
+                        {  "TestFacetValue1", 12 },
+                        {  "TestFacetValue2", 34 },
+                        {  "TestFacetValue3", 56 }
+                    }
+                },
+                {
+                    "TestFacet2",
+                    new Dictionary<string, long?>
+                    {
+                        {  "TestFacetValue4", 78 },
+                        {  "TestFacetValue5", 90 }
+                    }
+                }
+            });
+            result.TotalCount.Should().Be(3);
+        }
+    }
+}

--- a/tests/Dfc.CourseDirectory.Core.Tests/Search/AzureSearch/AzureSearchQueryBuilderTests.cs
+++ b/tests/Dfc.CourseDirectory.Core.Tests/Search/AzureSearch/AzureSearchQueryBuilderTests.cs
@@ -1,0 +1,292 @@
+﻿using System;
+using System.Linq;
+using Azure.Search.Documents.Models;
+using Dfc.CourseDirectory.Core.Search.AzureSearch;
+using FluentAssertions;
+using Xunit;
+
+namespace Dfc.CourseDirectory.Core.Tests.Search.AzureSearch
+{
+    public class AzureSearchQueryBuilderTests
+    {
+        [Fact]
+        public void Build_ReturnsExpectedQuery()
+        {
+            var searchFields = new[]
+            {
+                "TestSearchField1",
+                "TestSearchField2",
+                "TestSearchField3"
+            };
+
+            var facets = new[]
+            {
+                "TestFacet1",
+                "TestFacet2",
+                "TestFacet3"
+            };
+
+            var orderBy = new[]
+            {
+                "TestOrderBy1",
+                "TestOrderBy2",
+                "TestOrderBy3"
+            };
+
+            var builder = new AzureSearchQueryBuilder("TestSearchText")
+                .WithSearchMode(SearchMode.All)
+                .WithSearchFields(searchFields)
+                .WithFacets(facets)
+                .WithSearchInFilter("TestVariable1", new[] { "TestValue1" })
+                .WithSearchInFilter("TestVariable2", new[] { "TestValue2", "TestValue3" })
+                .WithSearchInFilter("TestVariable3", new[] { "TestValue4", "TestValue5", "TestValue6" }, ',')
+                .WithOrderBy(orderBy)
+                .WithScoringProfile("TestScoringProfile")
+                .WithSize(12)
+                .WithSkip(34)
+                .WithIncludeTotalCount();
+
+            var result = builder.Build();
+
+            result.SearchText.Should().Be("TestSearchText");
+            result.Options.SearchMode.Should().Be(SearchMode.All);
+            result.Options.SearchFields.Should().Equal(searchFields);
+            result.Options.Facets.Should().Equal(facets);
+            result.Options.Filter.Should().Be("search.in(TestVariable1, 'TestValue1', '|') AND search.in(TestVariable2, 'TestValue2|TestValue3', '|') AND search.in(TestVariable3, 'TestValue4,TestValue5,TestValue6', ',')");
+            result.Options.OrderBy.Should().Equal(orderBy);
+            result.Options.ScoringProfile.Should().Be("TestScoringProfile");
+            result.Options.Size.Should().Be(12);
+            result.Options.Skip.Should().Be(34);
+            result.Options.IncludeTotalCount.Should().BeTrue();
+        }
+
+        [Theory]
+        [InlineData(null, "*")]
+        [InlineData("", "*")]
+        [InlineData(" ", "*")]
+        [InlineData("*", "*")]
+        [InlineData("TestSearchText", "TestSearchText")]
+        public void Build_WithSearchText_ReturnsQueryWithExpectedSearchText(string searchText, string expectedResult)
+        {
+            var builder = new AzureSearchQueryBuilder(searchText);
+
+            var result = builder.Build();
+
+            result.SearchText.Should().Be(expectedResult);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData(SearchMode.All)]
+        [InlineData(SearchMode.Any)]
+        public void Build_WithSearchMode_ReturnsQueryWithExpectedSearchMode(SearchMode? searchMode)
+        {
+            var builder = new AzureSearchQueryBuilder("TestSearchText")
+                .WithSearchMode(searchMode);
+
+            var result = builder.Build();
+
+            result.Options.SearchMode.Should().Be(searchMode);
+        }
+
+        [Fact]
+        public void Build_WithSearchFields_ReturnsQueryWithExpectedSearchFields()
+        {
+            var searchFields = new[]
+            {
+                "TestSearchField1",
+                "TestSearchField2",
+                "TestSearchField3"
+            };
+
+            var builder = new AzureSearchQueryBuilder("TestSearchText")
+                .WithSearchFields(searchFields);
+
+            var result = builder.Build();
+
+            result.Options.SearchFields.Should().Equal(searchFields);
+        }
+
+        [Fact]
+        public void Build_WithFacets_ReturnsQueryWithExpectedFacets()
+        {
+            var facets = new[]
+            {
+                "TestFacet1",
+                "TestFacet2",
+                "TestFacet3"
+            };
+
+            var builder = new AzureSearchQueryBuilder("TestSearchText")
+                .WithFacets(facets);
+
+            var result = builder.Build();
+
+            result.Options.Facets.Should().Equal(facets);
+        }
+
+        [Fact]
+        public void Build_WithSingleSearchInFilterAndSingleValue_ReturnsQueryWithExpectedFilter()
+        {
+            var builder = new AzureSearchQueryBuilder("TestSearchText")
+                .WithSearchInFilter("TestVariable1", new[] { "TestValue1" });
+
+            var result = builder.Build();
+
+            result.Options.Filter.Should().Be("search.in(TestVariable1, 'TestValue1', '|')");
+        }
+
+        [Fact]
+        public void Build_WithSingleSearchInFilterAndMultipleValues_ReturnsQueryWithExpectedFilter()
+        {
+            var builder = new AzureSearchQueryBuilder("TestSearchText")
+                .WithSearchInFilter("TestVariable1", new[] { "TestValue1", "TestValue2", "TestValue3" });
+
+            var result = builder.Build();
+
+            result.Options.Filter.Should().Be("search.in(TestVariable1, 'TestValue1|TestValue2|TestValue3', '|')");
+        }
+
+        [Fact]
+        public void Build_WithMultipleSearchInFilters_ReturnsQueryWithExpectedFilter()
+        {
+            var builder = new AzureSearchQueryBuilder("TestSearchText")
+                .WithSearchInFilter("TestVariable1", new[] { "TestValue1" })
+                .WithSearchInFilter("TestVariable2", new[] { "TestValue2", "TestValue3" });
+
+            var result = builder.Build();
+
+            result.Options.Filter.Should().Be("search.in(TestVariable1, 'TestValue1', '|') AND search.in(TestVariable2, 'TestValue2|TestValue3', '|')");
+        }
+
+        [Fact]
+        public void Build_WithDelimiter_ReturnsQueryWithExpectedFilter()
+        {
+            var builder = new AzureSearchQueryBuilder("TestSearchText")
+                .WithSearchInFilter("TestVariable1", new[] { "TestValue1", "TestValue2", "TestValue3" }, ',');
+
+            var result = builder.Build();
+
+            result.Options.Filter.Should().Be("search.in(TestVariable1, 'TestValue1,TestValue2,TestValue3', ',')");
+        }
+
+        [Fact]
+        public void Build_WithOrderBy_ReturnsQueryWithExpectedOrderBy()
+        {
+            var orderBy = new[]
+            {
+                "TestOrderBy1",
+                "TestOrderBy2",
+                "TestOrderBy3"
+            };
+
+            var builder = new AzureSearchQueryBuilder("TestSearchText")
+                .WithOrderBy(orderBy);
+
+            var result = builder.Build();
+
+            result.Options.OrderBy.Should().Equal(orderBy);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("TestScoringProfile")]
+        public void Build_WithScoringProfile_ReturnsQueryWithExpectedScoringProfile(string scoringProfile)
+        {
+            var builder = new AzureSearchQueryBuilder("TestSearchText")
+                .WithScoringProfile(scoringProfile);
+
+            var result = builder.Build();
+
+            result.Options.ScoringProfile.Should().Be(scoringProfile);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData(123)]
+        public void Build_WithSize_ReturnsQueryWithExpectedSize(int? size)
+        {
+            var builder = new AzureSearchQueryBuilder("TestSearchText")
+                .WithSize(size);
+
+            var result = builder.Build();
+
+            result.Options.Size.Should().Be(size);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData(123)]
+        public void Build_WithSkip_ReturnsQueryWithExpectedSkip(int? skip)
+        {
+            var builder = new AzureSearchQueryBuilder("TestSearchText")
+                .WithSkip(skip);
+
+            var result = builder.Build();
+
+            result.Options.Skip.Should().Be(skip);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Build_WithInvludeTotalCount_ReturnsQueryWithExpectedTotalCount(bool? includeTotalCount)
+        {
+            var builder = new AzureSearchQueryBuilder("TestSearchText")
+                .WithIncludeTotalCount(includeTotalCount);
+
+            var result = builder.Build();
+
+            result.Options.IncludeTotalCount.Should().Be(includeTotalCount);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        public void WithSearchInFilter_WithNullOrWhiteSpaceVariable_ThrowsException(string variable)
+        {
+            var builder = new AzureSearchQueryBuilder("TestSearchText");
+
+            Func<AzureSearchQueryBuilder> action = () => builder.WithSearchInFilter(variable, new[] { "TestValue1", "TestValue2", "TestValue3" });
+
+            action.Should().ThrowExactly<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void WithSearchInFilter_WithValuesContainsDelimiter_ThrowsException()
+        {
+            var builder = new AzureSearchQueryBuilder("TestSearchText");
+
+            Func<AzureSearchQueryBuilder> action = () => builder.WithSearchInFilter("TestVariable1", new[] { "TestValue1", "Test|Value2", "TestValue3" });
+
+            action.Should().ThrowExactly<ArgumentException>();
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        public void WithSize_WithInvalidSize_ThrowsException(int? size)
+        {
+            var builder = new AzureSearchQueryBuilder("TestSearchText");
+
+            Func<AzureSearchQueryBuilder> action = () => builder.WithSize(size);
+
+            action.Should().ThrowExactly<ArgumentOutOfRangeException>();
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        public void WithSize_WithInvalidSkip_ThrowsException(int? skip)
+        {
+            var builder = new AzureSearchQueryBuilder("TestSearchText");
+
+            Func<AzureSearchQueryBuilder> action = () => builder.WithSkip(skip);
+
+            action.Should().ThrowExactly<ArgumentOutOfRangeException>();
+        }
+    }
+}

--- a/tests/Dfc.CourseDirectory.Core.Tests/Search/ProviderSearchQueryTests.cs
+++ b/tests/Dfc.CourseDirectory.Core.Tests/Search/ProviderSearchQueryTests.cs
@@ -1,0 +1,157 @@
+﻿using System.Linq;
+using Azure.Search.Documents.Models;
+using Dfc.CourseDirectory.Core.Search;
+using FluentAssertions;
+using Xunit;
+
+namespace Dfc.CourseDirectory.Core.Tests.Search
+{
+    public class ProviderSearchQueryTests
+    {
+        [Fact]
+        public void GenerateSearchQuery_GeneratesExpectedSearchQuery()
+        {
+            var query = new ProviderSearchQuery
+            {
+                SearchText = "TestSearchText",
+                Towns = new[] { "TestTown1", "TestTown2", "TestTown3" },
+                Size = 123
+            };
+
+            var result = query.GenerateSearchQuery();
+
+            result.SearchText.Should().Be("TestSearchText*");
+            result.Options.SearchMode.Should().Be(SearchMode.All);
+            result.Options.Filter.Should().Be("search.in(Town, 'TestTown1|TestTown2|TestTown3', '|')");
+            result.Options.Size.Should().Be(123);
+        }
+
+        [Theory]
+        [InlineData(null, "*")]
+        [InlineData("", "*")]
+        [InlineData(" ", "*")]
+        [InlineData("TestSearchText", "TestSearchText*")]
+        [InlineData(" TestSearchText", "TestSearchText*")]
+        [InlineData("TestSearchText ", "TestSearchText*")]
+        public void GenerateSearchQuery_WithSearchText_ReturnsQueryWithExpectedSearchText(string searchText, string expectedResult)
+        {
+            var query = new ProviderSearchQuery
+            {
+                SearchText = searchText
+            };
+
+            var result = query.GenerateSearchQuery();
+
+            result.SearchText.Should().Be(expectedResult);
+        }
+
+        [Fact]
+        public void GenerateSearchQuery_ReturnsQueryWithSearchModeAll()
+        {
+            var query = new ProviderSearchQuery
+            {
+                SearchText = "TestSearchText"
+            };
+
+            var result = query.GenerateSearchQuery();
+
+            result.Options.SearchMode.Should().Be(SearchMode.All);
+        }
+
+        [Fact]
+        public void GenerateSearchQuery_WithNullTowns_ReturnsQueryWithEmptyFilter()
+        {
+            var query = new ProviderSearchQuery
+            {
+                SearchText = "TestSearchText"
+            };
+
+            var result = query.GenerateSearchQuery();
+
+            result.Options.Filter.Should().Be(string.Empty);
+        }
+
+        [Fact]
+        public void GenerateSearchQuery_WithEmptyTowns_ReturnsQueryWithEmptyFilter()
+        {
+            var query = new ProviderSearchQuery
+            {
+                SearchText = "TestSearchText",
+                Towns = Enumerable.Empty<string>()
+            };
+
+            var result = query.GenerateSearchQuery();
+
+            result.Options.Filter.Should().Be(string.Empty);
+        }
+
+        [Fact]
+        public void GenerateSearchQuery_WithSingleTown_ReturnsQueryWithExpectedSearchInFilter()
+        {
+            var query = new ProviderSearchQuery
+            {
+                SearchText = "TestSearchText",
+                Towns = new[] { "TestTown1" }
+            };
+
+            var result = query.GenerateSearchQuery();
+
+            result.Options.Filter.Should().Be("search.in(Town, 'TestTown1', '|')");
+        }
+
+        [Fact]
+        public void GenerateSearchQuery_WithMultipleTowns_ReturnsQueryWithExpectedSearchInFilter()
+        {
+            var query = new ProviderSearchQuery
+            {
+                SearchText = "TestSearchText",
+                Towns = new[] { "TestTown1", "TestTown2", "TestTown3" }
+            };
+
+            var result = query.GenerateSearchQuery();
+
+            result.Options.Filter.Should().Be("search.in(Town, 'TestTown1|TestTown2|TestTown3', '|')");
+        }
+
+        [Fact]
+        public void GenerateSearchQuery_WithDuplicateTowns_ReturnsQueryWithExpectedSearchInFilter()
+        {
+            var query = new ProviderSearchQuery
+            {
+                SearchText = "TestSearchText",
+                Towns = new[] { "TestTown1", "TestTown2", "TestTown1" }
+            };
+
+            var result = query.GenerateSearchQuery();
+
+            result.Options.Filter.Should().Be("search.in(Town, 'TestTown1|TestTown2', '|')");
+        }
+
+        [Fact]
+        public void GenerateSearchQuery_WithSize_ReturnsQueryWithSize()
+        {
+            var query = new ProviderSearchQuery
+            {
+                SearchText = "TestSearchText",
+                Size = 123
+            };
+
+            var result = query.GenerateSearchQuery();
+
+            result.Options.Size.Should().Be(123);
+        }
+
+        [Fact]
+        public void GenerateSearchQuery_WithNullSize_ReturnsQueryWithSize20()
+        {
+            var query = new ProviderSearchQuery
+            {
+                SearchText = "TestSearchText"
+            };
+
+            var result = query.GenerateSearchQuery();
+
+            result.Options.Size.Should().Be(20);
+        }
+    }
+}


### PR DESCRIPTION
Add AzureCognitiveSearchClient with Provider search implementation to CourseDirectory.Core

For a bit of background, search functionality currently calls an external API (FAC) to query Azure CognitiveSearch - the implementations are messy and inconsistent and there's a lot of functional code spread out across multiple projects/classes that can influence the results.

The aim of this PR is to create an easily configurable search client that can be used directly by CourseDirect to talk to Azure directly.

This code is not currently being consumed, and therefore won't require testing, however the next iteration will see this implemented for both Provider search (PTCD-439) and LARS search (PTCD-470). We can migrate the rest of the search indexes across at our leisure.