### PR TITLE
Fix setting provider context more than once when a non-strict context follows a strict one

### DIFF
--- a/src/Dfc.CourseDirectory.WebV2/ProviderContextProvider.cs
+++ b/src/Dfc.CourseDirectory.WebV2/ProviderContextProvider.cs
@@ -53,8 +53,8 @@ namespace Dfc.CourseDirectory.WebV2
                 }
                 else if (currentContextFeature.ProviderContext.Strict && !providerContext.Strict)
                 {
-                    throw new InvalidOperationException(
-                        $"Cannot replace a strict provider context with a non-strict one.");
+                    // Don't allow going from strict -> non-strict
+                    return;
                 }
             }
 


### PR DESCRIPTION
A 'strict' provider context indicates that, once set, the provider cannot be changed for a given request.

Previously we would blow up if the set context was strict but the one being set was not. This changes the behavior so we maintain the strict-ness but don't explode.