### PR TITLE
Add an implementation of ISession{Store} for testing

### DIFF
--- a/tests/Dfc.CourseDirectory.WebV2.Tests/CourseDirectoryApplicationFactory.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/CourseDirectoryApplicationFactory.cs
@@ -6,6 +6,7 @@ using FormFlow.State;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.Session;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -47,6 +48,8 @@ namespace Dfc.CourseDirectory.WebV2.Tests
         public InMemoryMptxStateProvider MptxStateProvider =>
             Services.GetRequiredService<IMptxStateProvider>() as InMemoryMptxStateProvider;
 
+        public SingletonSession Session => ((SingletonSessionStore)Services.GetRequiredService<ISessionStore>()).Instance;
+
         public Settings Settings => Services.GetRequiredService<Settings>();
 
         public SqlQuerySpy SqlQuerySpy => DatabaseFixture.SqlQuerySpy;
@@ -67,32 +70,26 @@ namespace Dfc.CourseDirectory.WebV2.Tests
         {
             DatabaseFixture.OnTestStarting();
 
-            // Clear calls on any mocks
             ResetMocks();
 
-            // Reset cache
             MemoryCache.Clear();
 
             // Restore HostingOptions values to default
             Settings.RewriteForbiddenToNotFound = false;
 
-            // Reset the clock
             Clock.UtcNow = MutableClock.Start;
 
-            // Reset feature flag provider
             FeatureFlagProvider.Reset();
 
-            // Reset MPTX state
             MptxStateProvider.Clear();
 
-            // Clear StandardsAndFrameworksCache
             Services.GetRequiredService<IStandardsAndFrameworksCache>().Clear();
 
-            // Reset cookie preferences
             CookieSettingsProvider.Reset();
 
-            // Clear FormFlow state
             (Services.GetRequiredService<IUserInstanceStateStore>() as TestUserInstanceStateStore)?.Clear();
+
+            Session.Clear();
         }
 
         public async Task OnTestStartingAsync()

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/MvcTestBase.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/MvcTestBase.cs
@@ -44,6 +44,8 @@ namespace Dfc.CourseDirectory.WebV2.Tests
 
         protected MptxManager MptxManager => Factory.MptxManager;
 
+        protected SingletonSession Session => Factory.Session;
+
         protected SqlQuerySpy SqlQuerySpy => Factory.SqlQuerySpy;
 
         protected TestData TestData => Factory.TestData;

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/SingletonSession.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/SingletonSession.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Session;
+
+namespace Dfc.CourseDirectory.WebV2.Tests
+{
+    /// <summary>
+    /// A dictionary-backed implementation of <see cref="ISession" /> for testing.
+    /// </summary>
+    /// <remarks>
+    /// This allows us to query/amend the session data outside of an HTTP request.
+    /// </remarks>
+    public class SingletonSession : ISession
+    {
+        private readonly Dictionary<string, byte[]> _data;
+
+        public SingletonSession()
+        {
+            _data = new Dictionary<string, byte[]>();
+        }
+
+        public string Id => "1";
+
+        public bool IsAvailable => true;
+
+        public IEnumerable<string> Keys => _data.Keys;
+
+        public void Clear() => _data.Clear();
+
+        public Task CommitAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public Task LoadAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public void Remove(string key) => Remove(key);
+
+        public void Set(string key, byte[] value) => _data[key] = value;
+
+        public bool TryGetValue(string key, out byte[] value) => _data.TryGetValue(key, out value);
+    }
+
+    public class SingletonSessionStore : ISessionStore
+    {
+        public SingletonSession Instance { get; } = new SingletonSession();
+
+        public ISession Create(
+            string sessionKey,
+            TimeSpan idleTimeout,
+            TimeSpan ioTimeout,
+            Func<bool> tryEstablishSession,
+            bool isNewSessionKey)
+        {
+            return Instance;
+        }
+    }
+}

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/Startup.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/Startup.cs
@@ -7,6 +7,7 @@ using GovUk.Frontend.AspNetCore;
 using MediatR;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Session;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -49,6 +50,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddSession();
+            services.AddSingleton<ISessionStore, SingletonSessionStore>();
 
             services.AddRouting();
 


### PR DESCRIPTION
Use a single dictionary to back all sessions. This allows us to
query/amend the session data outside of an HTTP request.