### PR TITLE
Rename the ToDisplayName extension methods to ToDescription

### DIFF
--- a/src/Dfc.CourseDirectory.Core/Models/ApprenticeshipDeliveryMode.cs
+++ b/src/Dfc.CourseDirectory.Core/Models/ApprenticeshipDeliveryMode.cs
@@ -11,7 +11,7 @@ namespace Dfc.CourseDirectory.Core.Models
 
     public static class ApprenticeshipDeliveryModesExtensions
     {
-        public static string ToDisplayName(this ApprenticeshipDeliveryMode apprenticeshipDeliveryMode) =>
+        public static string ToDescription(this ApprenticeshipDeliveryMode apprenticeshipDeliveryMode) =>
             apprenticeshipDeliveryMode switch
             {
                 ApprenticeshipDeliveryMode.EmployerAddress => "Employer Address",

--- a/src/Dfc.CourseDirectory.Core/Models/ApprenticeshipLocationType.cs
+++ b/src/Dfc.CourseDirectory.Core/Models/ApprenticeshipLocationType.cs
@@ -12,7 +12,7 @@ namespace Dfc.CourseDirectory.Core.Models
 
     public static class ApprenticeshipLocationTypeExtensions
     {
-        public static string ToDisplayName(this ApprenticeshipLocationType apprenticeshipLocationType) =>
+        public static string ToDescription(this ApprenticeshipLocationType apprenticeshipLocationType) =>
             apprenticeshipLocationType switch
             {
                 ApprenticeshipLocationType.EmployerBased => "Employer based locations",

--- a/src/Dfc.CourseDirectory.Core/Models/ApprenticeshipQAStatus.cs
+++ b/src/Dfc.CourseDirectory.Core/Models/ApprenticeshipQAStatus.cs
@@ -15,7 +15,7 @@ namespace Dfc.CourseDirectory.Core.Models
 
     public static class ApprenticeshipQAStatusExtensions
     {
-        public static string ToDisplayName(this ApprenticeshipQAStatus status)
+        public static string ToDescription(this ApprenticeshipQAStatus status)
         {
             if (status.HasFlag(ApprenticeshipQAStatus.UnableToComplete))
             {

--- a/src/Dfc.CourseDirectory.Core/Models/ApprenticeshipQAUnableToCompleteReasons.cs
+++ b/src/Dfc.CourseDirectory.Core/Models/ApprenticeshipQAUnableToCompleteReasons.cs
@@ -15,7 +15,7 @@ namespace Dfc.CourseDirectory.Core.Models
 
     public static class ApprenticeshipQAUnableToCompleteReasonsExtensions
     {
-        public static string ToDisplayName(this ApprenticeshipQAUnableToCompleteReasons status)
+        public static string ToDescription(this ApprenticeshipQAUnableToCompleteReasons status)
         {
             switch (status)
             {

--- a/src/Dfc.CourseDirectory.Core/Models/CourseDeliveryMode.cs
+++ b/src/Dfc.CourseDirectory.Core/Models/CourseDeliveryMode.cs
@@ -11,7 +11,7 @@ namespace Dfc.CourseDirectory.Core.Models
 
     public static class CourseDeliveryModeExtensions
     {
-        public static string ToDisplayName(this CourseDeliveryMode deliveryMode) => deliveryMode switch
+        public static string ToDescription(this CourseDeliveryMode deliveryMode) => deliveryMode switch
         {
             CourseDeliveryMode.ClassroomBased => "Classroom based",
             CourseDeliveryMode.Online => "Online",

--- a/src/Dfc.CourseDirectory.Core/Models/ProviderType.cs
+++ b/src/Dfc.CourseDirectory.Core/Models/ProviderType.cs
@@ -13,7 +13,7 @@ namespace Dfc.CourseDirectory.Core.Models
 
     public static class ProviderTypeExtensions
     {
-        public static string ToDisplayName(this ProviderType providerType) =>
+        public static string ToDescription(this ProviderType providerType) =>
             providerType switch
             {
                 ProviderType.Undefined => "",

--- a/src/Dfc.CourseDirectory.WebV2/Features/ApprenticeshipQA/ApprenticeshipAssessment.cshtml
+++ b/src/Dfc.CourseDirectory.WebV2/Features/ApprenticeshipQA/ApprenticeshipAssessment.cshtml
@@ -139,7 +139,7 @@
                     @if (Model.ApprenticeshipClassroomLocations.Count > 0)
                     {
                         <govuk-accordion-item>
-                            <govuk-accordion-item-heading>@ApprenticeshipLocationType.ClassroomBased.ToDisplayName()</govuk-accordion-item-heading>
+                            <govuk-accordion-item-heading>@ApprenticeshipLocationType.ClassroomBased.ToDescription()</govuk-accordion-item-heading>
                             <table class="govuk-table pttcd-table--last-row-border-0">
                                 <thead class="govuk-table__head">
                                     <tr class="govuk-table__row">
@@ -157,7 +157,7 @@
                                                 <ul class="govuk-list">
                                                     @foreach (var dm in l.DeliveryModes)
                                                     {
-                                                        <li>@dm.ToDisplayName()</li>
+                                                        <li>@dm.ToDescription()</li>
                                                     }
                                                 </ul>
                                             </td>
@@ -171,7 +171,7 @@
                     @if (Model.ApprenticeshipEmployerLocationRegions.Count > 0 || Model.ApprenticeshipIsNational == true)
                     {
                         <govuk-accordion-item>
-                            <govuk-accordion-item-heading>@ApprenticeshipLocationType.EmployerBased.ToDisplayName()</govuk-accordion-item-heading>
+                            <govuk-accordion-item-heading>@ApprenticeshipLocationType.EmployerBased.ToDescription()</govuk-accordion-item-heading>
                             <table class="govuk-table pttcd-table--last-row-border-0">
                                 <thead class="govuk-table__head">
                                     <tr class="govuk-table__row">

--- a/src/Dfc.CourseDirectory.WebV2/Features/ApprenticeshipQA/ListProviders.cshtml
+++ b/src/Dfc.CourseDirectory.WebV2/Features/ApprenticeshipQA/ListProviders.cshtml
@@ -136,7 +136,7 @@
                             <ul class="govuk-list">
                                 @foreach (var reason in EnumHelper.SplitFlags(provider.UnableToCompleteReasons.Value))
                                 {
-                                    <li>@reason.ToDisplayName()</li>
+                                    <li>@reason.ToDescription()</li>
                                 }
                             </ul>
                         </td>

--- a/src/Dfc.CourseDirectory.WebV2/Features/ApprenticeshipQA/ProviderSelected.cshtml
+++ b/src/Dfc.CourseDirectory.WebV2/Features/ApprenticeshipQA/ProviderSelected.cshtml
@@ -13,7 +13,7 @@
         </h2>
         <div class="pttcd-apprenticeship-qa__provider-selected__summary govuk-!-margin-bottom-9">
             <div class="pttcd-apprenticeship-qa__provider-selected__summary__label">
-                @Model.ApprenticeshipQAStatus.ToDisplayName()
+                @Model.ApprenticeshipQAStatus.ToDescription()
             </div>
             <div class="pttcd-apprenticeship-qa__provider-selected__summary__status">
                 <a asp-action="Status" asp-route-providerId="@Model.ProviderId" class="govuk-link">

--- a/src/Dfc.CourseDirectory.WebV2/Features/ApprenticeshipQA/Report.cs
+++ b/src/Dfc.CourseDirectory.WebV2/Features/ApprenticeshipQA/Report.cs
@@ -69,10 +69,10 @@ namespace Dfc.CourseDirectory.WebV2.Features.ApprenticeshipQA.Report
                              Email = r.Email,
                              PassedQAOn = r.PassedQAOn.HasValue ? r.PassedQAOn.Value.ToString("dd MMM yyyy") : null,
                              FailedQAOn = r.FailedQAOn.HasValue ? r.FailedQAOn.Value.ToString("dd MMM yyyy") : null,
-                             UnableToCompleteReasons = r.UnableToCompleteReasons.HasValue ? string.Join(",", EnumHelper.SplitFlags(r.UnableToCompleteReasons.Value).ToList().Select(x => x.ToDisplayName()).ToList()) : null,
+                             UnableToCompleteReasons = r.UnableToCompleteReasons.HasValue ? string.Join(",", EnumHelper.SplitFlags(r.UnableToCompleteReasons.Value).ToList().Select(x => x.ToDescription()).ToList()) : null,
                              UnableToCompleteOn = r.UnabletoCompleteOn.HasValue ? r.UnabletoCompleteOn.Value.ToString("dd MMM yyyy") : null,
                              Notes = r.Notes,
-                             QAStatus = r.QAStatus.HasValue ? r.QAStatus.Value.ToDisplayName() : null,
+                             QAStatus = r.QAStatus.HasValue ? r.QAStatus.Value.ToDescription() : null,
                              PassedQA = r.QAStatus == ApprenticeshipQAStatus.Passed ? "Yes" : "No",
                              FailedQA = r.QAStatus == ApprenticeshipQAStatus.Failed ? "Yes" : "No",
                              UnableToComplete = r.QAStatus.HasValue ? (r.QAStatus.Value.HasFlag(ApprenticeshipQAStatus.UnableToComplete) ? "Yes" : "No") : "No"

--- a/src/Dfc.CourseDirectory.WebV2/Features/DeleteCourseRun/View.cshtml
+++ b/src/Dfc.CourseDirectory.WebV2/Features/DeleteCourseRun/View.cshtml
@@ -41,7 +41,7 @@
                 }
                 <govuk-summary-list-row>
                     <govuk-summary-list-row-key>Course type</govuk-summary-list-row-key>
-                    <govuk-summary-list-row-value>@Model.DeliveryMode.ToDisplayName()</govuk-summary-list-row-value>
+                    <govuk-summary-list-row-value>@Model.DeliveryMode.ToDescription()</govuk-summary-list-row-value>
                 </govuk-summary-list-row>
                 <govuk-summary-list-row>
                     <govuk-summary-list-row-key>Start date</govuk-summary-list-row-key>

--- a/src/Dfc.CourseDirectory.WebV2/Features/NewApprenticeshipProvider/ApprenticeshipSummary.cshtml
+++ b/src/Dfc.CourseDirectory.WebV2/Features/NewApprenticeshipProvider/ApprenticeshipSummary.cshtml
@@ -66,7 +66,7 @@
     </govuk-summary-list-row>
     <govuk-summary-list-row>
         <govuk-summary-list-row-key>Location type</govuk-summary-list-row-key>
-        <govuk-summary-list-row-value>@Model.ApprenticeshipLocationType.ToDisplayName()</govuk-summary-list-row-value>
+        <govuk-summary-list-row-value>@Model.ApprenticeshipLocationType.ToDescription()</govuk-summary-list-row-value>
         <govuk-summary-list-row-action>
             <a asp-action="ApprenticeshipLocations" asp-all-route-data="@ProviderContext.RouteValues" append-mptx-id class="govuk-link">
                 Change<span class="govuk-visually-hidden"> location type</span>
@@ -81,7 +81,7 @@
     <table class="govuk-table">
         <caption class="govuk-table__caption">
             <a asp-action="ApprenticeshipEmployerLocations" append-mptx-id class="govuk-link govuk-body govuk-!-margin-bottom-0" style="float:right">Change</a>
-            @ApprenticeshipLocationType.EmployerBased.ToDisplayName()
+            @ApprenticeshipLocationType.EmployerBased.ToDescription()
         </caption>
         <tbody class="govuk-table__body">
             @if (Model.ApprenticeshipIsNational == true)
@@ -115,7 +115,7 @@
     <table class="govuk-table">
         <caption class="govuk-table__caption">
             <a asp-action="AddApprenticeshipClassroomLocation" asp-all-route-data="@ProviderContext.RouteValues" append-mptx-id class="govuk-link govuk-body govuk-!-margin-bottom-0" style="float:right">Add</a>
-            @ApprenticeshipLocationType.ClassroomBased.ToDisplayName()
+            @ApprenticeshipLocationType.ClassroomBased.ToDescription()
         </caption>
         <thead>
             <tr class="govuk-table__row">
@@ -134,7 +134,7 @@
                         <ul class="govuk-list govuk-!-margin-0">
                             @foreach (var dm in location.DeliveryModes)
                             {
-                                <li>@dm.ToDisplayName()</li>
+                                <li>@dm.ToDescription()</li>
                             }
                         </ul>
                     </td>

--- a/src/Dfc.CourseDirectory.WebV2/Features/NewApprenticeshipProvider/ProviderDetailConfirmation.cshtml
+++ b/src/Dfc.CourseDirectory.WebV2/Features/NewApprenticeshipProvider/ProviderDetailConfirmation.cshtml
@@ -22,7 +22,7 @@
             </govuk-summary-list-row>
             <govuk-summary-list-row>
                 <govuk-summary-list-row-key>Provider type</govuk-summary-list-row-key>
-                <govuk-summary-list-row-value>@Model.ProviderType.ToDisplayName()</govuk-summary-list-row-value>
+                <govuk-summary-list-row-value>@Model.ProviderType.ToDescription()</govuk-summary-list-row-value>
             </govuk-summary-list-row>
             <govuk-summary-list-row class="pttcd-summary-list__row__split pttcd-new-apprenticeship-provider__provider-detail__marketing-information" data-testid="MarketingInformation">
                 <govuk-summary-list-row-key>Provider information</govuk-summary-list-row-key>

--- a/src/Dfc.CourseDirectory.WebV2/Features/Providers/ProviderDetails.cshtml
+++ b/src/Dfc.CourseDirectory.WebV2/Features/Providers/ProviderDetails.cshtml
@@ -40,7 +40,7 @@
             }
             <govuk-summary-list-row>
                 <govuk-summary-list-row-key>Provider type</govuk-summary-list-row-key>
-                <govuk-summary-list-row-value>@Model.ProviderType.ToDisplayName()</govuk-summary-list-row-value>
+                <govuk-summary-list-row-value>@Model.ProviderType.ToDescription()</govuk-summary-list-row-value>
                 @if (Model.CanChangeProviderType)
                 {
                     <govuk-summary-list-row-action asp-controller="Provider" asp-action="AddOrEditProviderType" asp-route-updateProviderType="true" class="govuk-link" data-testid="ChangeProviderType">

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/ApprenticeshipQA/QAStatusReportTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/ApprenticeshipQA/QAStatusReportTests.cs
@@ -107,7 +107,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ApprenticeshipQA
                 Assert.Empty(item.UnableToCompleteOn);
                 Assert.Equal("", item.Notes);
                 Assert.Empty(item.UnableToCompleteReasons);
-                Assert.Equal(ApprenticeshipQAStatus.Passed.ToDisplayName(), item.QAStatus);
+                Assert.Equal(ApprenticeshipQAStatus.Passed.ToDescription(), item.QAStatus);
             });
         }
 
@@ -213,7 +213,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ApprenticeshipQA
                 Assert.Empty(item.UnableToCompleteOn);
                 Assert.Equal("", item.Notes);
                 Assert.Empty(item.UnableToCompleteReasons);
-                Assert.Equal(ApprenticeshipQAStatus.Passed.ToDisplayName(), item.QAStatus);
+                Assert.Equal(ApprenticeshipQAStatus.Passed.ToDescription(), item.QAStatus);
             });
         }
 
@@ -292,7 +292,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ApprenticeshipQA
                 Assert.Empty(item.UnableToCompleteOn);
                 Assert.Equal("", item.Notes);
                 Assert.Empty(item.UnableToCompleteReasons);
-                Assert.Equal(ApprenticeshipQAStatus.Failed.ToDisplayName(), item.QAStatus);
+                Assert.Equal(ApprenticeshipQAStatus.Failed.ToDescription(), item.QAStatus);
             });
         }
 
@@ -369,10 +369,10 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ApprenticeshipQA
                 Assert.Equal("Yes", item.UnableToComplete);
                 Assert.Equal(unableToCompleteOn.ToString("dd MMM yyyy"), item.UnableToCompleteOn);
                 Assert.Equal(unableToCompleteComments, item.Notes);
-                Assert.Contains(unableReason1.ToDisplayName(), item.UnableToCompleteReasons);
-                Assert.Contains(unableReason2.ToDisplayName(), item.UnableToCompleteReasons);
-                Assert.Contains(unableReason3.ToDisplayName(), item.UnableToCompleteReasons);
-                Assert.Equal(ApprenticeshipQAStatus.UnableToComplete.ToDisplayName(), item.QAStatus);
+                Assert.Contains(unableReason1.ToDescription(), item.UnableToCompleteReasons);
+                Assert.Contains(unableReason2.ToDescription(), item.UnableToCompleteReasons);
+                Assert.Contains(unableReason3.ToDescription(), item.UnableToCompleteReasons);
+                Assert.Equal(ApprenticeshipQAStatus.UnableToComplete.ToDescription(), item.QAStatus);
             });
         }
 
@@ -452,8 +452,8 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ApprenticeshipQA
                 Assert.Equal("Yes", item.UnableToComplete);
                 Assert.Equal(unableToCompleteOn.ToString("dd MMM yyyy"), item.UnableToCompleteOn);
                 Assert.Equal(unableToCompleteComments, item.Notes);
-                Assert.Equal(item.UnableToCompleteReasons, unableReason.ToDisplayName());
-                Assert.Equal(ApprenticeshipQAStatus.UnableToComplete.ToDisplayName(), item.QAStatus);
+                Assert.Equal(item.UnableToCompleteReasons, unableReason.ToDescription());
+                Assert.Equal(ApprenticeshipQAStatus.UnableToComplete.ToDescription(), item.QAStatus);
             });
         }
 
@@ -493,7 +493,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ApprenticeshipQA
                 Assert.Equal("No", item.FailedQA);
                 Assert.Empty(item.FailedQAOn);
                 Assert.Equal("No", item.UnableToComplete);
-                Assert.Equal(ApprenticeshipQAStatus.NotStarted.ToDisplayName(), item.QAStatus);
+                Assert.Equal(ApprenticeshipQAStatus.NotStarted.ToDescription(), item.QAStatus);
             });
         }
 


### PR DESCRIPTION
'Display name' now means something else in our world (i.e. the _label_
for a Provider) so remove the overloaded term.