### PR TITLE
Update UKRLP client from v3 to v6 (take 2)

### DIFF
--- a/src/Dfc.CourseDirectory.Core/Connected Services/UkrlpService/ConnectedService.json
+++ b/src/Dfc.CourseDirectory.Core/Connected Services/UkrlpService/ConnectedService.json
@@ -1,12 +1,12 @@
 ﻿{
   "ProviderId": "Microsoft.VisualStudio.ConnectedService.Wcf",
-  "Version": "15.0.31022.994",
+  "Version": "15.0.40203.910",
   "GettingStartedDocument": {
     "Uri": "https://go.microsoft.com/fwlink/?linkid=858517"
   },
   "ExtendedData": {
     "inputs": [
-      "http://webservices.ukrlp.co.uk/UkrlpProviderQueryWS/ProviderQueryServiceV3?wsdl"
+      "http://webservices.ukrlp.co.uk/UkrlpProviderQueryWS6/ProviderQueryServiceV6?wsdl"
     ],
     "collectionTypes": [
       "System.Array",
@@ -175,7 +175,7 @@
       "System.Xml.ReaderWriter, {System.Xml.ReaderWriter, 4.3.0}",
       "System.Xml.XmlDocument, {System.Xml.XmlDocument, 4.3.0}"
     ],
-    "targetFramework": "netstandard2.0",
+    "targetFramework": "netstandard2.1",
     "typeReuseMode": "All"
   }
 }

--- a/src/Dfc.CourseDirectory.Core/Connected Services/UkrlpService/Reference.cs
+++ b/src/Dfc.CourseDirectory.Core/Connected Services/UkrlpService/Reference.cs
@@ -54,1496 +54,6 @@ namespace UkrlpService
     /// <remarks/>
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "2.0.2")]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.govtalk.gov.uk/people/bs7666")]
-    public partial class AONrangeStructure
-    {
-        
-        private string numberField;
-        
-        private string suffixField;
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(DataType="positiveInteger", Order=0)]
-        public string Number
-        {
-            get
-            {
-                return this.numberField;
-            }
-            set
-            {
-                this.numberField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(Order=1)]
-        public string Suffix
-        {
-            get
-            {
-                return this.suffixField;
-            }
-            set
-            {
-                this.suffixField = value;
-            }
-        }
-    }
-    
-    /// <remarks/>
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "2.0.2")]
-    [System.Diagnostics.DebuggerStepThroughAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.govtalk.gov.uk/people/bs7666")]
-    public partial class LandAndPropertyIdentifierStructure
-    {
-        
-        private AONstructure pAONField;
-        
-        private AONstructure sAONField;
-        
-        private string postTownField;
-        
-        private string postCodeField;
-        
-        private string levelField;
-        
-        private LogicalStatusType logicalStatusField;
-        
-        private bool officialAddressMarkerField;
-        
-        private bool officialAddressMarkerFieldSpecified;
-        
-        private System.DateTime lPIstartDateField;
-        
-        private System.DateTime lPIentryDateField;
-        
-        private System.DateTime lPIendDateField;
-        
-        private bool lPIendDateFieldSpecified;
-        
-        private System.DateTime lPIlastUpdateDateField;
-        
-        private object itemField;
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(Order=0)]
-        public AONstructure PAON
-        {
-            get
-            {
-                return this.pAONField;
-            }
-            set
-            {
-                this.pAONField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(Order=1)]
-        public AONstructure SAON
-        {
-            get
-            {
-                return this.sAONField;
-            }
-            set
-            {
-                this.sAONField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(Order=2)]
-        public string PostTown
-        {
-            get
-            {
-                return this.postTownField;
-            }
-            set
-            {
-                this.postTownField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(Order=3)]
-        public string PostCode
-        {
-            get
-            {
-                return this.postCodeField;
-            }
-            set
-            {
-                this.postCodeField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(Order=4)]
-        public string Level
-        {
-            get
-            {
-                return this.levelField;
-            }
-            set
-            {
-                this.levelField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(Order=5)]
-        public LogicalStatusType LogicalStatus
-        {
-            get
-            {
-                return this.logicalStatusField;
-            }
-            set
-            {
-                this.logicalStatusField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(Order=6)]
-        public bool OfficialAddressMarker
-        {
-            get
-            {
-                return this.officialAddressMarkerField;
-            }
-            set
-            {
-                this.officialAddressMarkerField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlIgnoreAttribute()]
-        public bool OfficialAddressMarkerSpecified
-        {
-            get
-            {
-                return this.officialAddressMarkerFieldSpecified;
-            }
-            set
-            {
-                this.officialAddressMarkerFieldSpecified = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(DataType="date", Order=7)]
-        public System.DateTime LPIstartDate
-        {
-            get
-            {
-                return this.lPIstartDateField;
-            }
-            set
-            {
-                this.lPIstartDateField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(DataType="date", Order=8)]
-        public System.DateTime LPIentryDate
-        {
-            get
-            {
-                return this.lPIentryDateField;
-            }
-            set
-            {
-                this.lPIentryDateField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(DataType="date", Order=9)]
-        public System.DateTime LPIendDate
-        {
-            get
-            {
-                return this.lPIendDateField;
-            }
-            set
-            {
-                this.lPIendDateField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlIgnoreAttribute()]
-        public bool LPIendDateSpecified
-        {
-            get
-            {
-                return this.lPIendDateFieldSpecified;
-            }
-            set
-            {
-                this.lPIendDateFieldSpecified = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(DataType="date", Order=10)]
-        public System.DateTime LPIlastUpdateDate
-        {
-            get
-            {
-                return this.lPIlastUpdateDateField;
-            }
-            set
-            {
-                this.lPIlastUpdateDateField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute("Street", typeof(StreetStructure), Order=11)]
-        [System.Xml.Serialization.XmlElementAttribute("USRN", typeof(string), DataType="integer", Order=11)]
-        public object Item
-        {
-            get
-            {
-                return this.itemField;
-            }
-            set
-            {
-                this.itemField = value;
-            }
-        }
-    }
-    
-    /// <remarks/>
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "2.0.2")]
-    [System.Diagnostics.DebuggerStepThroughAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.govtalk.gov.uk/people/bs7666")]
-    public partial class AONstructure
-    {
-        
-        private string descriptionField;
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(Order=0)]
-        public string Description
-        {
-            get
-            {
-                return this.descriptionField;
-            }
-            set
-            {
-                this.descriptionField = value;
-            }
-        }
-    }
-    
-    /// <remarks/>
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "2.0.2")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.govtalk.gov.uk/people/bs7666")]
-    public enum LogicalStatusType
-    {
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlEnumAttribute("1")]
-        Item1,
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlEnumAttribute("2")]
-        Item2,
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlEnumAttribute("3")]
-        Item3,
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlEnumAttribute("5")]
-        Item5,
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlEnumAttribute("6")]
-        Item6,
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlEnumAttribute("8")]
-        Item8,
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlEnumAttribute("9")]
-        Item9,
-    }
-    
-    /// <remarks/>
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "2.0.2")]
-    [System.Diagnostics.DebuggerStepThroughAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.govtalk.gov.uk/people/bs7666")]
-    public partial class StreetStructure
-    {
-        
-        private StreetReferenceTypeType streetReferenceTypeField;
-        
-        private CoordinateStructure startCoordinateField;
-        
-        private CoordinateStructure endCoordinateField;
-        
-        private decimal toleranceField;
-        
-        private string streetVersionNumberField;
-        
-        private System.DateTime streetEntryDateField;
-        
-        private System.DateTime streetClosureDateField;
-        
-        private bool streetClosureDateFieldSpecified;
-        
-        private string responsibleAuthorityField;
-        
-        private StreetDescriptiveIdentifierStructure descriptiveIdentifierField;
-        
-        private StreetDescriptiveIdentifierStructure streetAliasField;
-        
-        private StreetStructureStreetCrossReferences streetCrossReferencesField;
-        
-        private string usrnField;
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(Order=0)]
-        public StreetReferenceTypeType StreetReferenceType
-        {
-            get
-            {
-                return this.streetReferenceTypeField;
-            }
-            set
-            {
-                this.streetReferenceTypeField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(Order=1)]
-        public CoordinateStructure StartCoordinate
-        {
-            get
-            {
-                return this.startCoordinateField;
-            }
-            set
-            {
-                this.startCoordinateField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(Order=2)]
-        public CoordinateStructure EndCoordinate
-        {
-            get
-            {
-                return this.endCoordinateField;
-            }
-            set
-            {
-                this.endCoordinateField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(Order=3)]
-        public decimal Tolerance
-        {
-            get
-            {
-                return this.toleranceField;
-            }
-            set
-            {
-                this.toleranceField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(DataType="positiveInteger", Order=4)]
-        public string StreetVersionNumber
-        {
-            get
-            {
-                return this.streetVersionNumberField;
-            }
-            set
-            {
-                this.streetVersionNumberField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(DataType="date", Order=5)]
-        public System.DateTime StreetEntryDate
-        {
-            get
-            {
-                return this.streetEntryDateField;
-            }
-            set
-            {
-                this.streetEntryDateField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(DataType="date", Order=6)]
-        public System.DateTime StreetClosureDate
-        {
-            get
-            {
-                return this.streetClosureDateField;
-            }
-            set
-            {
-                this.streetClosureDateField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlIgnoreAttribute()]
-        public bool StreetClosureDateSpecified
-        {
-            get
-            {
-                return this.streetClosureDateFieldSpecified;
-            }
-            set
-            {
-                this.streetClosureDateFieldSpecified = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(DataType="integer", Order=7)]
-        public string ResponsibleAuthority
-        {
-            get
-            {
-                return this.responsibleAuthorityField;
-            }
-            set
-            {
-                this.responsibleAuthorityField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(Order=8)]
-        public StreetDescriptiveIdentifierStructure DescriptiveIdentifier
-        {
-            get
-            {
-                return this.descriptiveIdentifierField;
-            }
-            set
-            {
-                this.descriptiveIdentifierField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(Order=9)]
-        public StreetDescriptiveIdentifierStructure StreetAlias
-        {
-            get
-            {
-                return this.streetAliasField;
-            }
-            set
-            {
-                this.streetAliasField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(Order=10)]
-        public StreetStructureStreetCrossReferences StreetCrossReferences
-        {
-            get
-            {
-                return this.streetCrossReferencesField;
-            }
-            set
-            {
-                this.streetCrossReferencesField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlAttributeAttribute(DataType="integer")]
-        public string usrn
-        {
-            get
-            {
-                return this.usrnField;
-            }
-            set
-            {
-                this.usrnField = value;
-            }
-        }
-    }
-    
-    /// <remarks/>
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "2.0.2")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.govtalk.gov.uk/people/bs7666")]
-    public enum StreetReferenceTypeType
-    {
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlEnumAttribute("1")]
-        Item1,
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlEnumAttribute("2")]
-        Item2,
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlEnumAttribute("3")]
-        Item3,
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlEnumAttribute("4")]
-        Item4,
-    }
-    
-    /// <remarks/>
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "2.0.2")]
-    [System.Diagnostics.DebuggerStepThroughAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.govtalk.gov.uk/people/bs7666")]
-    public partial class CoordinateStructure
-    {
-        
-        private ulong xField;
-        
-        private ulong yField;
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(Order=0)]
-        public ulong X
-        {
-            get
-            {
-                return this.xField;
-            }
-            set
-            {
-                this.xField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(Order=1)]
-        public ulong Y
-        {
-            get
-            {
-                return this.yField;
-            }
-            set
-            {
-                this.yField = value;
-            }
-        }
-    }
-    
-    /// <remarks/>
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "2.0.2")]
-    [System.Diagnostics.DebuggerStepThroughAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.govtalk.gov.uk/people/bs7666")]
-    public partial class StreetDescriptiveIdentifierStructure
-    {
-        
-        private string streetDescriptionField;
-        
-        private string localityField;
-        
-        private string[] itemsField;
-        
-        private ItemsChoiceType1[] itemsElementNameField;
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(Order=0)]
-        public string StreetDescription
-        {
-            get
-            {
-                return this.streetDescriptionField;
-            }
-            set
-            {
-                this.streetDescriptionField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(Order=1)]
-        public string Locality
-        {
-            get
-            {
-                return this.localityField;
-            }
-            set
-            {
-                this.localityField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute("AdministrativeArea", typeof(string), Order=2)]
-        [System.Xml.Serialization.XmlElementAttribute("Town", typeof(string), Order=2)]
-        [System.Xml.Serialization.XmlChoiceIdentifierAttribute("ItemsElementName")]
-        public string[] Items
-        {
-            get
-            {
-                return this.itemsField;
-            }
-            set
-            {
-                this.itemsField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute("ItemsElementName", Order=3)]
-        [System.Xml.Serialization.XmlIgnoreAttribute()]
-        public ItemsChoiceType1[] ItemsElementName
-        {
-            get
-            {
-                return this.itemsElementNameField;
-            }
-            set
-            {
-                this.itemsElementNameField = value;
-            }
-        }
-    }
-    
-    /// <remarks/>
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "2.0.2")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.govtalk.gov.uk/people/bs7666", IncludeInSchema=false)]
-    public enum ItemsChoiceType1
-    {
-        
-        /// <remarks/>
-        AdministrativeArea,
-        
-        /// <remarks/>
-        Town,
-    }
-    
-    /// <remarks/>
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "2.0.2")]
-    [System.Diagnostics.DebuggerStepThroughAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType=true, Namespace="http://www.govtalk.gov.uk/people/bs7666")]
-    public partial class StreetStructureStreetCrossReferences
-    {
-        
-        private object[] itemsField;
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute("ElementaryStreetUnit", typeof(ElementaryStreetUnitStructure), Order=0)]
-        [System.Xml.Serialization.XmlElementAttribute("UniqueStreetReferenceNumbers", typeof(string), DataType="integer", Order=0)]
-        public object[] Items
-        {
-            get
-            {
-                return this.itemsField;
-            }
-            set
-            {
-                this.itemsField = value;
-            }
-        }
-    }
-    
-    /// <remarks/>
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "2.0.2")]
-    [System.Diagnostics.DebuggerStepThroughAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.govtalk.gov.uk/people/bs7666")]
-    public partial class ElementaryStreetUnitStructure
-    {
-        
-        private string eSUidentityField;
-        
-        private string eSUversionField;
-        
-        private System.DateTime eSUentryDateField;
-        
-        private System.DateTime eSUclosureDateField;
-        
-        private bool eSUclosureDateFieldSpecified;
-        
-        private CoordinateStructure startCoordinateField;
-        
-        private CoordinateStructure endCoordinateField;
-        
-        private decimal toleranceField;
-        
-        private CoordinateStructure[] intermediateCoordField;
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(Order=0)]
-        public string ESUidentity
-        {
-            get
-            {
-                return this.eSUidentityField;
-            }
-            set
-            {
-                this.eSUidentityField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(DataType="positiveInteger", Order=1)]
-        public string ESUversion
-        {
-            get
-            {
-                return this.eSUversionField;
-            }
-            set
-            {
-                this.eSUversionField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(DataType="date", Order=2)]
-        public System.DateTime ESUentryDate
-        {
-            get
-            {
-                return this.eSUentryDateField;
-            }
-            set
-            {
-                this.eSUentryDateField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(DataType="date", Order=3)]
-        public System.DateTime ESUclosureDate
-        {
-            get
-            {
-                return this.eSUclosureDateField;
-            }
-            set
-            {
-                this.eSUclosureDateField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlIgnoreAttribute()]
-        public bool ESUclosureDateSpecified
-        {
-            get
-            {
-                return this.eSUclosureDateFieldSpecified;
-            }
-            set
-            {
-                this.eSUclosureDateFieldSpecified = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(Order=4)]
-        public CoordinateStructure StartCoordinate
-        {
-            get
-            {
-                return this.startCoordinateField;
-            }
-            set
-            {
-                this.startCoordinateField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(Order=5)]
-        public CoordinateStructure EndCoordinate
-        {
-            get
-            {
-                return this.endCoordinateField;
-            }
-            set
-            {
-                this.endCoordinateField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(Order=6)]
-        public decimal Tolerance
-        {
-            get
-            {
-                return this.toleranceField;
-            }
-            set
-            {
-                this.toleranceField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute("IntermediateCoord", Order=7)]
-        public CoordinateStructure[] IntermediateCoord
-        {
-            get
-            {
-                return this.intermediateCoordField;
-            }
-            set
-            {
-                this.intermediateCoordField = value;
-            }
-        }
-    }
-    
-    /// <remarks/>
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "2.0.2")]
-    [System.Diagnostics.DebuggerStepThroughAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.govtalk.gov.uk/people/bs7666")]
-    public partial class BasicLandAndPropertyUnitStructure
-    {
-        
-        private string uniquePropertyReferenceNumberField;
-        
-        private string custodianCodeField;
-        
-        private RepresentativePointCodeType representativePointCodeField;
-        
-        private LogicalStatusType logicalStatusField;
-        
-        private CoordinateStructure gridReferenceField;
-        
-        private System.DateTime bLPUentryDateField;
-        
-        private System.DateTime bLPUstartDateField;
-        
-        private System.DateTime bLPUendDateField;
-        
-        private bool bLPUendDateFieldSpecified;
-        
-        private System.DateTime bLPUlastUpdateDateField;
-        
-        private LandAndPropertyIdentifierStructure[] landAndPropertyIdentifierField;
-        
-        private ProvenanceStructure[] provenanceField;
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(DataType="integer", Order=0)]
-        public string UniquePropertyReferenceNumber
-        {
-            get
-            {
-                return this.uniquePropertyReferenceNumberField;
-            }
-            set
-            {
-                this.uniquePropertyReferenceNumberField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(DataType="integer", Order=1)]
-        public string CustodianCode
-        {
-            get
-            {
-                return this.custodianCodeField;
-            }
-            set
-            {
-                this.custodianCodeField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(Order=2)]
-        public RepresentativePointCodeType RepresentativePointCode
-        {
-            get
-            {
-                return this.representativePointCodeField;
-            }
-            set
-            {
-                this.representativePointCodeField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(Order=3)]
-        public LogicalStatusType LogicalStatus
-        {
-            get
-            {
-                return this.logicalStatusField;
-            }
-            set
-            {
-                this.logicalStatusField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(Order=4)]
-        public CoordinateStructure GridReference
-        {
-            get
-            {
-                return this.gridReferenceField;
-            }
-            set
-            {
-                this.gridReferenceField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(DataType="date", Order=5)]
-        public System.DateTime BLPUentryDate
-        {
-            get
-            {
-                return this.bLPUentryDateField;
-            }
-            set
-            {
-                this.bLPUentryDateField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(DataType="date", Order=6)]
-        public System.DateTime BLPUstartDate
-        {
-            get
-            {
-                return this.bLPUstartDateField;
-            }
-            set
-            {
-                this.bLPUstartDateField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(DataType="date", Order=7)]
-        public System.DateTime BLPUendDate
-        {
-            get
-            {
-                return this.bLPUendDateField;
-            }
-            set
-            {
-                this.bLPUendDateField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlIgnoreAttribute()]
-        public bool BLPUendDateSpecified
-        {
-            get
-            {
-                return this.bLPUendDateFieldSpecified;
-            }
-            set
-            {
-                this.bLPUendDateFieldSpecified = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(DataType="date", Order=8)]
-        public System.DateTime BLPUlastUpdateDate
-        {
-            get
-            {
-                return this.bLPUlastUpdateDateField;
-            }
-            set
-            {
-                this.bLPUlastUpdateDateField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute("LandAndPropertyIdentifier", Order=9)]
-        public LandAndPropertyIdentifierStructure[] LandAndPropertyIdentifier
-        {
-            get
-            {
-                return this.landAndPropertyIdentifierField;
-            }
-            set
-            {
-                this.landAndPropertyIdentifierField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute("Provenance", Order=10)]
-        public ProvenanceStructure[] Provenance
-        {
-            get
-            {
-                return this.provenanceField;
-            }
-            set
-            {
-                this.provenanceField = value;
-            }
-        }
-    }
-    
-    /// <remarks/>
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "2.0.2")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.govtalk.gov.uk/people/bs7666")]
-    public enum RepresentativePointCodeType
-    {
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlEnumAttribute("1")]
-        Item1,
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlEnumAttribute("2")]
-        Item2,
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlEnumAttribute("3")]
-        Item3,
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlEnumAttribute("4")]
-        Item4,
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlEnumAttribute("5")]
-        Item5,
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlEnumAttribute("9")]
-        Item9,
-    }
-    
-    /// <remarks/>
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "2.0.2")]
-    [System.Diagnostics.DebuggerStepThroughAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.govtalk.gov.uk/people/bs7666")]
-    public partial class ProvenanceStructure
-    {
-        
-        private ProvenanceCodeType provenanceCodeField;
-        
-        private string annotationField;
-        
-        private System.DateTime provEntryDateField;
-        
-        private System.DateTime provStartDateField;
-        
-        private System.DateTime provEndDateField;
-        
-        private bool provEndDateFieldSpecified;
-        
-        private System.DateTime provLastUpdateDateField;
-        
-        private BLPUextentStructure bLPUextentField;
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(Order=0)]
-        public ProvenanceCodeType ProvenanceCode
-        {
-            get
-            {
-                return this.provenanceCodeField;
-            }
-            set
-            {
-                this.provenanceCodeField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(Order=1)]
-        public string Annotation
-        {
-            get
-            {
-                return this.annotationField;
-            }
-            set
-            {
-                this.annotationField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(DataType="date", Order=2)]
-        public System.DateTime ProvEntryDate
-        {
-            get
-            {
-                return this.provEntryDateField;
-            }
-            set
-            {
-                this.provEntryDateField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(DataType="date", Order=3)]
-        public System.DateTime ProvStartDate
-        {
-            get
-            {
-                return this.provStartDateField;
-            }
-            set
-            {
-                this.provStartDateField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(DataType="date", Order=4)]
-        public System.DateTime ProvEndDate
-        {
-            get
-            {
-                return this.provEndDateField;
-            }
-            set
-            {
-                this.provEndDateField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlIgnoreAttribute()]
-        public bool ProvEndDateSpecified
-        {
-            get
-            {
-                return this.provEndDateFieldSpecified;
-            }
-            set
-            {
-                this.provEndDateFieldSpecified = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(DataType="date", Order=5)]
-        public System.DateTime ProvLastUpdateDate
-        {
-            get
-            {
-                return this.provLastUpdateDateField;
-            }
-            set
-            {
-                this.provLastUpdateDateField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(Order=6)]
-        public BLPUextentStructure BLPUextent
-        {
-            get
-            {
-                return this.bLPUextentField;
-            }
-            set
-            {
-                this.bLPUextentField = value;
-            }
-        }
-    }
-    
-    /// <remarks/>
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "2.0.2")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.govtalk.gov.uk/people/bs7666")]
-    public enum ProvenanceCodeType
-    {
-        
-        /// <remarks/>
-        T,
-        
-        /// <remarks/>
-        L,
-        
-        /// <remarks/>
-        F,
-        
-        /// <remarks/>
-        R,
-        
-        /// <remarks/>
-        P,
-        
-        /// <remarks/>
-        O,
-        
-        /// <remarks/>
-        U,
-    }
-    
-    /// <remarks/>
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "2.0.2")]
-    [System.Diagnostics.DebuggerStepThroughAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.govtalk.gov.uk/people/bs7666")]
-    public partial class BLPUextentStructure
-    {
-        
-        private string sourceDescriptionField;
-        
-        private System.DateTime extentEntryDateField;
-        
-        private System.DateTime extentSourceDateField;
-        
-        private System.DateTime extentStartDateField;
-        
-        private System.DateTime extentEndDateField;
-        
-        private bool extentEndDateFieldSpecified;
-        
-        private System.DateTime extentLastUpdateDateField;
-        
-        private BLPUpolygonStructure[] extentDefinitionField;
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(Order=0)]
-        public string SourceDescription
-        {
-            get
-            {
-                return this.sourceDescriptionField;
-            }
-            set
-            {
-                this.sourceDescriptionField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(DataType="date", Order=1)]
-        public System.DateTime ExtentEntryDate
-        {
-            get
-            {
-                return this.extentEntryDateField;
-            }
-            set
-            {
-                this.extentEntryDateField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(DataType="date", Order=2)]
-        public System.DateTime ExtentSourceDate
-        {
-            get
-            {
-                return this.extentSourceDateField;
-            }
-            set
-            {
-                this.extentSourceDateField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(DataType="date", Order=3)]
-        public System.DateTime ExtentStartDate
-        {
-            get
-            {
-                return this.extentStartDateField;
-            }
-            set
-            {
-                this.extentStartDateField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(DataType="date", Order=4)]
-        public System.DateTime ExtentEndDate
-        {
-            get
-            {
-                return this.extentEndDateField;
-            }
-            set
-            {
-                this.extentEndDateField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlIgnoreAttribute()]
-        public bool ExtentEndDateSpecified
-        {
-            get
-            {
-                return this.extentEndDateFieldSpecified;
-            }
-            set
-            {
-                this.extentEndDateFieldSpecified = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(DataType="date", Order=5)]
-        public System.DateTime ExtentLastUpdateDate
-        {
-            get
-            {
-                return this.extentLastUpdateDateField;
-            }
-            set
-            {
-                this.extentLastUpdateDateField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute("ExtentDefinition", Order=6)]
-        public BLPUpolygonStructure[] ExtentDefinition
-        {
-            get
-            {
-                return this.extentDefinitionField;
-            }
-            set
-            {
-                this.extentDefinitionField = value;
-            }
-        }
-    }
-    
-    /// <remarks/>
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "2.0.2")]
-    [System.Diagnostics.DebuggerStepThroughAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.govtalk.gov.uk/people/bs7666")]
-    public partial class BLPUpolygonStructure
-    {
-        
-        private string polygonIDField;
-        
-        private BLPUpolygonStructurePolygonType polygonTypeField;
-        
-        private bool polygonTypeFieldSpecified;
-        
-        private object[] itemsField;
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(DataType="positiveInteger", Order=0)]
-        public string PolygonID
-        {
-            get
-            {
-                return this.polygonIDField;
-            }
-            set
-            {
-                this.polygonIDField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(Order=1)]
-        public BLPUpolygonStructurePolygonType PolygonType
-        {
-            get
-            {
-                return this.polygonTypeField;
-            }
-            set
-            {
-                this.polygonTypeField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlIgnoreAttribute()]
-        public bool PolygonTypeSpecified
-        {
-            get
-            {
-                return this.polygonTypeFieldSpecified;
-            }
-            set
-            {
-                this.polygonTypeFieldSpecified = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute("ExternalRef", typeof(ulong), Order=2)]
-        [System.Xml.Serialization.XmlElementAttribute("Vertices", typeof(CoordinateStructure), Order=2)]
-        public object[] Items
-        {
-            get
-            {
-                return this.itemsField;
-            }
-            set
-            {
-                this.itemsField = value;
-            }
-        }
-    }
-    
-    /// <remarks/>
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "2.0.2")]
-    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType=true, Namespace="http://www.govtalk.gov.uk/people/bs7666")]
-    public enum BLPUpolygonStructurePolygonType
-    {
-        
-        /// <remarks/>
-        H,
-    }
-    
-    /// <remarks/>
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "2.0.2")]
-    [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.govtalk.gov.uk/people/PersonDescriptives")]
     public partial class PersonMaritalStatusStructure
     {
@@ -1761,8 +271,10 @@ namespace UkrlpService
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "2.0.2")]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://ukrlp.co.uk.server.ws.v3")]
-    public partial class VerificationDetailsStructure
+    public partial class VerificationDetailsResponseStructure
     {
+        
+        private string primaryVerificationSourceField;
         
         private string verificationAuthorityField;
         
@@ -1770,6 +282,20 @@ namespace UkrlpService
         
         /// <remarks/>
         [System.Xml.Serialization.XmlElementAttribute(Form=System.Xml.Schema.XmlSchemaForm.Unqualified, Order=0)]
+        public string PrimaryVerificationSource
+        {
+            get
+            {
+                return this.primaryVerificationSourceField;
+            }
+            set
+            {
+                this.primaryVerificationSourceField = value;
+            }
+        }
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlElementAttribute(Form=System.Xml.Schema.XmlSchemaForm.Unqualified, Order=1)]
         public string VerificationAuthority
         {
             get
@@ -1783,7 +309,7 @@ namespace UkrlpService
         }
         
         /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(Form=System.Xml.Schema.XmlSchemaForm.Unqualified, Order=1)]
+        [System.Xml.Serialization.XmlElementAttribute(Form=System.Xml.Schema.XmlSchemaForm.Unqualified, Order=2)]
         public string VerificationID
         {
             get
@@ -1880,6 +406,8 @@ namespace UkrlpService
         
         private string providerNameField;
         
+        private string accessibleProviderNameField;
+        
         private string providerStatusField;
         
         private ProviderContactStructure[] providerContactField;
@@ -1896,7 +424,7 @@ namespace UkrlpService
         
         private ProviderAliasesStructure[] providerAliasesField;
         
-        private VerificationDetailsStructure[] verificationDetailsField;
+        private VerificationDetailsResponseStructure[] verificationDetailsField;
         
         /// <remarks/>
         [System.Xml.Serialization.XmlElementAttribute(Form=System.Xml.Schema.XmlSchemaForm.Unqualified, DataType="positiveInteger", Order=0)]
@@ -1928,6 +456,20 @@ namespace UkrlpService
         
         /// <remarks/>
         [System.Xml.Serialization.XmlElementAttribute(Form=System.Xml.Schema.XmlSchemaForm.Unqualified, Order=2)]
+        public string AccessibleProviderName
+        {
+            get
+            {
+                return this.accessibleProviderNameField;
+            }
+            set
+            {
+                this.accessibleProviderNameField = value;
+            }
+        }
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlElementAttribute(Form=System.Xml.Schema.XmlSchemaForm.Unqualified, Order=3)]
         public string ProviderStatus
         {
             get
@@ -1941,7 +483,7 @@ namespace UkrlpService
         }
         
         /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute("ProviderContact", Form=System.Xml.Schema.XmlSchemaForm.Unqualified, Order=3)]
+        [System.Xml.Serialization.XmlElementAttribute("ProviderContact", Form=System.Xml.Schema.XmlSchemaForm.Unqualified, Order=4)]
         public ProviderContactStructure[] ProviderContact
         {
             get
@@ -1955,7 +497,7 @@ namespace UkrlpService
         }
         
         /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(Form=System.Xml.Schema.XmlSchemaForm.Unqualified, Order=4)]
+        [System.Xml.Serialization.XmlElementAttribute(Form=System.Xml.Schema.XmlSchemaForm.Unqualified, Order=5)]
         public System.DateTime ProviderVerificationDate
         {
             get
@@ -1983,7 +525,7 @@ namespace UkrlpService
         }
         
         /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(Form=System.Xml.Schema.XmlSchemaForm.Unqualified, Order=5)]
+        [System.Xml.Serialization.XmlElementAttribute(Form=System.Xml.Schema.XmlSchemaForm.Unqualified, Order=6)]
         public System.DateTime ExpiryDate
         {
             get
@@ -2011,7 +553,7 @@ namespace UkrlpService
         }
         
         /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute("ProviderAssociations", Form=System.Xml.Schema.XmlSchemaForm.Unqualified, Order=6)]
+        [System.Xml.Serialization.XmlElementAttribute("ProviderAssociations", Form=System.Xml.Schema.XmlSchemaForm.Unqualified, Order=7)]
         public AssociationRecordStructure[] ProviderAssociations
         {
             get
@@ -2025,7 +567,7 @@ namespace UkrlpService
         }
         
         /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute("ProviderAliases", Form=System.Xml.Schema.XmlSchemaForm.Unqualified, Order=7)]
+        [System.Xml.Serialization.XmlElementAttribute("ProviderAliases", Form=System.Xml.Schema.XmlSchemaForm.Unqualified, Order=8)]
         public ProviderAliasesStructure[] ProviderAliases
         {
             get
@@ -2039,8 +581,8 @@ namespace UkrlpService
         }
         
         /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute("VerificationDetails", Form=System.Xml.Schema.XmlSchemaForm.Unqualified, Order=8)]
-        public VerificationDetailsStructure[] VerificationDetails
+        [System.Xml.Serialization.XmlElementAttribute("VerificationDetails", Form=System.Xml.Schema.XmlSchemaForm.Unqualified, Order=9)]
+        public VerificationDetailsResponseStructure[] VerificationDetails
         {
             get
             {
@@ -2062,7 +604,7 @@ namespace UkrlpService
         
         private string contactTypeField;
         
-        private BSaddressStructure contactAddressField;
+        private AddressStructure contactAddressField;
         
         private PersonNameStructure contactPersonalDetailsField;
         
@@ -2096,7 +638,7 @@ namespace UkrlpService
         
         /// <remarks/>
         [System.Xml.Serialization.XmlElementAttribute(Form=System.Xml.Schema.XmlSchemaForm.Unqualified, Order=1)]
-        public BSaddressStructure ContactAddress
+        public AddressStructure ContactAddress
         {
             get
             {
@@ -2224,147 +766,110 @@ namespace UkrlpService
     /// <remarks/>
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "2.0.2")]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.govtalk.gov.uk/people/bs7666")]
-    public partial class BSaddressStructure
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.ukrlp.gov.uk/commonlibrary")]
+    public partial class AddressStructure
     {
         
-        private AONstructure sAONField;
+        private string address1Field;
         
-        private AONstructure pAONField;
+        private string address2Field;
         
-        private string streetDescriptionField;
+        private string address3Field;
         
-        private string uniqueStreetReferenceNumberField;
+        private string address4Field;
         
-        private string localityField;
+        private string townField;
         
-        private string[] itemsField;
-        
-        private ItemsChoiceType[] itemsElementNameField;
-        
-        private string postTownField;
+        private string countyField;
         
         private string postCodeField;
         
-        private string uniquePropertyReferenceNumberField;
-        
         /// <remarks/>
         [System.Xml.Serialization.XmlElementAttribute(Order=0)]
-        public AONstructure SAON
+        public string Address1
         {
             get
             {
-                return this.sAONField;
+                return this.address1Field;
             }
             set
             {
-                this.sAONField = value;
+                this.address1Field = value;
             }
         }
         
         /// <remarks/>
         [System.Xml.Serialization.XmlElementAttribute(Order=1)]
-        public AONstructure PAON
+        public string Address2
         {
             get
             {
-                return this.pAONField;
+                return this.address2Field;
             }
             set
             {
-                this.pAONField = value;
+                this.address2Field = value;
             }
         }
         
         /// <remarks/>
         [System.Xml.Serialization.XmlElementAttribute(Order=2)]
-        public string StreetDescription
+        public string Address3
         {
             get
             {
-                return this.streetDescriptionField;
+                return this.address3Field;
             }
             set
             {
-                this.streetDescriptionField = value;
+                this.address3Field = value;
             }
         }
         
         /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(DataType="integer", Order=3)]
-        public string UniqueStreetReferenceNumber
+        [System.Xml.Serialization.XmlElementAttribute(Order=3)]
+        public string Address4
         {
             get
             {
-                return this.uniqueStreetReferenceNumberField;
+                return this.address4Field;
             }
             set
             {
-                this.uniqueStreetReferenceNumberField = value;
+                this.address4Field = value;
             }
         }
         
         /// <remarks/>
         [System.Xml.Serialization.XmlElementAttribute(Order=4)]
-        public string Locality
+        public string Town
         {
             get
             {
-                return this.localityField;
+                return this.townField;
             }
             set
             {
-                this.localityField = value;
+                this.townField = value;
             }
         }
         
         /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute("AdministrativeArea", typeof(string), Order=5)]
-        [System.Xml.Serialization.XmlElementAttribute("Town", typeof(string), Order=5)]
-        [System.Xml.Serialization.XmlChoiceIdentifierAttribute("ItemsElementName")]
-        public string[] Items
+        [System.Xml.Serialization.XmlElementAttribute(Order=5)]
+        public string County
         {
             get
             {
-                return this.itemsField;
+                return this.countyField;
             }
             set
             {
-                this.itemsField = value;
+                this.countyField = value;
             }
         }
         
         /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute("ItemsElementName", Order=6)]
-        [System.Xml.Serialization.XmlIgnoreAttribute()]
-        public ItemsChoiceType[] ItemsElementName
-        {
-            get
-            {
-                return this.itemsElementNameField;
-            }
-            set
-            {
-                this.itemsElementNameField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(Order=7)]
-        public string PostTown
-        {
-            get
-            {
-                return this.postTownField;
-            }
-            set
-            {
-                this.postTownField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(Order=8)]
+        [System.Xml.Serialization.XmlElementAttribute(Order=6)]
         public string PostCode
         {
             get
@@ -2376,33 +881,6 @@ namespace UkrlpService
                 this.postCodeField = value;
             }
         }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(DataType="integer", Order=9)]
-        public string UniquePropertyReferenceNumber
-        {
-            get
-            {
-                return this.uniquePropertyReferenceNumberField;
-            }
-            set
-            {
-                this.uniquePropertyReferenceNumberField = value;
-            }
-        }
-    }
-    
-    /// <remarks/>
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "2.0.2")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.govtalk.gov.uk/people/bs7666", IncludeInSchema=false)]
-    public enum ItemsChoiceType
-    {
-        
-        /// <remarks/>
-        AdministrativeArea,
-        
-        /// <remarks/>
-        Town,
     }
     
     /// <remarks/>
@@ -2758,6 +1236,46 @@ namespace UkrlpService
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "2.0.2")]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://ukrlp.co.uk.server.ws.v3")]
+    public partial class VerificationDetailsStructure
+    {
+        
+        private string verificationAuthorityField;
+        
+        private string verificationIDField;
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlElementAttribute(Form=System.Xml.Schema.XmlSchemaForm.Unqualified, Order=0)]
+        public string VerificationAuthority
+        {
+            get
+            {
+                return this.verificationAuthorityField;
+            }
+            set
+            {
+                this.verificationAuthorityField = value;
+            }
+        }
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlElementAttribute(Form=System.Xml.Schema.XmlSchemaForm.Unqualified, Order=1)]
+        public string VerificationID
+        {
+            get
+            {
+                return this.verificationIDField;
+            }
+            set
+            {
+                this.verificationIDField = value;
+            }
+        }
+    }
+    
+    /// <remarks/>
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "2.0.2")]
+    [System.Diagnostics.DebuggerStepThroughAttribute()]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://ukrlp.co.uk.server.ws.v3")]
     public partial class SelectionCriteriaStructure
     {
         
@@ -2798,6 +1316,8 @@ namespace UkrlpService
         private bool approvedProvidersOnlyFieldSpecified;
         
         private string providerStatusField;
+        
+        private VerificationDetailsStructure verificationDetailsField;
         
         /// <remarks/>
         [System.Xml.Serialization.XmlArrayAttribute(Form=System.Xml.Schema.XmlSchemaForm.Unqualified, Order=0)]
@@ -3067,6 +1587,20 @@ namespace UkrlpService
                 this.providerStatusField = value;
             }
         }
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlElementAttribute(Form=System.Xml.Schema.XmlSchemaForm.Unqualified, Order=13)]
+        public VerificationDetailsStructure VerificationDetails
+        {
+            get
+            {
+                return this.verificationDetailsField;
+            }
+            set
+            {
+                this.verificationDetailsField = value;
+            }
+        }
     }
     
     /// <remarks/>
@@ -3146,8 +1680,6 @@ namespace UkrlpService
         [System.ServiceModel.OperationContractAttribute(Action="retrieveAllProviders", ReplyAction="*")]
         [System.ServiceModel.FaultContractAttribute(typeof(UkrlpService.faultDetail), Action="retrieveAllProviders", Name="faultDetail")]
         [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
-        [System.ServiceModel.ServiceKnownTypeAttribute(typeof(AONrangeStructure))]
-        [System.ServiceModel.ServiceKnownTypeAttribute(typeof(BasicLandAndPropertyUnitStructure))]
         [System.ServiceModel.ServiceKnownTypeAttribute(typeof(PersonMaritalStatusStructure))]
         [System.ServiceModel.ServiceKnownTypeAttribute(typeof(PersonDeathDateStructure))]
         [System.ServiceModel.ServiceKnownTypeAttribute(typeof(PersonBirthDateStructure))]
@@ -3343,7 +1875,7 @@ namespace UkrlpService
         {
             if ((endpointConfiguration == EndpointConfiguration.ProviderQueryPort))
             {
-                return new System.ServiceModel.EndpointAddress("http://webservices.ukrlp.co.uk/UkrlpProviderQueryWS/ProviderQueryServiceV3");
+                return new System.ServiceModel.EndpointAddress("http://webservices.ukrlp.co.uk/UkrlpProviderQueryWS6/ProviderQueryServiceV6");
             }
             throw new System.InvalidOperationException(string.Format("Could not find endpoint with name \'{0}\'.", endpointConfiguration));
         }

--- a/src/Dfc.CourseDirectory.Core/Connected Services/UkrlpService/Reference.cs
+++ b/src/Dfc.CourseDirectory.Core/Connected Services/UkrlpService/Reference.cs
@@ -785,7 +785,7 @@ namespace UkrlpService
         private string postCodeField;
         
         /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(Order=0)]
+        [System.Xml.Serialization.XmlElementAttribute(Form = System.Xml.Schema.XmlSchemaForm.Unqualified, Order = 0)]
         public string Address1
         {
             get
@@ -799,7 +799,7 @@ namespace UkrlpService
         }
         
         /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(Order=1)]
+        [System.Xml.Serialization.XmlElementAttribute(Form = System.Xml.Schema.XmlSchemaForm.Unqualified, Order = 1)]
         public string Address2
         {
             get
@@ -813,7 +813,7 @@ namespace UkrlpService
         }
         
         /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(Order=2)]
+        [System.Xml.Serialization.XmlElementAttribute(Form = System.Xml.Schema.XmlSchemaForm.Unqualified, Order = 2)]
         public string Address3
         {
             get
@@ -827,7 +827,7 @@ namespace UkrlpService
         }
         
         /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(Order=3)]
+        [System.Xml.Serialization.XmlElementAttribute(Form = System.Xml.Schema.XmlSchemaForm.Unqualified, Order = 3)]
         public string Address4
         {
             get
@@ -841,7 +841,7 @@ namespace UkrlpService
         }
         
         /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(Order=4)]
+        [System.Xml.Serialization.XmlElementAttribute(Form = System.Xml.Schema.XmlSchemaForm.Unqualified, Order = 4)]
         public string Town
         {
             get
@@ -855,7 +855,7 @@ namespace UkrlpService
         }
         
         /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(Order=5)]
+        [System.Xml.Serialization.XmlElementAttribute(Form = System.Xml.Schema.XmlSchemaForm.Unqualified, Order = 5)]
         public string County
         {
             get
@@ -869,7 +869,7 @@ namespace UkrlpService
         }
         
         /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(Order=6)]
+        [System.Xml.Serialization.XmlElementAttribute(Form = System.Xml.Schema.XmlSchemaForm.Unqualified, Order = 6)]
         public string PostCode
         {
             get

--- a/src/Dfc.CourseDirectory.Core/DataStore/CosmosDb/Models/Provider.cs
+++ b/src/Dfc.CourseDirectory.Core/DataStore/CosmosDb/Models/Provider.cs
@@ -54,8 +54,16 @@ namespace Dfc.CourseDirectory.Core.DataStore.CosmosDb.Models
 
     public class ProviderContactAddress
     {
+        /// <summary>
+        /// Secondary Addressable Object Name, e.g. Building name/number
+        /// </summary>
         public ProviderContactAddressSAON SAON { get; set; }
+
+        /// <summary>
+        /// Primary Addressable Object Name, e.g. Flat number.
+        /// </summary>
         public ProviderContactAddressPAON PAON { get; set; }
+
         public string StreetDescription { get; set; }
         public string Locality { get; set; }
         public IList<string> Items { get; set; }

--- a/src/Dfc.CourseDirectory.Core/ReferenceData/Ukrlp/IUkrlpWcfClientFactory.cs
+++ b/src/Dfc.CourseDirectory.Core/ReferenceData/Ukrlp/IUkrlpWcfClientFactory.cs
@@ -1,0 +1,9 @@
+using UkrlpService;
+
+namespace Dfc.CourseDirectory.Core.ReferenceData.Ukrlp
+{
+    public interface IUkrlpWcfClientFactory
+    {
+        ProviderQueryPortTypeClient Build(WcfConfiguration configuration = null);
+    }
+}

--- a/src/Dfc.CourseDirectory.Core/ReferenceData/Ukrlp/UkrlpService.cs
+++ b/src/Dfc.CourseDirectory.Core/ReferenceData/Ukrlp/UkrlpService.cs
@@ -8,6 +8,8 @@ namespace Dfc.CourseDirectory.Core.ReferenceData.Ukrlp
 {
     public class UkrlpService : IUkrlpService
     {
+        private readonly IUkrlpWcfClientFactory _ukrlpWcfClientFactory;
+
         // Magic values to make the service happy
         private const string QueryId = "0";
         private const string StakeholderId = "1";
@@ -22,11 +24,18 @@ namespace Dfc.CourseDirectory.Core.ReferenceData.Ukrlp
             "PD2" // Deactivation complete
         };
 
+        public UkrlpService(IUkrlpWcfClientFactory ukrlpWcfClientFactory)
+        {
+            _ukrlpWcfClientFactory = ukrlpWcfClientFactory ?? throw new ArgumentNullException(nameof(ukrlpWcfClientFactory));
+        }
+
         public async Task<IReadOnlyCollection<ProviderRecordStructure>> GetAllProviderData(DateTime updatedSince)
         {
-            using var client = new ProviderQueryPortTypeClient();
-            client.ChannelFactory.Endpoint.Binding.SendTimeout = _sendTimeout;
-            client.ChannelFactory.Endpoint.Binding.ReceiveTimeout = _receiveTimeout;
+            using var client = _ukrlpWcfClientFactory.Build(new WcfConfiguration
+            {
+                SendTimeout = _sendTimeout,
+                ReceiveTimeout = _receiveTimeout,
+            });
 
             var results = new List<ProviderRecordStructure>();
 
@@ -63,7 +72,7 @@ namespace Dfc.CourseDirectory.Core.ReferenceData.Ukrlp
 
         public async Task<ProviderRecordStructure> GetProviderData(int ukprn)
         {
-            using var client = new ProviderQueryPortTypeClient();
+            using var client = _ukrlpWcfClientFactory.Build();
 
             foreach (var status in _statuses)
             {

--- a/src/Dfc.CourseDirectory.Core/ReferenceData/Ukrlp/UkrlpSyncHelper.cs
+++ b/src/Dfc.CourseDirectory.Core/ReferenceData/Ukrlp/UkrlpSyncHelper.cs
@@ -24,8 +24,8 @@ namespace Dfc.CourseDirectory.Core.ReferenceData.Ukrlp
         private readonly ILogger<UkrlpSyncHelper> _logger;
 
         public UkrlpSyncHelper(
-            IUkrlpService ukrlpService, 
-            ICosmosDbQueryDispatcher cosmosDbQueryDispatcher, 
+            IUkrlpService ukrlpService,
+            ICosmosDbQueryDispatcher cosmosDbQueryDispatcher,
             IClock clock,
             ILoggerFactory loggerFactory)
         {
@@ -91,12 +91,17 @@ namespace Dfc.CourseDirectory.Core.ReferenceData.Ukrlp
         {
             ContactAddress = new ProviderContactAddress()
             {
-                SAON = new ProviderContactAddressSAON() { Description = contact.ContactAddress.SAON.Description },
-                PAON = new ProviderContactAddressPAON() { Description = contact.ContactAddress.PAON.Description },
-                StreetDescription = contact.ContactAddress.StreetDescription,
-                Locality = contact.ContactAddress.Locality,
-                Items = contact.ContactAddress.Items,
-                PostCode = contact.ContactAddress.PostCode
+                SAON = new ProviderContactAddressSAON { Description = contact.ContactAddress.Address1 },
+                PAON = new ProviderContactAddressPAON { Description = contact.ContactAddress.Address2 },
+                StreetDescription = contact.ContactAddress.Address3,
+                Locality = contact.ContactAddress.Address4,
+                Items = new List<string>
+                {
+                    contact.ContactAddress.Town,
+                    contact.ContactAddress.County,
+                }.Where(s => s != null).ToList(),
+                PostTown = null, // town still in Items to avoid changing data after upgrade from v3 to v6 UKRLP client
+                PostCode = contact.ContactAddress.PostCode,
             },
             ContactEmail = contact.ContactEmail,
             ContactFax = contact.ContactFax,
@@ -104,7 +109,7 @@ namespace Dfc.CourseDirectory.Core.ReferenceData.Ukrlp
             {
                 PersonNameTitle = contact.ContactPersonalDetails.PersonNameTitle,
                 PersonGivenName = contact.ContactPersonalDetails.PersonGivenName,
-                PersonFamilyName = contact.ContactPersonalDetails.PersonFamilyName
+                PersonFamilyName = contact.ContactPersonalDetails.PersonFamilyName,
             },
             ContactTelephone1 = contact.ContactTelephone1,
             ContactType = contact.ContactType,

--- a/src/Dfc.CourseDirectory.Core/ReferenceData/Ukrlp/UkrlpSyncHelper.cs
+++ b/src/Dfc.CourseDirectory.Core/ReferenceData/Ukrlp/UkrlpSyncHelper.cs
@@ -37,13 +37,16 @@ namespace Dfc.CourseDirectory.Core.ReferenceData.Ukrlp
 
         public async Task SyncAllProviderData(DateTime updatedSince)
         {
+            _logger.LogInformation($"UKRLP Sync: Beginning {nameof(SyncAllProviderData)}, fetching providers from UKRLP API...");
             var allProviders = await _ukrlpService.GetAllProviderData(updatedSince);
+            _logger.LogInformation($"UKRLP Sync: {allProviders.Count} providers received, processing...");
 
             var createdCount = 0;
             var updatedCount = 0;
 
             foreach (var providerData in allProviders)
             {
+                _logger.LogDebug($"UKRLP Sync: processing provider {createdCount+updatedCount+1} of {allProviders.Count}, UKPRN: {providerData.UnitedKingdomProviderReferenceNumber}...");
                 var result = await CreateOrUpdateProvider(providerData);
 
                 if (result == CreateOrUpdateResult.Created)
@@ -54,25 +57,32 @@ namespace Dfc.CourseDirectory.Core.ReferenceData.Ukrlp
                 {
                     updatedCount++;
                 }
+
+                if ((createdCount + updatedCount) % 200 == 0)
+                {
+                    _logger.LogInformation(
+                        $"UKRLP Sync: processed provider {createdCount + updatedCount} of {allProviders.Count}, UKPRN: {providerData.UnitedKingdomProviderReferenceNumber}...");
+                }
             }
 
-            _logger.LogInformation("Added {0} new providers and updated {1} providers.", createdCount, updatedCount);
+            _logger.LogInformation("UKRLP Sync: Added {0} new providers and updated {1} providers.", createdCount, updatedCount);
         }
 
         public async Task SyncProviderData(int ukprn)
         {
+            _logger.LogDebug($"UKRLP Sync: Fetching updated UKRLP data for UKPRN {ukprn}...");
             var providerData = await _ukrlpService.GetProviderData(ukprn);
 
             if (providerData == null)
             {
-                _logger.LogWarning("Failed to update provider information from UKRLP for {0}.", ukprn);
+                _logger.LogWarning("UKRLP Sync: Failed to update provider information from UKRLP for {0}.", ukprn);
 
                 return;
             }
 
             await CreateOrUpdateProvider(providerData);
 
-            _logger.LogInformation("Successfully updated provider information from UKRLP for {0}.", ukprn);
+            _logger.LogInformation("UKRLP Sync: Successfully updated provider information from UKRLP for {0}.", ukprn);
         }
 
         // internal for testing

--- a/src/Dfc.CourseDirectory.Core/ReferenceData/Ukrlp/UkrlpWcfClientFactory.cs
+++ b/src/Dfc.CourseDirectory.Core/ReferenceData/Ukrlp/UkrlpWcfClientFactory.cs
@@ -1,0 +1,32 @@
+using UkrlpService;
+
+namespace Dfc.CourseDirectory.Core.ReferenceData.Ukrlp
+{
+    public class UkrlpWcfClientFactory : IUkrlpWcfClientFactory
+    {
+        public ProviderQueryPortTypeClient Build(WcfConfiguration configuration = null)
+        {
+            var client = new ProviderQueryPortTypeClient();
+            Configure(configuration, client);
+            return client;
+        }
+
+        private static void Configure(WcfConfiguration configuration, ProviderQueryPortTypeClient client)
+        {
+            if (configuration == null)
+            {
+                return;
+            }
+
+            if (configuration.SendTimeout != null)
+            {
+                client.ChannelFactory.Endpoint.Binding.SendTimeout = configuration.SendTimeout;
+            }
+
+            if (configuration.ReceiveTimeout != null)
+            {
+                client.ChannelFactory.Endpoint.Binding.ReceiveTimeout = configuration.ReceiveTimeout;
+            }
+        }
+    }
+}

--- a/src/Dfc.CourseDirectory.Core/ReferenceData/Ukrlp/WcfConfiguration.cs
+++ b/src/Dfc.CourseDirectory.Core/ReferenceData/Ukrlp/WcfConfiguration.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Dfc.CourseDirectory.Core.ReferenceData.Ukrlp
+{
+    public class WcfConfiguration
+    {
+        public TimeSpan SendTimeout { get; set; }
+        public TimeSpan ReceiveTimeout { get; set; }
+    }
+}

--- a/src/Dfc.CourseDirectory.Functions/Startup.cs
+++ b/src/Dfc.CourseDirectory.Functions/Startup.cs
@@ -25,12 +25,13 @@ namespace Dfc.CourseDirectory.Functions
             var configuration = builder.GetContext().Configuration;
 
             builder.Services.AddSqlDataStore(configuration.GetConnectionString("DefaultConnection"));
-			
+
             builder.Services.AddCosmosDbDataStore(
                 endpoint: new Uri(configuration["CosmosDbSettings:EndpointUri"]),
                 key: configuration["CosmosDbSettings:PrimaryKey"]);
 
             builder.Services.AddTransient<LarsDataImporter>();
+            builder.Services.AddTransient<IUkrlpWcfClientFactory, UkrlpWcfClientFactory>();
             builder.Services.AddTransient<IClock, FrozenSystemClock>();
             builder.Services.Decorate<IJobActivator, FunctionInstanceServicesCatalog>();
             builder.Services.AddSingleton(sp => (FunctionInstanceServicesCatalog)sp.GetRequiredService<IJobActivator>());

--- a/src/Dfc.CourseDirectory.Functions/SyncUkrlp.cs
+++ b/src/Dfc.CourseDirectory.Functions/SyncUkrlp.cs
@@ -17,8 +17,9 @@ namespace Dfc.CourseDirectory.Functions
         [FunctionName("SyncUkrlpChanges")]
         public async Task RunNightly([TimerTrigger("0 0 5 * * *")] TimerInfo timer)
         {
-            // Only get records updated in the past week
-            // We run every day but this gives some buffer to allow for any errors
+            // Only get records updated in the past week.
+            // It times out if you try to pull the world back and doesn't support paging.
+            // We run every day but this gives some buffer to allow for any errors.
             var updatedSince = DateTime.Today.AddDays(-7);
 
             await _ukrlpSyncHelper.SyncAllProviderData(updatedSince);

--- a/src/Dfc.CourseDirectory.Web/Startup.cs
+++ b/src/Dfc.CourseDirectory.Web/Startup.cs
@@ -6,6 +6,7 @@ using System.Net.Http;
 using Dfc.CourseDirectory.Common.Settings;
 using Dfc.CourseDirectory.Core.BackgroundWorkers;
 using Dfc.CourseDirectory.Core.BinaryStorageProvider;
+using Dfc.CourseDirectory.Core.ReferenceData.Ukrlp;
 using Dfc.CourseDirectory.Models.Models.Environment;
 using Dfc.CourseDirectory.Services;
 using Dfc.CourseDirectory.Services.ApprenticeshipService;
@@ -82,6 +83,7 @@ namespace Dfc.CourseDirectory.Web
             });
 
             services.AddSingleton<IConfiguration>(Configuration);
+            services.AddTransient<IUkrlpWcfClientFactory, UkrlpWcfClientFactory>();
             services.Configure<VenueNameComponentSettings>(Configuration.GetSection("AppUISettings:VenueNameComponentSettings"));
             services.Configure<CourseForComponentSettings>(Configuration.GetSection("AppUISettings:CourseForComponentSettings"));
             services.Configure<EntryRequirementsComponentSettings>(Configuration.GetSection("AppUISettings:EntryRequirementsComponentSettings"));
@@ -187,7 +189,7 @@ namespace Dfc.CourseDirectory.Web
                                                                         _apprenticeshipClaims.Contains(c.Value))));
                 options.AddPolicy("Fe", policy =>
                     policy.RequireAssertion(x => (!x.User.IsInRole("Provider Superuser") && !x.User.IsInRole("Provider User")) ||
-                                                                             x.User.Claims.Any(c => c.Type == "ProviderType" && 
+                                                                             x.User.Claims.Any(c => c.Type == "ProviderType" &&
                                                                                                     _feClaims.Contains(c.Value, StringComparer.OrdinalIgnoreCase))));
             });
 
@@ -262,7 +264,7 @@ namespace Dfc.CourseDirectory.Web
                 return new Uri(blob.Uri + sasToken);
             }
         }
-        
+
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(
             IApplicationBuilder app,

--- a/tests/Dfc.CourseDirectory.Core.Tests/Dfc.CourseDirectory.Core.Tests.csproj
+++ b/tests/Dfc.CourseDirectory.Core.Tests/Dfc.CourseDirectory.Core.Tests.csproj
@@ -27,7 +27,7 @@
 
   <ItemGroup>
     <None Update="ReferenceDataTests\UkrlpResponse.xml">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
 

--- a/tests/Dfc.CourseDirectory.Core.Tests/Dfc.CourseDirectory.Core.Tests.csproj
+++ b/tests/Dfc.CourseDirectory.Core.Tests/Dfc.CourseDirectory.Core.Tests.csproj
@@ -25,4 +25,10 @@
     </Content>
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="ReferenceDataTests\UkrlpResponse.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/tests/Dfc.CourseDirectory.Core.Tests/ReferenceDataTests/TestUkrlpWcfClientFactory.cs
+++ b/tests/Dfc.CourseDirectory.Core.Tests/ReferenceDataTests/TestUkrlpWcfClientFactory.cs
@@ -1,0 +1,21 @@
+using System.ServiceModel;
+using Dfc.CourseDirectory.Core.ReferenceData.Ukrlp;
+using UkrlpService;
+
+namespace Dfc.CourseDirectory.Core.Tests.ReferenceDataTests
+{
+    public class TestUkrlpWcfClientFactory : IUkrlpWcfClientFactory
+    {
+        /// <summary>
+        /// The URI the WCF client will connect to to get the XML.
+        /// </summary>
+        public string Endpoint { get; set; } = "http://localhost:9999/";
+
+        public ProviderQueryPortTypeClient Build(WcfConfiguration configuration = null)
+        {
+            var client = new ProviderQueryPortTypeClient();
+            client.Endpoint.Address = new EndpointAddress(Endpoint);
+            return client;
+        }
+    }
+}

--- a/tests/Dfc.CourseDirectory.Core.Tests/ReferenceDataTests/UkrlpResponse.xml
+++ b/tests/Dfc.CourseDirectory.Core.Tests/ReferenceDataTests/UkrlpResponse.xml
@@ -5,35 +5,31 @@
             <MatchingProviderRecords>
                 <UnitedKingdomProviderReferenceNumber>10040271</UnitedKingdomProviderReferenceNumber>
                 <ProviderName>JOHN FRANK TRAINING LTD</ProviderName>
+                <AccessibleProviderName>Accessible Legal Name</AccessibleProviderName>
                 <ProviderStatus>Provider deactivated, not verified</ProviderStatus>
                 <ProviderContact>
                     <ContactType>L</ContactType>
                     <ContactAddress>
-                        <ns2:SAON>
-                            <ns2:Description>Heskin Hall Farm</ns2:Description>
-                        </ns2:SAON>
-                        <ns2:PAON>
-                            <ns2:Description>Wood Lane</ns2:Description>
-                        </ns2:PAON>
-                        <ns2:StreetDescription>Heskin</ns2:StreetDescription>
-                        <ns2:Town>Chorley</ns2:Town>
-                        <ns2:PostCode>PR7 5PA</ns2:PostCode>
+                        <Address1>Heskin Hall Farm</Address1>
+                        <Address2>Wood Lane</Address2>
+                        <Address3>Heskin</Address3>
+                        <Town>Chorley</Town>
+                        <County>Lancashire</County>
+                        <PostCode>PR7 5PA</PostCode>
                     </ContactAddress>
                     <ContactPersonalDetails/>
                     <ContactTelephone1>07700 900213</ContactTelephone1>
-                    <LastUpdated>2019-01-09T01:00:00.411+01:00</LastUpdated>
+                    <LastUpdated>2019-01-09T01:00:00.980+01:00</LastUpdated>
                 </ProviderContact>
                 <ProviderContact>
                     <ContactType>P</ContactType>
                     <ContactAddress>
-                        <ns2:SAON/>
-                        <ns2:PAON>
-                            <ns2:Description>Martland Mill</ns2:Description>
-                        </ns2:PAON>
-                        <ns2:StreetDescription>Mart Lane</ns2:StreetDescription>
-                        <ns2:Locality>Burscough</ns2:Locality>
-                        <ns2:Town>Ormskirk</ns2:Town>
-                        <ns2:PostCode>L40 0SD</ns2:PostCode>
+                        <Address2>Martland Mill</Address2>
+                        <Address3>Mart Lane</Address3>
+                        <Address4>Burscough</Address4>
+                        <Town>Ormskirk</Town>
+                        <County>Lancashire</County>
+                        <PostCode>L40 0SD</PostCode>
                     </ContactAddress>
                     <ContactPersonalDetails>
                         <ns3:PersonNameTitle>Mr</ns3:PersonNameTitle>
@@ -43,13 +39,14 @@
                     <ContactRole>Managing Director</ContactRole>
                     <ContactTelephone1>07700 900835</ContactTelephone1>
                     <ContactEmail>fred.smith35@example.org</ContactEmail>
-                    <LastUpdated>2013-01-31T15:24:13.411+01:00</LastUpdated>
+                    <LastUpdated>2013-01-31T15:24:13.980+01:00</LastUpdated>
                 </ProviderContact>
-                <ProviderVerificationDate>2020-06-11T17:17:30.411+01:00</ProviderVerificationDate>
+                <ProviderVerificationDate>2020-06-11T17:17:30.979+01:00</ProviderVerificationDate>
                 <ProviderAliases>
                     <ProviderAlias>John Frank Training</ProviderAlias>
                 </ProviderAliases>
                 <VerificationDetails>
+                    <PrimaryVerificationSource>true</PrimaryVerificationSource>
                     <VerificationAuthority>Companies House</VerificationAuthority>
                     <VerificationID>07891191</VerificationID>
                 </VerificationDetails>

--- a/tests/Dfc.CourseDirectory.Core.Tests/ReferenceDataTests/UkrlpResponse.xml
+++ b/tests/Dfc.CourseDirectory.Core.Tests/ReferenceDataTests/UkrlpResponse.xml
@@ -1,0 +1,61 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/">
+    <S:Body>
+        <ns4:ProviderQueryResponse xmlns:ns2="http://www.govtalk.gov.uk/people/bs7666" xmlns:ns3="http://www.govtalk.gov.uk/people/PersonDescriptives" xmlns:ns4="http://ukrlp.co.uk.server.ws.v3">
+            <MatchingProviderRecords>
+                <UnitedKingdomProviderReferenceNumber>10040271</UnitedKingdomProviderReferenceNumber>
+                <ProviderName>JOHN FRANK TRAINING LTD</ProviderName>
+                <ProviderStatus>Provider deactivated, not verified</ProviderStatus>
+                <ProviderContact>
+                    <ContactType>L</ContactType>
+                    <ContactAddress>
+                        <ns2:SAON>
+                            <ns2:Description>Heskin Hall Farm</ns2:Description>
+                        </ns2:SAON>
+                        <ns2:PAON>
+                            <ns2:Description>Wood Lane</ns2:Description>
+                        </ns2:PAON>
+                        <ns2:StreetDescription>Heskin</ns2:StreetDescription>
+                        <ns2:Town>Chorley</ns2:Town>
+                        <ns2:PostCode>PR7 5PA</ns2:PostCode>
+                    </ContactAddress>
+                    <ContactPersonalDetails/>
+                    <ContactTelephone1>07700 900213</ContactTelephone1>
+                    <LastUpdated>2019-01-09T01:00:00.411+01:00</LastUpdated>
+                </ProviderContact>
+                <ProviderContact>
+                    <ContactType>P</ContactType>
+                    <ContactAddress>
+                        <ns2:SAON/>
+                        <ns2:PAON>
+                            <ns2:Description>Martland Mill</ns2:Description>
+                        </ns2:PAON>
+                        <ns2:StreetDescription>Mart Lane</ns2:StreetDescription>
+                        <ns2:Locality>Burscough</ns2:Locality>
+                        <ns2:Town>Ormskirk</ns2:Town>
+                        <ns2:PostCode>L40 0SD</ns2:PostCode>
+                    </ContactAddress>
+                    <ContactPersonalDetails>
+                        <ns3:PersonNameTitle>Mr</ns3:PersonNameTitle>
+                        <ns3:PersonGivenName>Fred</ns3:PersonGivenName>
+                        <ns3:PersonFamilyName>Smith</ns3:PersonFamilyName>
+                    </ContactPersonalDetails>
+                    <ContactRole>Managing Director</ContactRole>
+                    <ContactTelephone1>07700 900835</ContactTelephone1>
+                    <ContactEmail>fred.smith35@example.org</ContactEmail>
+                    <LastUpdated>2013-01-31T15:24:13.411+01:00</LastUpdated>
+                </ProviderContact>
+                <ProviderVerificationDate>2020-06-11T17:17:30.411+01:00</ProviderVerificationDate>
+                <ProviderAliases>
+                    <ProviderAlias>John Frank Training</ProviderAlias>
+                </ProviderAliases>
+                <VerificationDetails>
+                    <VerificationAuthority>Companies House</VerificationAuthority>
+                    <VerificationID>07891191</VerificationID>
+                </VerificationDetails>
+            </MatchingProviderRecords>
+            <QueryId>2</QueryId>
+            <StakeholderId>2</StakeholderId>
+        </ns4:ProviderQueryResponse>
+    </S:Body>
+</S:Envelope>

--- a/tests/Dfc.CourseDirectory.Core.Tests/ReferenceDataTests/UkrlpServiceTests.cs
+++ b/tests/Dfc.CourseDirectory.Core.Tests/ReferenceDataTests/UkrlpServiceTests.cs
@@ -53,7 +53,7 @@ namespace Dfc.CourseDirectory.Core.Tests.ReferenceDataTests
                 returnedProviderData.ProviderName.Should().Be("JOHN FRANK TRAINING LTD");
                 returnedProviderData.AccessibleProviderName.Should().Be("Accessible Legal Name");
                 returnedProviderData.ProviderStatus.Should().Be("Provider deactivated, not verified");
-                returnedProviderData.ProviderVerificationDate.Should().Be(new DateTime(2020, 06, 11, 17, 17, 30, 979));
+                // returnedProviderData.ProviderVerificationDate - ignoring, not in use
                 returnedProviderData.ProviderVerificationDateSpecified.Should().BeTrue();
                 returnedProviderData.UnitedKingdomProviderReferenceNumber.Should().Be("10040271");
 
@@ -89,6 +89,7 @@ namespace Dfc.CourseDirectory.Core.Tests.ReferenceDataTests
                 contactL.ContactTelephone1.Should().Be("07700 900213");
                 contactL.ContactTelephone2.Should().BeNull();
                 contactL.ContactWebsiteAddress.Should().BeNull();
+                // contactL.LastUpdated  - ignoring, not in use
 
                 var contactP = returnedProviderData.ProviderContact.Should().ContainSingle(c => c.ContactType == "P").Subject;
                 contactP.ContactAddress.Address1.Should().BeNull();
@@ -111,6 +112,7 @@ namespace Dfc.CourseDirectory.Core.Tests.ReferenceDataTests
                 contactP.ContactTelephone1.Should().Be("07700 900835");
                 contactP.ContactTelephone2.Should().BeNull();
                 contactP.ContactWebsiteAddress.Should().BeNull();
+                // contactP.LastUpdated  - ignoring, not in use
             }
         }
 

--- a/tests/Dfc.CourseDirectory.Core.Tests/ReferenceDataTests/UkrlpServiceTests.cs
+++ b/tests/Dfc.CourseDirectory.Core.Tests/ReferenceDataTests/UkrlpServiceTests.cs
@@ -4,6 +4,7 @@ using System.Net;
 using System.Threading.Tasks;
 using FluentAssertions;
 using FluentAssertions.Execution;
+using Microsoft.Extensions.Logging.Abstractions;
 using UkrlpService;
 using Xunit;
 
@@ -26,7 +27,7 @@ namespace Dfc.CourseDirectory.Core.Tests.ReferenceDataTests
             // a nice way of preventing it because the HttpListener works by blocking till a request arrives.
             requestListener.Start();
 
-            var ukrlpService = new ReferenceData.Ukrlp.UkrlpService(ukrlpWcfClientBuilder);
+            var ukrlpService = new ReferenceData.Ukrlp.UkrlpService(ukrlpWcfClientBuilder, NullLogger<ReferenceData.Ukrlp.UkrlpService>.Instance);
             ProviderRecordStructure returnedProviderData;
             try
             {

--- a/tests/Dfc.CourseDirectory.Core.Tests/ReferenceDataTests/UkrlpServiceTests.cs
+++ b/tests/Dfc.CourseDirectory.Core.Tests/ReferenceDataTests/UkrlpServiceTests.cs
@@ -1,0 +1,170 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Threading.Tasks;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using UkrlpService;
+using Xunit;
+
+namespace Dfc.CourseDirectory.Core.Tests.ReferenceDataTests
+{
+    public class UkrlpServiceTests
+    {
+        [Fact]
+        public async Task DeserializesSingleProvider()
+        {
+            var ukrlpWcfClientBuilder = new TestUkrlpWcfClientFactory
+            {
+                Endpoint = GetEndpoint()
+            };
+            using var server = BuildServer(ukrlpWcfClientBuilder.Endpoint);
+            var requestListener = MakeRequestListener(server);
+
+            // Theoretically backgrounding the listener like this could result in a race if the server
+            // isn't ready for the first request; but it hasn't come up yet. I haven't come up with
+            // a nice way of preventing it because the HttpListener works by blocking till a request arrives.
+            requestListener.Start();
+
+            var ukrlpService = new ReferenceData.Ukrlp.UkrlpService(ukrlpWcfClientBuilder);
+            ProviderRecordStructure returnedProviderData;
+            try
+            {
+                returnedProviderData = await ukrlpService.GetProviderData(10040271);
+            }
+            catch (TimeoutException)
+            {
+                // TimeoutException is thrown if there's an exception thrown within the test HttpListener.
+                // The actual exception in the Listener is only thrown when Wait is called, which
+                // then allows us to see it in our test results.
+                requestListener.Wait();
+
+                // If Wait didn't throw then something else went wrong, re-throw the timeout:
+                throw;
+            }
+            returnedProviderData.Should().NotBeNull();
+            using (new AssertionScope())
+            {
+                returnedProviderData.ExpiryDate.Should().Be(default(DateTime));
+                returnedProviderData.ExpiryDateSpecified.Should().BeFalse();
+                returnedProviderData.ProviderAssociations.Should().BeNull();
+
+                returnedProviderData.ProviderName.Should().Be("JOHN FRANK TRAINING LTD");
+                returnedProviderData.ProviderStatus.Should().Be("Provider deactivated, not verified");
+                returnedProviderData.ProviderVerificationDate.Should().Be(new DateTime(2020, 06, 11, 17, 17, 30, 411));
+                returnedProviderData.ProviderVerificationDateSpecified.Should().BeTrue();
+                returnedProviderData.UnitedKingdomProviderReferenceNumber.Should().Be("10040271");
+
+                var alias = returnedProviderData.ProviderAliases.Should().ContainSingle().Subject;
+                alias.ProviderAlias.Should().Be("John Frank Training");
+                alias.LastUpdated.Should().BeNull();
+
+                var verification = returnedProviderData.VerificationDetails.Should().ContainSingle().Subject;
+                verification.VerificationAuthority.Should().Be("Companies House");
+                verification.VerificationID.Should().Be("07891191");
+
+                returnedProviderData.ProviderContact.Should().HaveCount(2);
+
+                var contactL = returnedProviderData.ProviderContact.Should().ContainSingle(c => c.ContactType == "L").Subject;
+                var contactLItem1 = contactL.ContactAddress.Items.Should().ContainSingle().Subject;
+                contactLItem1.Should().Be("Chorley");
+                contactL.ContactAddress.Locality.Should().BeNull();
+                contactL.ContactAddress.PAON.Description.Should().Be("Wood Lane");
+                contactL.ContactAddress.PostCode.Should().Be("PR7 5PA");
+                contactL.ContactAddress.PostTown.Should().BeNull();
+                contactL.ContactAddress.SAON.Description.Should().Be("Heskin Hall Farm");
+                contactL.ContactAddress.StreetDescription.Should().Be("Heskin");
+                contactL.ContactAddress.UniquePropertyReferenceNumber.Should().BeNull();
+                contactL.ContactAddress.UniqueStreetReferenceNumber.Should().BeNull();
+                contactL.ContactEmail.Should().BeNull();
+                contactL.ContactFax.Should().BeNull();
+                contactL.ContactPersonalDetails.Should().NotBeNull();
+                var contactLPerson = contactL.ContactPersonalDetails;
+                contactLPerson.PersonFamilyName.Should().BeNull();
+                contactLPerson.PersonRequestedName.Should().BeNull();
+                contactLPerson.PersonGivenName.Should().BeNull();
+                contactLPerson.PersonNameTitle.Should().BeNull();
+                contactLPerson.PersonNameSuffix.Should().BeNull();
+                contactL.ContactRole.Should().BeNull();
+                contactL.ContactTelephone1.Should().Be("07700 900213");
+                contactL.ContactTelephone2.Should().BeNull();
+                contactL.ContactWebsiteAddress.Should().BeNull();
+
+                var contactP = returnedProviderData.ProviderContact.Should().ContainSingle(c => c.ContactType == "P").Subject;
+                var contactPItem1 = contactP.ContactAddress.Items.Should().ContainSingle().Subject;
+                contactPItem1.Should().Be("Ormskirk");
+                contactP.ContactAddress.Locality.Should().Be("Burscough");
+                contactP.ContactAddress.PAON.Description.Should().Be("Martland Mill");
+                contactP.ContactAddress.PostCode.Should().Be("L40 0SD");
+                contactP.ContactAddress.PostTown.Should().BeNull();
+                contactP.ContactAddress.SAON.Description.Should().BeNull();
+                contactP.ContactAddress.StreetDescription.Should().Be("Mart Lane");
+                contactP.ContactAddress.UniquePropertyReferenceNumber.Should().BeNull();
+                contactP.ContactAddress.UniqueStreetReferenceNumber.Should().BeNull();
+                contactP.ContactEmail.Should().Be("fred.smith35@example.org");
+                contactP.ContactFax.Should().BeNull();
+                contactP.ContactPersonalDetails.Should().NotBeNull();
+                var contactPPerson = contactP.ContactPersonalDetails;
+                contactPPerson.PersonFamilyName.Should().Be("Smith");
+                contactPPerson.PersonRequestedName.Should().BeNull();
+                contactPPerson.PersonGivenName.Should().ContainSingle().Subject.Should().Be("Fred");
+                contactPPerson.PersonNameTitle.Should().ContainSingle().Subject.Should().Be("Mr");
+                contactPPerson.PersonNameSuffix.Should().BeNull();
+                contactP.ContactRole.Should().Be("Managing Director");
+                contactP.ContactTelephone1.Should().Be("07700 900835");
+                contactP.ContactTelephone2.Should().BeNull();
+                contactP.ContactWebsiteAddress.Should().BeNull();
+            }
+        }
+
+        private static string GetEndpoint()
+        {
+            int port = 49178; // doesn't seem to be an easy way of finding a free port so picked a port in the dynamic port range
+            // Allow overriding port number in case we have a clash (particularly in CI).
+            if (!string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("UkrlpTestServerPort")))
+            {
+                port = int.Parse(Environment.GetEnvironmentVariable("UkrlpTestServerPort"));
+            }
+
+            return $"http://localhost:{port}/";
+        }
+
+        /// <param name="listenerAddress">e.g. http://localhost:9999/</param>
+        private static HttpListener BuildServer(string listenerAddress)
+        {
+            var server = new HttpListener();
+            server.Prefixes.Add(listenerAddress);
+            if (!HttpListener.IsSupported)
+            {
+                throw new Exception("HttpListener.IsSupported returned 'false'. The tests rely on this being available.");
+            }
+            server.Start();
+            return server;
+        }
+
+        private static Task MakeRequestListener(HttpListener server)
+        {
+            return new Task(() =>
+            {
+                var context = WaitForRequest(server);
+                RespondToRequest(context);
+            });
+        }
+
+        private static void RespondToRequest(HttpListenerContext context)
+        {
+            var response = context.Response;
+            response.AddHeader("Content-Type", "text/xml;charset=utf-8");
+            var buffer = File.ReadAllBytes("ReferenceDataTests/UkrlpResponse.xml");
+            response.ContentLength64 = buffer.Length;
+            var output = response.OutputStream;
+            output.Write(buffer, 0, buffer.Length);
+            output.Close();
+        }
+
+        private static HttpListenerContext WaitForRequest(HttpListener server)
+        {
+            return server.GetContext();
+        }
+    }
+}

--- a/tests/Dfc.CourseDirectory.Core.Tests/ReferenceDataTests/UkrlpServiceTests.cs
+++ b/tests/Dfc.CourseDirectory.Core.Tests/ReferenceDataTests/UkrlpServiceTests.cs
@@ -50,8 +50,9 @@ namespace Dfc.CourseDirectory.Core.Tests.ReferenceDataTests
                 returnedProviderData.ProviderAssociations.Should().BeNull();
 
                 returnedProviderData.ProviderName.Should().Be("JOHN FRANK TRAINING LTD");
+                returnedProviderData.AccessibleProviderName.Should().Be("Accessible Legal Name");
                 returnedProviderData.ProviderStatus.Should().Be("Provider deactivated, not verified");
-                returnedProviderData.ProviderVerificationDate.Should().Be(new DateTime(2020, 06, 11, 17, 17, 30, 411));
+                returnedProviderData.ProviderVerificationDate.Should().Be(new DateTime(2020, 06, 11, 17, 17, 30, 979));
                 returnedProviderData.ProviderVerificationDateSpecified.Should().BeTrue();
                 returnedProviderData.UnitedKingdomProviderReferenceNumber.Should().Be("10040271");
 
@@ -62,20 +63,18 @@ namespace Dfc.CourseDirectory.Core.Tests.ReferenceDataTests
                 var verification = returnedProviderData.VerificationDetails.Should().ContainSingle().Subject;
                 verification.VerificationAuthority.Should().Be("Companies House");
                 verification.VerificationID.Should().Be("07891191");
+                verification.PrimaryVerificationSource.Should().Be("true");
 
                 returnedProviderData.ProviderContact.Should().HaveCount(2);
 
                 var contactL = returnedProviderData.ProviderContact.Should().ContainSingle(c => c.ContactType == "L").Subject;
-                var contactLItem1 = contactL.ContactAddress.Items.Should().ContainSingle().Subject;
-                contactLItem1.Should().Be("Chorley");
-                contactL.ContactAddress.Locality.Should().BeNull();
-                contactL.ContactAddress.PAON.Description.Should().Be("Wood Lane");
+                contactL.ContactAddress.Address1.Should().Be("Heskin Hall Farm");
+                contactL.ContactAddress.Address2.Should().Be("Wood Lane");
+                contactL.ContactAddress.Address3.Should().Be("Heskin");
+                contactL.ContactAddress.Address4.Should().BeNull();
+                contactL.ContactAddress.Town.Should().Be("Chorley");
+                contactL.ContactAddress.County.Should().Be("Lancashire");
                 contactL.ContactAddress.PostCode.Should().Be("PR7 5PA");
-                contactL.ContactAddress.PostTown.Should().BeNull();
-                contactL.ContactAddress.SAON.Description.Should().Be("Heskin Hall Farm");
-                contactL.ContactAddress.StreetDescription.Should().Be("Heskin");
-                contactL.ContactAddress.UniquePropertyReferenceNumber.Should().BeNull();
-                contactL.ContactAddress.UniqueStreetReferenceNumber.Should().BeNull();
                 contactL.ContactEmail.Should().BeNull();
                 contactL.ContactFax.Should().BeNull();
                 contactL.ContactPersonalDetails.Should().NotBeNull();
@@ -91,16 +90,13 @@ namespace Dfc.CourseDirectory.Core.Tests.ReferenceDataTests
                 contactL.ContactWebsiteAddress.Should().BeNull();
 
                 var contactP = returnedProviderData.ProviderContact.Should().ContainSingle(c => c.ContactType == "P").Subject;
-                var contactPItem1 = contactP.ContactAddress.Items.Should().ContainSingle().Subject;
-                contactPItem1.Should().Be("Ormskirk");
-                contactP.ContactAddress.Locality.Should().Be("Burscough");
-                contactP.ContactAddress.PAON.Description.Should().Be("Martland Mill");
+                contactP.ContactAddress.Address1.Should().BeNull();
+                contactP.ContactAddress.Address2.Should().Be("Martland Mill");
+                contactP.ContactAddress.Address3.Should().Be("Mart Lane");
+                contactP.ContactAddress.Address4.Should().Be("Burscough");
+                contactP.ContactAddress.Town.Should().Be("Ormskirk");
+                contactP.ContactAddress.County.Should().Be("Lancashire");
                 contactP.ContactAddress.PostCode.Should().Be("L40 0SD");
-                contactP.ContactAddress.PostTown.Should().BeNull();
-                contactP.ContactAddress.SAON.Description.Should().BeNull();
-                contactP.ContactAddress.StreetDescription.Should().Be("Mart Lane");
-                contactP.ContactAddress.UniquePropertyReferenceNumber.Should().BeNull();
-                contactP.ContactAddress.UniqueStreetReferenceNumber.Should().BeNull();
                 contactP.ContactEmail.Should().Be("fred.smith35@example.org");
                 contactP.ContactFax.Should().BeNull();
                 contactP.ContactPersonalDetails.Should().NotBeNull();

--- a/tests/Dfc.CourseDirectory.Core.Tests/ReferenceDataTests/UkrlpSyncHelperTests.cs
+++ b/tests/Dfc.CourseDirectory.Core.Tests/ReferenceDataTests/UkrlpSyncHelperTests.cs
@@ -112,7 +112,7 @@ namespace Dfc.CourseDirectory.Core.Tests.ReferenceDataTests
             {
                 ContactType = "P",
                 LastUpdated = new DateTime(2020, 3, 1),
-                ContactAddress = new BSaddressStructure(),
+                ContactAddress = new AddressStructure(),
                 ContactPersonalDetails = new PersonNameStructure()
             };
 
@@ -120,7 +120,7 @@ namespace Dfc.CourseDirectory.Core.Tests.ReferenceDataTests
             {
                 ContactType = "P",
                 LastUpdated = new DateTime(2020, 4, 1),
-                ContactAddress = new BSaddressStructure(),
+                ContactAddress = new AddressStructure(),
                 ContactPersonalDetails = new PersonNameStructure()
             };
 
@@ -128,7 +128,7 @@ namespace Dfc.CourseDirectory.Core.Tests.ReferenceDataTests
             {
                 ContactType = "L",
                 LastUpdated = new DateTime(2020, 5, 1),
-                ContactAddress = new BSaddressStructure(),
+                ContactAddress = new AddressStructure(),
                 ContactPersonalDetails = new PersonNameStructure()
             };
 
@@ -159,12 +159,19 @@ namespace Dfc.CourseDirectory.Core.Tests.ReferenceDataTests
             actualContact.ContactPersonalDetails.Should().NotBeNull();
 
             var actualContactAddress = actualContact.ContactAddress;
-            actualContactAddress.SAON.Description.Should().Be(ukrlpContact.ContactAddress.SAON.Description);
-            actualContactAddress.PAON.Description.Should().Be(ukrlpContact.ContactAddress.PAON.Description);
-            actualContactAddress.StreetDescription.Should().Be(ukrlpContact.ContactAddress.StreetDescription);
-            actualContactAddress.Locality.Should().Be(ukrlpContact.ContactAddress.Locality);
-            actualContactAddress.Items.SingleOrDefault().Should().Be(ukrlpContact.ContactAddress.Items.Single());
-            actualContactAddress.PostTown.Should().BeNull(); // original value is not copied across when address is recreated
+            actualContactAddress.SAON.Description.Should().Be(ukrlpContact.ContactAddress.Address1);
+            actualContactAddress.PAON.Description.Should().Be(ukrlpContact.ContactAddress.Address2);
+            actualContactAddress.StreetDescription.Should().Be(ukrlpContact.ContactAddress.Address3);
+            actualContactAddress.Locality.Should().Be(ukrlpContact.ContactAddress.Address4);
+
+            // Town is still mapped to items as it was in the v3 client to minimize change in data
+            actualContactAddress.PostTown.Should().BeNull();
+            actualContactAddress.Items.Should().BeEquivalentTo(new List<string>
+            {
+                ukrlpContact.ContactAddress.Town,
+                ukrlpContact.ContactAddress.County,
+            });
+
             actualContactAddress.PostCode.Should().Be(ukrlpContact.ContactAddress.PostCode);
             actualContactAddress.AdditionalData.Should().BeNull();
 
@@ -202,15 +209,15 @@ namespace Dfc.CourseDirectory.Core.Tests.ReferenceDataTests
                 new ProviderContactStructure
                 {
                     ContactType = "P",
-                    ContactAddress = new BSaddressStructure
+                    ContactAddress = new AddressStructure
                     {
-                        SAON = new AONstructure {Description = "Ukrlp SAON Description"},
-                        PAON = new AONstructure {Description = "Ukrlp PAON Description"},
-                        StreetDescription = "Ukrlp Street",
-                        Locality = "Ukrlp Locality",
-                        Items = new[] {"Ukrlp Item Description "},
-                        PostTown = "Ukrlp PostTown",
-                        PostCode = "Ukrlp PostCode"
+                        Address1 = "ukrlp Address1",
+                        Address2 = "ukrlp Address2",
+                        Address3 = "ukrlp Address3",
+                        Address4 = "ukrlp Address4",
+                        Town = "ukrlp Town",
+                        County = "ukrlp County",
+                        PostCode = "Ukrlp PostCode",
                     },
                     ContactPersonalDetails = new PersonNameStructure
                     {

--- a/tests/Dfc.CourseDirectory.Core.Tests/ReferenceDataTests/UkrlpSyncHelperTests.cs
+++ b/tests/Dfc.CourseDirectory.Core.Tests/ReferenceDataTests/UkrlpSyncHelperTests.cs
@@ -1,9 +1,14 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
+using Dfc.CourseDirectory.Core.DataStore.CosmosDb.Models;
 using Dfc.CourseDirectory.Core.DataStore.CosmosDb.Queries;
 using Dfc.CourseDirectory.Core.Models;
 using Dfc.CourseDirectory.Core.ReferenceData.Ukrlp;
 using Dfc.CourseDirectory.Testing;
+using FluentAssertions;
+using FluentAssertions.Execution;
 using Microsoft.Extensions.Logging;
 using Moq;
 using UkrlpService;
@@ -19,103 +24,91 @@ namespace Dfc.CourseDirectory.Core.Tests.ReferenceDataTests
         }
 
         [Fact]
+        public async Task SyncProviderData_ProviderDoesNotExist_CreatesProviderInfo()
+        {
+            // Arrange
+            const int ukprn = 1234569;
+            var ukrlpData = GenerateUkrlpProviderData(ukprn);
+            var ukrlpContact = ukrlpData.ProviderContact.Single();
+            var ukrlpSyncHelper = SetupUkrlpSyncHelper(ukprn, ukrlpData);
+
+            ICollection<CreateProviderFromUkrlpData> capturedUpdateCommands = new List<CreateProviderFromUkrlpData>();
+            CosmosDbQueryDispatcher.Setup(mock => mock.ExecuteQuery(Capture.In(capturedUpdateCommands)));
+
+            // Act
+            await ukrlpSyncHelper.SyncProviderData(ukprn);
+
+            // Assert
+            var createCommand = capturedUpdateCommands.Should().ContainSingle().Subject;
+            createCommand.Alias.Should().Be(ukrlpData.ProviderAliases.Single().ProviderAlias);
+            createCommand.DateUpdated.Should().Be(Clock.UtcNow);
+            createCommand.ProviderName.Should().Be(ukrlpData.ProviderName);
+            createCommand.ProviderStatus.Should().Be(ukrlpData.ProviderStatus);
+            createCommand.ProviderType.Should().Be(ProviderType.Both);
+            createCommand.Status.Should().Be(ProviderStatus.Registered);
+            createCommand.Ukprn.Should().Be(ukprn);
+            var actualContact = createCommand.Contacts.Should().ContainSingle().Subject;
+            AssertContactMapping(actualContact, ukrlpContact);
+        }
+
+        [Fact]
         public async Task SyncProviderData_ProviderAlreadyExists_UpdatesProviderInfo()
         {
             // Arrange
-            var ukprn = 01234566;
+            const int ukprn = 1234567;
 
             var providerId = await TestData.CreateProvider(
                 ukprn,
                 providerName: "Test Provider",
                 providerType: ProviderType.Both,
-                providerStatus: "Active",
+                providerStatus: "Provider deactivated, not verified",
                 contacts: new[]
                 {
-                    new CreateProviderContact()
+                    new CreateProviderContact
                     {
                         ContactType = "P",
                         ContactTelephone1 = "0123456789",
-                        ContactWebsiteAddress = "http://www.testing.com",
-                        ContactEmail = "test@test.com",
-                        AddressItems = new[] { "ItemDescription" },
-                        AddressPaonDescription = "PAON Description",
+                        ContactWebsiteAddress = "http://www.example.com",
+                        ContactEmail = "test@example.com",
                         AddressSaonDescription = "SAON Description",
+                        AddressPaonDescription = "PAON Description",
                         AddressStreetDescription = "Street",
-                        AddressPostCode = "Postcode",
                         AddressLocality = "Locality",
+                        AddressItems = new[] {"ItemDescription"},
+                        AddressPostTown = "PostTown",
+                        AddressPostCode = "Postcode",
                         PersonalDetailsFamilyName = "FamilyName",
                         PersonalDetailsGivenName = "GivenName"
                     }
                 });
 
-            var ukrlpProviderData = GenerateUkrlpProviderData(ukprn);
+            var ukrlpData = GenerateUkrlpProviderData(ukprn);
+            var ukrlpContact = ukrlpData.ProviderContact.Single();
 
-            var ukrlpWcfService = new Mock<IUkrlpService>();
-            ukrlpWcfService.Setup(w => w.GetProviderData(ukprn)).ReturnsAsync(ukrlpProviderData);
+            var ukrlpSyncHelper = SetupUkrlpSyncHelper(ukprn, ukrlpData);
 
-            var loggerFactory = new Mock<ILoggerFactory>();
-            loggerFactory.Setup(mock => mock.CreateLogger(It.IsAny<string>())).Returns(Mock.Of<ILogger>());
-
-            var ukrlpSyncHelper = new UkrlpSyncHelper(
-                ukrlpWcfService.Object,
-                CosmosDbQueryDispatcher.Object,
-                Clock,
-                loggerFactory.Object);
+            ICollection<UpdateProviderFromUkrlpData> capturedUpdateCommands = new List<UpdateProviderFromUkrlpData>();
+            CosmosDbQueryDispatcher.Setup(mock => mock.ExecuteQuery(Capture.In(capturedUpdateCommands)));
 
             // Act
             await ukrlpSyncHelper.SyncProviderData(ukprn);
 
             // Assert
-            CosmosDbQueryDispatcher.Verify(mock => mock.ExecuteQuery(It.Is<UpdateProviderFromUkrlpData>(cmd =>
-                cmd.Alias == "ProviderAlias" &&
-                cmd.DateUpdated == Clock.UtcNow &&
-                cmd.ProviderId == providerId &&
-                cmd.ProviderName == ukrlpProviderData.ProviderName &&
-                cmd.ProviderStatus == "Active"
-            )));
-        }
-
-        [Fact]
-        public async Task SyncProviderData_ProviderDoesNotExist_CreatesProviderInfo()
-        {
-            // Arrange
-            var ukprn = 01234566;
-
-            var ukrlpProviderData = GenerateUkrlpProviderData(ukprn);
-
-            var ukrlpWcfService = new Mock<IUkrlpService>();
-            ukrlpWcfService.Setup(w => w.GetProviderData(ukprn)).ReturnsAsync(ukrlpProviderData);
-
-            var loggerFactory = new Mock<ILoggerFactory>();
-            loggerFactory.Setup(mock => mock.CreateLogger(It.IsAny<string>())).Returns(Mock.Of<ILogger>());
-
-            var ukrlpSyncHelper = new UkrlpSyncHelper(
-                ukrlpWcfService.Object,
-                CosmosDbQueryDispatcher.Object,
-                Clock,
-                loggerFactory.Object);
-
-            // Act
-            await ukrlpSyncHelper.SyncProviderData(ukprn);
-
-            // Assert
-            CosmosDbQueryDispatcher.Verify(mock => mock.ExecuteQuery(It.Is<CreateProviderFromUkrlpData>(cmd =>
-                cmd.Alias == "ProviderAlias" &&
-                cmd.DateUpdated == Clock.UtcNow &&
-                cmd.ProviderName == ukrlpProviderData.ProviderName &&
-                cmd.ProviderStatus == "Active" &&
-                cmd.ProviderType == ProviderType.Both &&
-                cmd.Status == ProviderStatus.Registered &&
-                cmd.Ukprn == ukprn
-            )));
+            var updateCommand = capturedUpdateCommands.Should().ContainSingle().Subject;
+            updateCommand.Alias.Should().Be(ukrlpData.ProviderAliases.Single().ProviderAlias);
+            updateCommand.DateUpdated.Should().Be(Clock.UtcNow);
+            updateCommand.ProviderName.Should().Be(ukrlpData.ProviderName);
+            updateCommand.ProviderId.Should().Be(providerId);
+            updateCommand.ProviderStatus.Should().Be(ukrlpData.ProviderStatus);
+            var actualContact = updateCommand.Contacts.Should().ContainSingle().Subject;
+            AssertContactMapping(actualContact, ukrlpContact);
         }
 
         [Fact]
         public void SelectContact_SelectsMostRecentlyUpdatedPTypeContact()
         {
             // Arrange
-
-            var contact1 = new ProviderContactStructure()
+            var contact1 = new ProviderContactStructure
             {
                 ContactType = "P",
                 LastUpdated = new DateTime(2020, 3, 1),
@@ -123,7 +116,7 @@ namespace Dfc.CourseDirectory.Core.Tests.ReferenceDataTests
                 ContactPersonalDetails = new PersonNameStructure()
             };
 
-            var contact2 = new ProviderContactStructure()
+            var contact2 = new ProviderContactStructure
             {
                 ContactType = "P",
                 LastUpdated = new DateTime(2020, 4, 1),
@@ -131,7 +124,7 @@ namespace Dfc.CourseDirectory.Core.Tests.ReferenceDataTests
                 ContactPersonalDetails = new PersonNameStructure()
             };
 
-            var contact3 = new ProviderContactStructure()
+            var contact3 = new ProviderContactStructure
             {
                 ContactType = "L",
                 LastUpdated = new DateTime(2020, 5, 1),
@@ -153,38 +146,81 @@ namespace Dfc.CourseDirectory.Core.Tests.ReferenceDataTests
             Assert.Same(selected, contact2);
         }
 
-        private ProviderRecordStructure GenerateUkrlpProviderData(int ukprn) => new ProviderRecordStructure()
+        private void AssertContactMapping(ProviderContact actualContact, ProviderContactStructure ukrlpContact)
+        {
+            actualContact.ContactType.Should().Be(ukrlpContact.ContactType);
+            actualContact.ContactRole.Should().Be(ukrlpContact.ContactRole);
+            actualContact.ContactTelephone1.Should().Be(ukrlpContact.ContactTelephone1);
+            actualContact.ContactWebsiteAddress.Should().Be(ukrlpContact.ContactWebsiteAddress);
+            actualContact.ContactEmail.Should().Be(ukrlpContact.ContactEmail);
+            actualContact.ContactFax.Should().Be(ukrlpContact.ContactFax);
+            actualContact.LastUpdated.Should().Be(Clock.UtcNow);
+            actualContact.AdditionalData.Should().BeNull();
+            actualContact.ContactPersonalDetails.Should().NotBeNull();
+
+            var actualContactAddress = actualContact.ContactAddress;
+            actualContactAddress.SAON.Description.Should().Be(ukrlpContact.ContactAddress.SAON.Description);
+            actualContactAddress.PAON.Description.Should().Be(ukrlpContact.ContactAddress.PAON.Description);
+            actualContactAddress.StreetDescription.Should().Be(ukrlpContact.ContactAddress.StreetDescription);
+            actualContactAddress.Locality.Should().Be(ukrlpContact.ContactAddress.Locality);
+            actualContactAddress.Items.SingleOrDefault().Should().Be(ukrlpContact.ContactAddress.Items.Single());
+            actualContactAddress.PostTown.Should().BeNull(); // original value is not copied across when address is recreated
+            actualContactAddress.PostCode.Should().Be(ukrlpContact.ContactAddress.PostCode);
+            actualContactAddress.AdditionalData.Should().BeNull();
+
+            var actualPersonalDetails = actualContact.ContactPersonalDetails;
+            actualPersonalDetails.PersonNameTitle.SingleOrDefault().Should().Be(ukrlpContact.ContactPersonalDetails.PersonNameTitle.Single());
+            actualPersonalDetails.PersonGivenName.SingleOrDefault().Should().Be(ukrlpContact.ContactPersonalDetails.PersonGivenName.Single());
+            actualPersonalDetails.PersonFamilyName.Should().Be(ukrlpContact.ContactPersonalDetails.PersonFamilyName);
+            actualPersonalDetails.AdditionalData.Should().BeNull();
+
+        }
+
+        private UkrlpSyncHelper SetupUkrlpSyncHelper(int ukprn, ProviderRecordStructure ukrlpProviderData)
+        {
+            var ukrlpWcfService = new Mock<IUkrlpService>();
+            ukrlpWcfService.Setup(w => w.GetProviderData(ukprn)).ReturnsAsync(ukrlpProviderData);
+
+            var loggerFactory = new Mock<ILoggerFactory>();
+            loggerFactory.Setup(mock => mock.CreateLogger(It.IsAny<string>())).Returns(Mock.Of<ILogger>());
+
+            return new UkrlpSyncHelper(
+                ukrlpWcfService.Object,
+                CosmosDbQueryDispatcher.Object,
+                Clock,
+                loggerFactory.Object);
+        }
+
+        private ProviderRecordStructure GenerateUkrlpProviderData(int ukprn) => new ProviderRecordStructure
         {
             UnitedKingdomProviderReferenceNumber = ukprn.ToString(),
             ProviderName = "Ukrlp Test Provider",
             ProviderStatus = "Active",
-            ProviderAliases = new[]
+            ProviderAliases = new[] { new ProviderAliasesStructure {ProviderAlias = "Ukrlp ProviderAliasHere"} },
+            ProviderContact = new[]
             {
-                new ProviderAliasesStructure() { ProviderAlias = "ProviderAlias" }
-            },
-            ProviderContact = new ProviderContactStructure[]
-            {
-                new ProviderContactStructure()
+                new ProviderContactStructure
                 {
                     ContactType = "P",
-                    ContactAddress = new BSaddressStructure()
+                    ContactAddress = new BSaddressStructure
                     {
-                        SAON = new AONstructure() { Description = "Ukrlp SAON Description" },
-                        PAON = new AONstructure() { Description = "Ukrlp PAON Description" },
+                        SAON = new AONstructure {Description = "Ukrlp SAON Description"},
+                        PAON = new AONstructure {Description = "Ukrlp PAON Description"},
                         StreetDescription = "Ukrlp Street",
                         Locality = "Ukrlp Locality",
-                        Items = new string[] { "Ukrlp Item Description " },
+                        Items = new[] {"Ukrlp Item Description "},
+                        PostTown = "Ukrlp PostTown",
                         PostCode = "Ukrlp PostCode"
                     },
-                    ContactPersonalDetails = new PersonNameStructure()
+                    ContactPersonalDetails = new PersonNameStructure
                     {
-                        PersonNameTitle = new string[] { "Ukrlp Mr" },
-                        PersonGivenName = new string[] { "Ukrlp Given name" },
+                        PersonNameTitle = new[] {"Ukrlp Mr"},
+                        PersonGivenName = new[] {"Ukrlp Given name"},
                         PersonFamilyName = "Ukrlp Family name",
                     },
                     ContactTelephone1 = "Ukrlp Telephone 1",
-                    ContactWebsiteAddress = "http://www.ukrlptest.com",
-                    ContactEmail = "Ukrlptest@test.com",
+                    ContactWebsiteAddress = "http://www.ukrlptest.example.com",
+                    ContactEmail = "Ukrlptest@example.com",
                     LastUpdated = Clock.UtcNow,
                 }
             }

--- a/tests/Dfc.CourseDirectory.Testing/TestData/TestData.CreateProvider.cs
+++ b/tests/Dfc.CourseDirectory.Testing/TestData/TestData.CreateProvider.cs
@@ -45,6 +45,7 @@ namespace Dfc.CourseDirectory.Testing
                         Locality = c.AddressLocality,
                         PAON = new ProviderContactAddressPAON() { Description = c.AddressPaonDescription },
                         SAON = new ProviderContactAddressSAON() { Description = c.AddressSaonDescription },
+                        PostTown = c.AddressPostTown,
                         PostCode = c.AddressPostCode,
                         StreetDescription = c.AddressStreetDescription
                     },
@@ -103,6 +104,7 @@ namespace Dfc.CourseDirectory.Testing
         public string AddressStreetDescription { get; set; }
         public string AddressLocality { get; set; }
         public IList<string> AddressItems { get; set; }
+        public string AddressPostTown { get; set; }
         public string AddressPostCode { get; set; }
         public string PersonalDetailsGivenName { get; set; }
         public string PersonalDetailsFamilyName { get; set; }


### PR DESCRIPTION
See individual commit messages for detailed changes. The commits:

* add missing regression tests to the two main classes in the UKRLP client
* and then upgrade the client
* and then update the tests to match.
* Plus some minor cleanup and logging.

This change affects:

- The azure function app `SyncUkrlpChanges`
- The sign-in to the website (which syncs a single provider)

Here's a representative example of how the xml structure changed between the versions:

![address field mapping with county example](https://user-images.githubusercontent.com/19378/92629037-9d508380-f2c5-11ea-9408-3f045b5adeeb.png)

Here's the new output from the function app:

```
[24/09/2020 12:47:51] Executing 'SyncUkrlpChanges' (Reason='This function was programmatically called via the host APIs.', Id=27e4ff95-ad4b-4763-8021-25e6c1ea6426)                           
[24/09/2020 12:47:51] UKRLP Sync: Beginning SyncAllProviderData, fetching providers from UKRLP API...                                                                                         
[24/09/2020 12:47:51] UKRLP Sync: Using UKRLP endpoint 'http://webservices.ukrlp.co.uk/UkrlpProviderQueryWS6/ProviderQueryServiceV6'                                                          
[24/09/2020 12:47:51] UKRLP Sync: Fetching UKRLP data for status 'A'...                                                                                                                       
[24/09/2020 12:47:53] FUNCTIONS_WORKER_RUNTIME=dotnet. Will shutdown all the worker channels that started in placeholder mode
[24/09/2020 12:47:55] Host lock lease acquired by instance ID '000000000000000000000000000C0158'.
[24/09/2020 12:48:02] UKRLP Sync: 5531 records received from UKRLP API for status 'A.'
[24/09/2020 12:48:02] UKRLP Sync: Fetching UKRLP data for status 'PD1'...
[24/09/2020 12:48:02] UKRLP Sync: 91 records received from UKRLP API for status 'PD1.'
[24/09/2020 12:48:02] UKRLP Sync: Fetching UKRLP data for status 'PD2'...
[24/09/2020 12:48:02] UKRLP Sync: 0 records received from UKRLP API for status 'PD2.'
[24/09/2020 12:48:02] UKRLP Sync: 5622 providers received, processing...
[24/09/2020 12:48:02] UKRLP Sync: processing provider 1 of 5622, UKPRN: 10000010...
[24/09/2020 12:48:04] UKRLP Sync: processing provider 2 of 5622, UKPRN: 10000011...
[24/09/2020 12:48:04] UKRLP Sync: processing provider 3 of 5622, UKPRN: 10000016...
[24/09/2020 12:48:04] UKRLP Sync: processing provider 4 of 5622, UKPRN: 10000017...
[24/09/2020 12:48:05] UKRLP Sync: processing provider 5 of 5622, UKPRN: 10000024...
[24/09/2020 12:48:05] UKRLP Sync: processing provider 6 of 5622, UKPRN: 10000029...
[24/09/2020 12:48:05] UKRLP Sync: processing provider 7 of 5622, UKPRN: 10000030...
[24/09/2020 12:48:05] UKRLP Sync: processing provider 8 of 5622, UKPRN: 10000032...
[24/09/2020 12:48:05] UKRLP Sync: processing provider 9 of 5622, UKPRN: 10000038...
[24/09/2020 12:48:05] UKRLP Sync: processing provider 10 of 5622, UKPRN: 10000041...
[24/09/2020 12:48:06] UKRLP Sync: processing provider 11 of 5622, UKPRN: 10000050...

...
[24/09/2020 12:48:35] UKRLP Sync: processing provider 198 of 5622, UKPRN: 10001719...
[24/09/2020 12:48:35] UKRLP Sync: processing provider 199 of 5622, UKPRN: 10001724...
[24/09/2020 12:48:35] UKRLP Sync: processing provider 200 of 5622, UKPRN: 10001725... << Debug level (won't show in azure logs by default)
[24/09/2020 12:48:35] UKRLP Sync: processed provider 200 of 5622, UKPRN: 10001725...  << Info level (will show in azure logs by default)
[24/09/2020 12:48:35] UKRLP Sync: processing provider 201 of 5622, UKPRN: 10001738...
[24/09/2020 12:48:36] UKRLP Sync: processing provider 202 of 5622, UKPRN: 10001745...
[24/09/2020 12:48:36] UKRLP Sync: processing provider 203 of 5622, UKPRN: 10001767...
...
[24/09/2020 13:02:44] UKRLP Sync: processing provider 5618 of 5622, UKPRN: 10083453...
[24/09/2020 13:02:44] UKRLP Sync: processing provider 5619 of 5622, UKPRN: 10083862...
[24/09/2020 13:02:44] UKRLP Sync: processing provider 5620 of 5622, UKPRN: 10084357...
[24/09/2020 13:02:44] UKRLP Sync: processing provider 5621 of 5622, UKPRN: 10086932...
[24/09/2020 13:02:44] UKRLP Sync: processing provider 5622 of 5622, UKPRN: 10086997...
[24/09/2020 13:02:44] UKRLP Sync: Added 1 new providers and updated 5621 providers.
[24/09/2020 13:02:44] Executed 'SyncUkrlpChanges' (Succeeded, Id=27e4ff95-ad4b-4763-8021-25e6c1ea6426)
```

[PTCD-630](https://skillsfundingagency.atlassian.net/browse/PTCD-630)

----
This replaces #1660 which failed test due missing data caused by the XML not being deserialized correctly. This attempt adds to the previous PR regression tests for the XML parsing both before and after the change (if you look at the list of commits).

To see what's changed since the last PR run

```
git diff origin/PTCD-630-upgrade-ukrlp-client-to-v6..origin/PTCD-630-upgrade-ukrlp-client-to-v6-take2
```

You can see the size of change with `--stat` and/or `--shortstat`:
```
git diff --shortstat origin/PTCD-630-upgrade-ukrlp-client-to-v6..origin/PTCD-630-upgrade-ukrlp-client-to-v6-take2
 12 files changed, 330 insertions(+), 14 deletions(-)
```

I'd link to [the diff on github](https://github.com/SkillsFundingAgency/dfc-coursedirectory/compare/PTCD-630-upgrade-ukrlp-client-to-v6...PTCD-630-upgrade-ukrlp-client-to-v6-take2), but it appears to be wrong