### PR TITLE
Apprenticeship SQL sync timeout fixes

### DIFF
--- a/src/Dfc.CourseDirectory.Core/DataStore/Sql/BulkCopyHelper.cs
+++ b/src/Dfc.CourseDirectory.Core/DataStore/Sql/BulkCopyHelper.cs
@@ -42,6 +42,7 @@ namespace Dfc.CourseDirectory.Core.DataStore.Sql
                     bulk.ColumnMappings.Add(new SqlBulkCopyColumnMapping(c.ColumnName, c.ColumnName));
                 }
 
+                bulk.BulkCopyTimeout = 0;
                 bulk.DestinationTableName = tableName;
                 await bulk.WriteToServerAsync(table);
             }

--- a/src/Dfc.CourseDirectory.Core/Dfc.CourseDirectory.Core.csproj
+++ b/src/Dfc.CourseDirectory.Core/Dfc.CourseDirectory.Core.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="OneOf" Version="2.1.151" />
     <PackageReference Include="Scrutor" Version="3.1.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.6.0" />
+    <PackageReference Include="System.Interactive" Version="4.1.1" />
     <PackageReference Include="System.Private.ServiceModel" Version="4.7.0" />
     <PackageReference Include="System.ServiceModel.Http" Version="4.7.0" />
   </ItemGroup>


### PR DESCRIPTION
- Remove the command timeout for bulk copying.
- Reduce the size of records synced in a single transaction.