### PR TITLE
Add retries to SyncAllApprenticeships

### DIFF
--- a/src/Dfc.CourseDirectory.Core/Dfc.CourseDirectory.Core.csproj
+++ b/src/Dfc.CourseDirectory.Core/Dfc.CourseDirectory.Core.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.3" />
     <PackageReference Include="Microsoft.SqlServer.DACFx" Version="150.4573.2" />
     <PackageReference Include="OneOf" Version="2.1.151" />
+    <PackageReference Include="Polly" Version="7.2.1" />
     <PackageReference Include="Scrutor" Version="3.1.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.6.0" />
     <PackageReference Include="System.Interactive" Version="4.1.1" />


### PR DESCRIPTION
We have intermittent errors running this and the errors are proving difficult to nail down. For a one-time sync, retrying a few times per batch should this execute successfully.