### PR TITLE
Editorconfig - add final newline

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,8 @@
-# editorconfig.org
-
+# https://editorconfig.org/
 root = true
 
-[*.cs]
+[*]
+insert_final_newline = true
 
+[*.cs]
 dotnet_sort_system_directives_first = true


### PR DESCRIPTION
Editorconfig - add final newline

Because git and github complain if you don't which is minorly annoying.