### PR TITLE
PTCD-683 Standardise nav links and order

### DIFF
--- a/src/Dfc.CourseDirectory.WebV2/SharedViews/Components/AdminProviderContextNav.cshtml
+++ b/src/Dfc.CourseDirectory.WebV2/SharedViews/Components/AdminProviderContextNav.cshtml
@@ -2,60 +2,57 @@
 @{
     var currentController = (string)ViewContext.RouteData.Values["Controller"];
     var currentAction = (string)ViewContext.RouteData.Values["Action"];
-
-    var enableApprenticeshipBulkUpload = Model.ProviderContext.ProviderType.HasFlag(ProviderType.Apprenticeships) &&
-        Model.ApprenticeshipQAStatus == ApprenticeshipQAStatus.Passed;
 }
 
 <div class="pttcd-subnav govuk-!-margin-top-6">
-    <div class="pttcd-subnav__provider-name">@Model.ProviderContext.ProviderName</div>
+    <div class="pttcd-subnav__provider-name">@Model.ProviderInfo.ProviderName</div>
     <ul class="pttcd-subnav__items">
         <li class="pttcd-subnav__item">
-            <a asp-action="SearchProvider" asp-controller="ProviderSearch" asp-route-UKPRN="@Model.ProviderContext.Ukprn" class="pttcd-subnav__item__link">
+            <a asp-action="SearchProvider" asp-controller="ProviderSearch" asp-route-UKPRN="@Model.ProviderInfo.Ukprn" class="pttcd-subnav__item__link" data-testid="adminsubnav-home">
                 Home
             </a>
         </li>
-        <li class="pttcd-subnav__item">
-            <a asp-action="LandingOptions" asp-controller="Venues" class="pttcd-subnav__item__link">
-                Your locations
-            </a>
-        </li>
-        @if (Model.ShowApprenticeshipsLink)
+        @if (Model.ShowCoursesLinks)
+        {
+            <li class="pttcd-subnav__item">
+                <a asp-action="LandingOptions" asp-controller="Qualifications" class="pttcd-subnav__item__link" data-testid="adminsubnav-courses">
+                    Courses
+                </a>
+            </li>
+        }
+        @if (Model.ShowApprenticeshipsLinks)
         {
             <li class="pttcd-subnav__item@(currentController == "Apprenticeships" ? " govuk-header__navigation-item--active" : null)">
                 <a asp-action="WhatWouldYouLikeToDo" asp-controller="Apprenticeships" class="pttcd-subnav__item__link" data-testid="adminsubnav-apprenticeships">
-                    Your apprenticeships training
+                    Apprenticeships
                 </a>
             </li>
         }
-        @if (Model.ProviderContext.ProviderType.HasFlag(ProviderType.FE))
-        {
-            <li class="pttcd-subnav__item">
-                <a asp-action="LandingOptions" asp-controller="Qualifications" class="pttcd-subnav__item__link">
-                    Your courses
-                </a>
-            </li>
-        }
-        @if (Model.ProviderContext.ProviderType == ProviderType.Both && enableApprenticeshipBulkUpload)
+        <li class="pttcd-subnav__item">
+            <a asp-action="LandingOptions" asp-controller="Venues" class="pttcd-subnav__item__link" data-testid="adminsubnav-locations">
+                Locations
+            </a>
+        </li>
+        @if (Model.ShowCoursesLinks && Model.ShowApprenticeshipsLinks)
         {
             <li class="pttcd-subnav__item@(currentController == "BulkUpload" || currentController == "BulkUploadApprenticeships" ? " govuk-header__navigation-item--active" : null)">
-                <a asp-action="LandingOptions" asp-controller="BulkUpload" class="pttcd-subnav__item__link">
+                <a asp-action="LandingOptions" asp-controller="BulkUpload" class="pttcd-subnav__item__link" data-testid="adminsubnav-bulkupload">
                     Bulk upload
                 </a>
             </li>
         }
-        else if (enableApprenticeshipBulkUpload)
+        else if (Model.ShowApprenticeshipsLinks)
         {
             <li class="pttcd-subnav__item@(currentController == "BulkUploadApprenticeships" ? " govuk-header__navigation-item--active" : null)">
-                <a asp-action="Index" asp-controller="BulkUploadApprenticeships" class="pttcd-subnav__item__link">
+                <a asp-action="Index" asp-controller="BulkUploadApprenticeships" class="pttcd-subnav__item__link" data-testid="adminsubnav-bulkupload">
                     Bulk upload
                 </a>
             </li>
         }
-        else if (Model.ProviderContext.ProviderType.HasFlag(ProviderType.FE))
+        else if (Model.ShowCoursesLinks)
         {
             <li class="pttcd-subnav__item@(currentController == "BulkUpload" || currentController == "BulkUploadApprenticeships" ? " govuk-header__navigation-item--active" : null)">
-                <a asp-action="Index" asp-controller="BulkUpload" class="pttcd-subnav__item__link">
+                <a asp-action="Index" asp-controller="BulkUpload" class="pttcd-subnav__item__link" data-testid="adminsubnav-bulkupload">
                     Bulk upload
                 </a>
             </li>

--- a/src/Dfc.CourseDirectory.WebV2/SharedViews/Components/AdminProviderContextNavViewComponent.cs
+++ b/src/Dfc.CourseDirectory.WebV2/SharedViews/Components/AdminProviderContextNavViewComponent.cs
@@ -1,7 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Dfc.CourseDirectory.Core.DataStore.Sql;
 using Dfc.CourseDirectory.Core.DataStore.Sql.Queries;
-using Dfc.CourseDirectory.Core.Models;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Dfc.CourseDirectory.WebV2.SharedViews.Components
@@ -23,13 +22,7 @@ namespace Dfc.CourseDirectory.WebV2.SharedViews.Components
                     ProviderId = providerInfo.ProviderId
                 });
 
-            var vm = new ProviderNavViewModel()
-            {
-                ApprenticeshipQAStatus = qaStatus ?? ApprenticeshipQAStatus.NotStarted,
-                ProviderContext = providerInfo,
-                ShowApprenticeshipsLink = providerInfo.ProviderType.HasFlag(ProviderType.Apprenticeships) &&
-                    qaStatus == ApprenticeshipQAStatus.Passed
-            };
+            var vm = ProviderNavViewModel.Create(providerInfo, qaStatus);
 
             return View("~/SharedViews/Components/AdminProviderContextNav.cshtml", vm);
         }

--- a/src/Dfc.CourseDirectory.WebV2/SharedViews/Components/AdminTopNav.cshtml
+++ b/src/Dfc.CourseDirectory.WebV2/SharedViews/Components/AdminTopNav.cshtml
@@ -9,32 +9,32 @@
 <nav>
     <ul id="navigation" class="govuk-header__navigation" aria-label="Top Level Navigation">
         <li class="govuk-header__navigation-item@(currentController == "HelpdeskDashboard" && currentAction == "Dashboard" ? " govuk-header__navigation-item--active" : null)">
-            <a asp-action="Dashboard" asp-controller="HelpdeskDashboard" class="govuk-header__link">
+            <a asp-action="Dashboard" asp-controller="HelpdeskDashboard" class="govuk-header__link" data-testid="topnav-home">
                 Home
             </a>
         </li>
         <li class="govuk-header__navigation-item@(currentController == "ApprenticeshipQA" ? " govuk-header__navigation-item--active" : null)">
-            <a asp-action="ListProviders" asp-controller="ApprenticeshipQA" class="govuk-header__link">
+            <a asp-action="ListProviders" asp-controller="ApprenticeshipQA" class="govuk-header__link" data-testid="topnav-qa">
                 Quality assurance
             </a>
         </li>
         <li class="govuk-header__navigation-item@(currentController == "SearchProvider" ? " govuk-header__navigation-item--active" : null)">
-            <a asp-action="Index" asp-controller="SearchProvider" class="govuk-header__link">
+            <a asp-action="Index" asp-controller="SearchProvider" class="govuk-header__link" data-testid="topnav-searchproviders">
                 Search providers
             </a>
         </li>
         <li class="govuk-header__navigation-item">
-            <a href="@Settings.ManageUsersUrl" target="_blank" rel="noreferrer" class="govuk-header__link">
+            <a href="@Settings.ManageUsersUrl" target="_blank" rel="noreferrer" class="govuk-header__link" data-testid="topnav-manageusers">
                 Manage users
             </a>
         </li>
         <li class="govuk-header__navigation-item@(currentController == "Report" && currentAction == "Index" ? " govuk-header__navigation-item--active" : null)">
-            <a asp-action="Index" asp-controller="Report" class="govuk-header__link">
+            <a asp-action="Index" asp-controller="Report" class="govuk-header__link" data-testid="topnav-migrationreports">
                 Migration reports
             </a>
         </li>
         <li class="govuk-header__navigation-item pttcd-sign-out-navigation-item">
-            <a asp-action="Logout" asp-controller="Auth" class="govuk-header__link">
+            <a asp-action="Logout" asp-controller="Auth" class="govuk-header__link" data-testid="topnav-signout">
                 Sign out
             </a>
         </li>

--- a/src/Dfc.CourseDirectory.WebV2/SharedViews/Components/ProviderNavViewModel.cs
+++ b/src/Dfc.CourseDirectory.WebV2/SharedViews/Components/ProviderNavViewModel.cs
@@ -4,8 +4,21 @@ namespace Dfc.CourseDirectory.WebV2.SharedViews.Components
 {
     public class ProviderNavViewModel
     {
-        public ProviderInfo ProviderContext { get; set; }
-        public ApprenticeshipQAStatus ApprenticeshipQAStatus { get; set; }
-        public bool ShowApprenticeshipsLink { get; set; }
+        public ProviderInfo ProviderInfo { get; set; }
+        public bool ShowApprenticeshipsLinks { get; set; }
+        public bool ShowCoursesLinks { get; set; }
+
+        public static ProviderNavViewModel Create(
+            ProviderInfo providerInfo,
+            ApprenticeshipQAStatus? apprenticeshipQAStatus)
+        {
+            return new ProviderNavViewModel()
+            {
+                ProviderInfo = providerInfo,
+                ShowApprenticeshipsLinks = providerInfo.ProviderType.HasFlag(ProviderType.Apprenticeships) &&
+                    apprenticeshipQAStatus == ApprenticeshipQAStatus.Passed,
+                ShowCoursesLinks = providerInfo.ProviderType.HasFlag(ProviderType.FE)
+            };
+        }
     }
 }

--- a/src/Dfc.CourseDirectory.WebV2/SharedViews/Components/ProviderTopNav.cshtml
+++ b/src/Dfc.CourseDirectory.WebV2/SharedViews/Components/ProviderTopNav.cshtml
@@ -2,66 +2,63 @@
 @{
     var currentController = (string)ViewContext.RouteData.Values["Controller"];
     var currentAction = (string)ViewContext.RouteData.Values["Action"];
-
-    var enableApprenticeshipBulkUpload = Model.ProviderContext.ProviderType.HasFlag(ProviderType.Apprenticeships) &&
-        Model.ApprenticeshipQAStatus == ApprenticeshipQAStatus.Passed;
 }
 
 <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
 <nav>
     <ul id="navigation" class="govuk-header__navigation" aria-label="Top Level Navigation">
         <li class="govuk-header__navigation-item@(currentController == "Home" && currentAction == "Index" ? " govuk-header__navigation-item--active" : null)">
-            <a asp-action="Index" asp-controller="Home" class="govuk-header__link">
+            <a asp-action="Index" asp-controller="Home" class="govuk-header__link" data-testid="topnav-home">
                 Home
             </a>
         </li>
-        <li class="govuk-header__navigation-item@(currentController == "Venues" ? " govuk-header__navigation-item--active" : null)">
-            <a asp-action="Index" asp-controller="Venues" class="govuk-header__link">
-                Your locations
-            </a>
-        </li>
-        @if (Model.ShowApprenticeshipsLink)
+        @if (Model.ShowCoursesLinks)
+        {
+            <li class="govuk-header__navigation-item@(currentController == "Qualifications" ? " govuk-header__navigation-item--active" : null)">
+                <a asp-action="LandingOptions" asp-controller="Qualifications" class="govuk-header__link" data-testid="topnav-courses">
+                    Courses
+                </a>
+            </li>
+        }
+        @if (Model.ShowApprenticeshipsLinks)
         {
             <li class="govuk-header__navigation-item@(currentController == "Apprenticeships" ? " govuk-header__navigation-item--active" : null)">
                 <a asp-action="WhatWouldYouLikeToDo" asp-controller="Apprenticeships" class="govuk-header__link" data-testid="topnav-apprenticeships">
-                    Your apprenticeships training
+                    Apprenticeships
                 </a>
             </li>
         }
-        @if (Model.ProviderContext.ProviderType.HasFlag(ProviderType.FE))
-        {
-            <li class="govuk-header__navigation-item@(currentController == "Qualifications" ? " govuk-header__navigation-item--active" : null)">
-                <a asp-action="LandingOptions" asp-controller="Qualifications" class="govuk-header__link">
-                    Your courses
-                </a>
-            </li>
-        }
-        @if (Model.ProviderContext.ProviderType == ProviderType.Both && enableApprenticeshipBulkUpload)
+        <li class="govuk-header__navigation-item@(currentController == "Venues" ? " govuk-header__navigation-item--active" : null)">
+            <a asp-action="Index" asp-controller="Venues" class="govuk-header__link" data-testid="topnav-locations">
+                Locations
+            </a>
+        </li>
+        @if (Model.ShowCoursesLinks && Model.ShowApprenticeshipsLinks)
         {
             <li class="govuk-header__navigation-item@(currentController == "BulkUpload" || currentController == "BulkUploadApprenticeships" ? " govuk-header__navigation-item--active" : null)">
-                <a asp-action="LandingOptions" asp-controller="BulkUpload" class="govuk-header__link">
+                <a asp-action="LandingOptions" asp-controller="BulkUpload" class="govuk-header__link" data-testid="topnav-bulkupload">
                     Bulk upload
                 </a>
             </li>
         }
-        else if (enableApprenticeshipBulkUpload)
+        else if (Model.ShowApprenticeshipsLinks)
         {
             <li class="govuk-header__navigation-item@(currentController == "BulkUploadApprenticeships" ? " govuk-header__navigation-item--active" : null)">
-                <a asp-action="Index" asp-controller="BulkUploadApprenticeships" class="govuk-header__link">
+                <a asp-action="Index" asp-controller="BulkUploadApprenticeships" class="govuk-header__link" data-testid="topnav-bulkupload">
                     Bulk upload
                 </a>
             </li>
         }
-        else if (Model.ProviderContext.ProviderType.HasFlag(ProviderType.FE))
+        else if (Model.ShowCoursesLinks)
         {
             <li class="govuk-header__navigation-item@(currentController == "BulkUpload" || currentController == "BulkUploadApprenticeships" ? " govuk-header__navigation-item--active" : null)">
-                <a asp-action="index" asp-controller="BulkUpload" class="govuk-header__link">
+                <a asp-action="index" asp-controller="BulkUpload" class="govuk-header__link" data-testid="topnav-bulkupload">
                     Bulk upload
                 </a>
             </li>
         }
         <li class="govuk-header__navigation-item pttcd-sign-out-navigation-item">
-            <a asp-action="Logout" asp-controller="Auth" class="govuk-header__link">
+            <a asp-action="Logout" asp-controller="Auth" class="govuk-header__link" data-testid="topnav-signout">
                 Sign out
             </a>
         </li>

--- a/src/Dfc.CourseDirectory.WebV2/SharedViews/Components/ProviderTopNavViewComponent.cs
+++ b/src/Dfc.CourseDirectory.WebV2/SharedViews/Components/ProviderTopNavViewComponent.cs
@@ -1,7 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Dfc.CourseDirectory.Core.DataStore.Sql;
 using Dfc.CourseDirectory.Core.DataStore.Sql.Queries;
-using Dfc.CourseDirectory.Core.Models;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Dfc.CourseDirectory.WebV2.SharedViews.Components
@@ -23,13 +22,7 @@ namespace Dfc.CourseDirectory.WebV2.SharedViews.Components
                     ProviderId = providerInfo.ProviderId
                 });
 
-            var vm = new ProviderNavViewModel()
-            {
-                ApprenticeshipQAStatus = qaStatus ?? ApprenticeshipQAStatus.NotStarted,
-                ProviderContext = providerInfo,
-                ShowApprenticeshipsLink = providerInfo.ProviderType.HasFlag(ProviderType.Apprenticeships) &&
-                    qaStatus == ApprenticeshipQAStatus.Passed
-            };
+            var vm = ProviderNavViewModel.Create(providerInfo, qaStatus);
 
             return View("~/SharedViews/Components/ProviderTopNav.cshtml", vm);
         }

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/LayoutTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/LayoutTests.cs
@@ -2,9 +2,10 @@
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
-using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
 using Dfc.CourseDirectory.Core.Models;
+using FluentAssertions;
+using FluentAssertions.Execution;
 using Xunit;
 
 namespace Dfc.CourseDirectory.WebV2.Tests
@@ -30,7 +31,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests
             response.EnsureSuccessStatusCode();
 
             var doc = await response.GetDocument();
-            Assert.Equal(0, doc.QuerySelectorAll(".pttcd-sign-out-navigation-item").Length);
+            doc.QuerySelectorAll(".pttcd-sign-out-navigation-item").Length.Should().Be(0);
         }
 
         [Fact]
@@ -47,7 +48,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests
             response.EnsureSuccessStatusCode();
 
             var doc = await response.GetDocument();
-            Assert.Equal(1, doc.QuerySelectorAll(".pttcd-sign-out-navigation-item").Length);
+            doc.QuerySelectorAll(".pttcd-sign-out-navigation-item").Length.Should().Be(1);
         }
 
         [Theory]
@@ -68,15 +69,19 @@ namespace Dfc.CourseDirectory.WebV2.Tests
             var topLevelLinks = GetTopLevelNavLinks(doc);
             var subNavLinks = GetSubNavLinks(doc);
 
-            Assert.Equal(6, topLevelLinks.Count);
-            Assert.Equal("Home", topLevelLinks[0].Label);
-            Assert.Equal("Quality assurance", topLevelLinks[1].Label);
-            Assert.Equal("Search providers", topLevelLinks[2].Label);
-            Assert.Equal("Manage users", topLevelLinks[3].Label);
-            Assert.Equal("Migration reports", topLevelLinks[4].Label);
-            Assert.Equal("Sign out", topLevelLinks[5].Label);
+            topLevelLinks.Count.Should().Be(6);
 
-            Assert.Equal(0, subNavLinks.Count);
+            using (new AssertionScope())
+            {
+                topLevelLinks[0].TestId.Should().Be("topnav-home");
+                topLevelLinks[1].TestId.Should().Be("topnav-qa");
+                topLevelLinks[2].TestId.Should().Be("topnav-searchproviders");
+                topLevelLinks[3].TestId.Should().Be("topnav-manageusers");
+                topLevelLinks[4].TestId.Should().Be("topnav-migrationreports");
+                topLevelLinks[5].TestId.Should().Be("topnav-signout");
+            }
+
+            subNavLinks.Count.Should().Be(0);
         }
 
         [Theory]
@@ -101,20 +106,28 @@ namespace Dfc.CourseDirectory.WebV2.Tests
             var topLevelLinks = GetTopLevelNavLinks(doc);
             var subNavLinks = GetSubNavLinks(doc);
 
-            Assert.Equal(6, topLevelLinks.Count);
-            Assert.Equal("Home", topLevelLinks[0].Label);
-            Assert.Equal("Quality assurance", topLevelLinks[1].Label);
-            Assert.Equal("Search providers", topLevelLinks[2].Label);
-            Assert.Equal("Manage users", topLevelLinks[3].Label);
-            Assert.Equal("Migration reports", topLevelLinks[4].Label);
-            Assert.Equal("Sign out", topLevelLinks[5].Label);
+            topLevelLinks.Count.Should().Be(6);
+
+            using (new AssertionScope())
+            {
+                topLevelLinks[0].TestId.Should().Be("topnav-home");
+                topLevelLinks[1].TestId.Should().Be("topnav-qa");
+                topLevelLinks[2].TestId.Should().Be("topnav-searchproviders");
+                topLevelLinks[3].TestId.Should().Be("topnav-manageusers");
+                topLevelLinks[4].TestId.Should().Be("topnav-migrationreports");
+                topLevelLinks[5].TestId.Should().Be("topnav-signout");
+            }
 
             Assert.Equal(4, subNavLinks.Count);
-            Assert.Equal("Home", subNavLinks[0].Label);
-            Assert.Equal("Your locations", subNavLinks[1].Label);
-            Assert.Equal("Your courses", subNavLinks[2].Label);
-            Assert.Equal("Bulk upload", subNavLinks[3].Label);
-            Assert.Equal("/BulkUpload", subNavLinks[3].Href);
+
+            using (new AssertionScope())
+            {
+                subNavLinks[0].TestId.Should().Be("adminsubnav-home");
+                subNavLinks[1].TestId.Should().Be("adminsubnav-courses");
+                subNavLinks[2].TestId.Should().Be("adminsubnav-locations");
+                subNavLinks[3].TestId.Should().Be("adminsubnav-bulkupload");
+                subNavLinks[3].Href.Should().Be("/BulkUpload");
+            }
         }
 
         [Theory]
@@ -139,20 +152,28 @@ namespace Dfc.CourseDirectory.WebV2.Tests
             var topLevelLinks = GetTopLevelNavLinks(doc);
             var subNavLinks = GetSubNavLinks(doc);
 
-            Assert.Equal(6, topLevelLinks.Count);
-            Assert.Equal("Home", topLevelLinks[0].Label);
-            Assert.Equal("Quality assurance", topLevelLinks[1].Label);
-            Assert.Equal("Search providers", topLevelLinks[2].Label);
-            Assert.Equal("Manage users", topLevelLinks[3].Label);
-            Assert.Equal("Migration reports", topLevelLinks[4].Label);
-            Assert.Equal("Sign out", topLevelLinks[5].Label);
+            topLevelLinks.Count.Should().Be(6);
+
+            using (new AssertionScope())
+            {
+                topLevelLinks[0].TestId.Should().Be("topnav-home");
+                topLevelLinks[1].TestId.Should().Be("topnav-qa");
+                topLevelLinks[2].TestId.Should().Be("topnav-searchproviders");
+                topLevelLinks[3].TestId.Should().Be("topnav-manageusers");
+                topLevelLinks[4].TestId.Should().Be("topnav-migrationreports");
+                topLevelLinks[5].TestId.Should().Be("topnav-signout");
+            }
 
             Assert.Equal(4, subNavLinks.Count);
-            Assert.Equal("Home", subNavLinks[0].Label);
-            Assert.Equal("Your locations", subNavLinks[1].Label);
-            Assert.Equal("Your apprenticeships training", subNavLinks[2].Label);
-            Assert.Equal("Bulk upload", subNavLinks[3].Label);
-            Assert.Equal("/BulkUploadApprenticeships", subNavLinks[3].Href);
+
+            using (new AssertionScope())
+            {
+                subNavLinks[0].TestId.Should().Be("adminsubnav-home");
+                subNavLinks[1].TestId.Should().Be("adminsubnav-apprenticeships");
+                subNavLinks[2].TestId.Should().Be("adminsubnav-locations");
+                subNavLinks[3].TestId.Should().Be("adminsubnav-bulkupload");
+                subNavLinks[3].Href.Should().Be("/BulkUploadApprenticeships");
+            }
         }
 
         [Theory]
@@ -177,21 +198,29 @@ namespace Dfc.CourseDirectory.WebV2.Tests
             var topLevelLinks = GetTopLevelNavLinks(doc);
             var subNavLinks = GetSubNavLinks(doc);
 
-            Assert.Equal(6, topLevelLinks.Count);
-            Assert.Equal("Home", topLevelLinks[0].Label);
-            Assert.Equal("Quality assurance", topLevelLinks[1].Label);
-            Assert.Equal("Search providers", topLevelLinks[2].Label);
-            Assert.Equal("Manage users", topLevelLinks[3].Label);
-            Assert.Equal("Migration reports", topLevelLinks[4].Label);
-            Assert.Equal("Sign out", topLevelLinks[5].Label);
+            topLevelLinks.Count.Should().Be(6);
+
+            using (new AssertionScope())
+            {
+                topLevelLinks[0].TestId.Should().Be("topnav-home");
+                topLevelLinks[1].TestId.Should().Be("topnav-qa");
+                topLevelLinks[2].TestId.Should().Be("topnav-searchproviders");
+                topLevelLinks[3].TestId.Should().Be("topnav-manageusers");
+                topLevelLinks[4].TestId.Should().Be("topnav-migrationreports");
+                topLevelLinks[5].TestId.Should().Be("topnav-signout");
+            }
 
             Assert.Equal(5, subNavLinks.Count);
-            Assert.Equal("Home", subNavLinks[0].Label);
-            Assert.Equal("Your locations", subNavLinks[1].Label);
-            Assert.Equal("Your apprenticeships training", subNavLinks[2].Label);
-            Assert.Equal("Your courses", subNavLinks[3].Label);
-            Assert.Equal("Bulk upload", subNavLinks[4].Label);
-            Assert.Equal("/BulkUpload/LandingOptions", subNavLinks[4].Href);
+
+            using (new AssertionScope())
+            {
+                subNavLinks[0].TestId.Should().Be("adminsubnav-home");
+                subNavLinks[1].TestId.Should().Be("adminsubnav-courses");
+                subNavLinks[2].TestId.Should().Be("adminsubnav-apprenticeships");
+                subNavLinks[3].TestId.Should().Be("adminsubnav-locations");
+                subNavLinks[4].TestId.Should().Be("adminsubnav-bulkupload");
+                subNavLinks[4].Href.Should().Be("/BulkUpload/LandingOptions");
+            }
         }
 
         [Theory]
@@ -216,15 +245,19 @@ namespace Dfc.CourseDirectory.WebV2.Tests
             var topLevelLinks = GetTopLevelNavLinks(doc);
             var subNavLinks = GetSubNavLinks(doc);
 
-            Assert.Equal(5, topLevelLinks.Count);
-            Assert.Equal("Home", topLevelLinks[0].Label);
-            Assert.Equal("Your locations", topLevelLinks[1].Label);
-            Assert.Equal("Your courses", topLevelLinks[2].Label);
-            Assert.Equal("Bulk upload", topLevelLinks[3].Label);
-            Assert.Equal("Sign out", topLevelLinks[4].Label);
-            Assert.Equal("/BulkUpload", topLevelLinks[3].Href);
-            
-            Assert.Equal(0, subNavLinks.Count);
+            topLevelLinks.Count.Should().Be(5);
+
+            using (new AssertionScope())
+            {
+                topLevelLinks[0].TestId.Should().Be("topnav-home");
+                topLevelLinks[1].TestId.Should().Be("topnav-courses");
+                topLevelLinks[2].TestId.Should().Be("topnav-locations");
+                topLevelLinks[3].TestId.Should().Be("topnav-bulkupload");
+                topLevelLinks[3].Href.Should().Be("/BulkUpload");
+                topLevelLinks[4].TestId.Should().Be("topnav-signout");
+            }
+
+            subNavLinks.Count.Should().Be(0);
         }
 
         [Theory]
@@ -249,15 +282,19 @@ namespace Dfc.CourseDirectory.WebV2.Tests
             var topLevelLinks = GetTopLevelNavLinks(doc);
             var subNavLinks = GetSubNavLinks(doc);
 
-            Assert.Equal(5, topLevelLinks.Count);
-            Assert.Equal("Home", topLevelLinks[0].Label);
-            Assert.Equal("Your locations", topLevelLinks[1].Label);
-            Assert.Equal("Your apprenticeships training", topLevelLinks[2].Label);
-            Assert.Equal("Bulk upload", topLevelLinks[3].Label);
-            Assert.Equal("/BulkUploadApprenticeships", topLevelLinks[3].Href);
-            Assert.Equal("Sign out", topLevelLinks[4].Label);
+            topLevelLinks.Count.Should().Be(5);
 
-            Assert.Equal(0, subNavLinks.Count);
+            using (new AssertionScope())
+            {
+                topLevelLinks[0].TestId.Should().Be("topnav-home");
+                topLevelLinks[1].TestId.Should().Be("topnav-apprenticeships");
+                topLevelLinks[2].TestId.Should().Be("topnav-locations");
+                topLevelLinks[3].TestId.Should().Be("topnav-bulkupload");
+                topLevelLinks[3].Href.Should().Be("/BulkUploadApprenticeships");
+                topLevelLinks[4].TestId.Should().Be("topnav-signout");
+            }
+
+            subNavLinks.Count.Should().Be(0);
         }
 
         [Theory]
@@ -282,16 +319,20 @@ namespace Dfc.CourseDirectory.WebV2.Tests
             var topLevelLinks = GetTopLevelNavLinks(doc);
             var subNavLinks = GetSubNavLinks(doc);
 
-            Assert.Equal(6, topLevelLinks.Count);
-            Assert.Equal("Home", topLevelLinks[0].Label);
-            Assert.Equal("Your locations", topLevelLinks[1].Label);
-            Assert.Equal("Your apprenticeships training", topLevelLinks[2].Label);
-            Assert.Equal("Your courses", topLevelLinks[3].Label);
-            Assert.Equal("Bulk upload", topLevelLinks[4].Label);
-            Assert.Equal("/BulkUpload/LandingOptions", topLevelLinks[4].Href);
-            Assert.Equal("Sign out", topLevelLinks[5].Label);
+            topLevelLinks.Count.Should().Be(6);
 
-            Assert.Equal(0, subNavLinks.Count);
+            using (new AssertionScope())
+            {
+                topLevelLinks[0].TestId.Should().Be("topnav-home");
+                topLevelLinks[1].TestId.Should().Be("topnav-courses");
+                topLevelLinks[2].TestId.Should().Be("topnav-apprenticeships");
+                topLevelLinks[3].TestId.Should().Be("topnav-locations");
+                topLevelLinks[4].TestId.Should().Be("topnav-bulkupload");
+                topLevelLinks[4].Href.Should().Be("/BulkUpload/LandingOptions");
+                topLevelLinks[5].TestId.Should().Be("topnav-signout");
+            }
+
+            subNavLinks.Count.Should().Be(0);
         }
 
         [Theory]
@@ -316,7 +357,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests
 
             var doc = await response.GetDocument();
             var bulkUploadLink = doc.GetElementsByTagName("a").Single(a => a.TextContent.Trim() == "Bulk upload");
-            Assert.Equal(expectedHref, bulkUploadLink.GetAttribute("href"));
+            bulkUploadLink.GetAttribute("href").Should().Be(expectedHref);
         }
 
         [Theory]
@@ -342,7 +383,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests
 
             var doc = await response.GetDocument();
             var bulkUploadLink = doc.GetElementsByTagName("a").Single(a => a.TextContent.Trim() == "Bulk upload");
-            Assert.Equal(expectedHref, bulkUploadLink.GetAttribute("href"));
+            bulkUploadLink.GetAttribute("href").Should().Be(expectedHref);
         }
 
         [Theory]
@@ -365,7 +406,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests
             response.EnsureSuccessStatusCode();
 
             var doc = await response.GetDocument();
-            Assert.Null(doc.GetElementByTestId("topnav-apprenticeships"));
+            doc.GetElementByTestId("topnav-apprenticeships").Should().BeNull();
         }
 
         [Theory]
@@ -388,7 +429,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests
             response.EnsureSuccessStatusCode();
 
             var doc = await response.GetDocument();
-            Assert.Null(doc.GetElementByTestId("adminsubnav-apprenticeships"));
+            doc.GetElementByTestId("adminsubnav-apprenticeships").Should().BeNull();
         }
 
         [Fact]
@@ -402,7 +443,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests
 
             // Assert
             var doc = await response.GetDocument();
-            Assert.NotNull(doc.GetAllElementsByTestId("cookie-banner"));
+            doc.GetAllElementsByTestId("cookie-banner").Should().NotBeNull();
         }
 
         [Theory]
@@ -421,7 +462,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests
 
             // Assert
             var doc = await response.GetDocument();
-            Assert.Null(doc.GetElementById("pttcd-cookie-banner"));
+            doc.GetElementByTestId("cookie-banner").Should().BeNull();
         }
 
         [Fact]
@@ -435,7 +476,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests
 
             // Assert
             var doc = await response.GetDocument();
-            Assert.NotNull(doc.GetAllElementsByTestId("cookie-banner-confirmation"));
+            doc.GetAllElementsByTestId("cookie-banner-confirmation").Should().NotBeNull();
         }
 
         [Theory]
@@ -464,36 +505,36 @@ namespace Dfc.CourseDirectory.WebV2.Tests
             var gotGATags = doc.QuerySelectorAll("script")
                 .Where(s => s.GetAttribute("src")?.StartsWith("https://www.googletagmanager.com") == true)
                 .Any();
-            Assert.Equal(expectGATagsToBeRendered, gotGATags);
+            gotGATags.Should().Be(expectGATagsToBeRendered);
         }
 
-        private IReadOnlyList<(string Href, string Label)> GetTopLevelNavLinks(IHtmlDocument doc)
+        private IReadOnlyList<(string Href, string TestId)> GetTopLevelNavLinks(IHtmlDocument doc)
         {
-            var results = new List<(string href, string label)>();
+            var results = new List<(string Href, string TestId)>();
 
             foreach (var item in doc.GetElementsByClassName("govuk-header__navigation-item"))
             {
                 var anchor = item.GetElementsByTagName("a")[0];
                 var href = anchor.GetAttribute("href");
-                var label = anchor.TextContent.Trim();
+                var testId = anchor.GetAttribute("data-testid");
 
-                results.Add((href, label));
+                results.Add((href, testId));
             }
 
             return results;
         }
 
-        private IReadOnlyList<(string Href, string Label)> GetSubNavLinks(IHtmlDocument doc)
+        private IReadOnlyList<(string Href, string TestId)> GetSubNavLinks(IHtmlDocument doc)
         {
-            var results = new List<(string href, string label)>();
+            var results = new List<(string Href, string TestId)>();
 
             foreach (var item in doc.GetElementsByClassName("pttcd-subnav__item"))
             {
                 var anchor = item.GetElementsByTagName("a")[0];
                 var href = anchor.GetAttribute("href");
-                var label = anchor.TextContent.Trim();
+                var testId = anchor.GetAttribute("data-testid");
 
-                results.Add((href, label));
+                results.Add((href, testId));
             }
 
             return results;


### PR DESCRIPTION
- Converted tests to use FluentAssertions and use testid attributes
  instead of labels.