### PR TITLE
Db command signature consistency

### DIFF
--- a/src/Dfc.CourseDirectory.Core/DataStore/CosmosDb/Queries/UpdateApprenticeship.cs
+++ b/src/Dfc.CourseDirectory.Core/DataStore/CosmosDb/Queries/UpdateApprenticeship.cs
@@ -1,11 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using Dfc.CourseDirectory.Core.Models;
+using OneOf;
 using OneOf.Types;
 
 namespace Dfc.CourseDirectory.Core.DataStore.CosmosDb.Queries
 {
-    public class UpdateApprenticeship : ICosmosDbQuery<Success>
+    public class UpdateApprenticeship : ICosmosDbQuery<OneOf<NotFound, Success>>
     {
         public Guid Id { get; set; }
         public int ProviderUkprn { get; set; }

--- a/src/Dfc.CourseDirectory.Core/DataStore/CosmosDb/Queries/UpdateProviderFromUkrlpData.cs
+++ b/src/Dfc.CourseDirectory.Core/DataStore/CosmosDb/Queries/UpdateProviderFromUkrlpData.cs
@@ -1,11 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using Dfc.CourseDirectory.Core.DataStore.CosmosDb.Models;
+using OneOf;
 using OneOf.Types;
 
 namespace Dfc.CourseDirectory.Core.DataStore.CosmosDb.Queries
 {
-    public class UpdateProviderFromUkrlpData : ICosmosDbQuery<Success>
+    public class UpdateProviderFromUkrlpData : ICosmosDbQuery<OneOf<NotFound, Success>>
     {
         public Guid ProviderId { get; set; }
         public string ProviderName { get; set; }

--- a/src/Dfc.CourseDirectory.Core/DataStore/CosmosDb/Queries/UpdateProviderInfo.cs
+++ b/src/Dfc.CourseDirectory.Core/DataStore/CosmosDb/Queries/UpdateProviderInfo.cs
@@ -1,10 +1,11 @@
 ﻿using System;
 using Dfc.CourseDirectory.Core.Models;
+using OneOf;
 using OneOf.Types;
 
 namespace Dfc.CourseDirectory.Core.DataStore.CosmosDb.Queries
 {
-    public class UpdateProviderInfo : ICosmosDbQuery<Success>
+    public class UpdateProviderInfo : ICosmosDbQuery<OneOf<NotFound, Success>>
     {
         public Guid ProviderId { get; set; }
         public string MarketingInformation { get; set; }

--- a/src/Dfc.CourseDirectory.Core/DataStore/CosmosDb/QueryHandlers/UpdateProviderFromUkrlpDataHandler.cs
+++ b/src/Dfc.CourseDirectory.Core/DataStore/CosmosDb/QueryHandlers/UpdateProviderFromUkrlpDataHandler.cs
@@ -1,15 +1,19 @@
 ﻿using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 using Dfc.CourseDirectory.Core.DataStore.CosmosDb.Models;
 using Dfc.CourseDirectory.Core.DataStore.CosmosDb.Queries;
+using Microsoft.Azure.Documents;
 using Microsoft.Azure.Documents.Client;
+using OneOf;
 using OneOf.Types;
 
 namespace Dfc.CourseDirectory.Core.DataStore.CosmosDb.QueryHandlers
 {
-    public class UpdateProviderFromUkrlpDataHandler : ICosmosDbQueryHandler<UpdateProviderFromUkrlpData, Success>
+    public class UpdateProviderFromUkrlpDataHandler :
+        ICosmosDbQueryHandler<UpdateProviderFromUkrlpData, OneOf<NotFound, Success>>
     {
-        public async Task<Success> Execute(
+        public async Task<OneOf<NotFound, Success>> Execute(
             DocumentClient client,
             Configuration configuration,
             UpdateProviderFromUkrlpData request)
@@ -19,9 +23,18 @@ namespace Dfc.CourseDirectory.Core.DataStore.CosmosDb.QueryHandlers
                 configuration.ProviderCollectionName,
                 request.ProviderId.ToString());
 
-            var response = await client.ReadDocumentAsync<Provider>(documentUri);
+            Provider provider;
 
-            var provider = response.Document;
+            try
+            {
+                var response = await client.ReadDocumentAsync<Provider>(documentUri);
+
+                provider = response.Document;
+            }
+            catch (DocumentClientException dex) when (dex.StatusCode == HttpStatusCode.NotFound)
+            {
+                return new NotFound();
+            }
 
             provider.ProviderName = request.ProviderName;
             provider.ProviderAliases = request.Aliases.ToList();

--- a/src/Dfc.CourseDirectory.Core/DataStore/CosmosDb/QueryHandlers/UpdateProviderInfoHandler.cs
+++ b/src/Dfc.CourseDirectory.Core/DataStore/CosmosDb/QueryHandlers/UpdateProviderInfoHandler.cs
@@ -1,14 +1,17 @@
-﻿using System.Threading.Tasks;
+﻿using System.Net;
+using System.Threading.Tasks;
 using Dfc.CourseDirectory.Core.DataStore.CosmosDb.Models;
 using Dfc.CourseDirectory.Core.DataStore.CosmosDb.Queries;
+using Microsoft.Azure.Documents;
 using Microsoft.Azure.Documents.Client;
+using OneOf;
 using OneOf.Types;
 
 namespace Dfc.CourseDirectory.Core.DataStore.CosmosDb.QueryHandlers
 {
-    public class UpdateProviderInfoHandler : ICosmosDbQueryHandler<UpdateProviderInfo, Success>
+    public class UpdateProviderInfoHandler : ICosmosDbQueryHandler<UpdateProviderInfo, OneOf<NotFound, Success>>
     {
-        public async Task<Success> Execute(
+        public async Task<OneOf<NotFound, Success>> Execute(
             DocumentClient client,
             Configuration configuration,
             UpdateProviderInfo request)
@@ -18,9 +21,18 @@ namespace Dfc.CourseDirectory.Core.DataStore.CosmosDb.QueryHandlers
                 configuration.ProviderCollectionName,
                 request.ProviderId.ToString());
 
-            var response = await client.ReadDocumentAsync<Provider>(documentUri);
+            Provider provider;
 
-            var provider = response.Document;
+            try
+            {
+                var response = await client.ReadDocumentAsync<Provider>(documentUri);
+
+                provider = response.Document;
+            }
+            catch (DocumentClientException dex) when (dex.StatusCode == HttpStatusCode.NotFound)
+            {
+                return new NotFound();
+            }
 
             provider.MarketingInformation = request.MarketingInformation;
             provider.DateUpdated = request.UpdatedOn;

--- a/tests/Dfc.CourseDirectory.Testing/DataStore/CosmosDb/QueryHandlers/UpdateApprenticeshipHandler.cs
+++ b/tests/Dfc.CourseDirectory.Testing/DataStore/CosmosDb/QueryHandlers/UpdateApprenticeshipHandler.cs
@@ -1,17 +1,24 @@
 ﻿using System;
 using System.Linq;
-using Dfc.CourseDirectory.Core;
 using Dfc.CourseDirectory.Core.DataStore.CosmosDb.Models;
 using Dfc.CourseDirectory.Core.DataStore.CosmosDb.Queries;
+using OneOf;
 using OneOf.Types;
 
 namespace Dfc.CourseDirectory.Testing.DataStore.CosmosDb.QueryHandlers
 {
-    public class UpdateApprenticeshipHandler : ICosmosDbQueryHandler<UpdateApprenticeship, Success>
+    public class UpdateApprenticeshipHandler : ICosmosDbQueryHandler<UpdateApprenticeship, OneOf<NotFound, Success>>
     {
-        public Success Execute(InMemoryDocumentStore inMemoryDocumentStore, UpdateApprenticeship request)
+        public OneOf<NotFound, Success> Execute(
+            InMemoryDocumentStore inMemoryDocumentStore,
+            UpdateApprenticeship request)
         {
             var apprenticeship = inMemoryDocumentStore.Apprenticeships.All.SingleOrDefault(p => p.Id == request.Id);
+
+            if (apprenticeship == null)
+            {
+                return new NotFound();
+            }
 
             apprenticeship.ProviderUKPRN = request.ProviderUkprn;
             apprenticeship.ApprenticeshipTitle = request.ApprenticeshipTitle;

--- a/tests/Dfc.CourseDirectory.Testing/DataStore/CosmosDb/QueryHandlers/UpdateProviderFromUkrlpDataHandler.cs
+++ b/tests/Dfc.CourseDirectory.Testing/DataStore/CosmosDb/QueryHandlers/UpdateProviderFromUkrlpDataHandler.cs
@@ -1,28 +1,33 @@
 ﻿using System.Linq;
 using Dfc.CourseDirectory.Core.DataStore.CosmosDb.Queries;
+using OneOf;
 using OneOf.Types;
 
 namespace Dfc.CourseDirectory.Testing.DataStore.CosmosDb.QueryHandlers
 {
-    public class UpdateProviderFromUkrlpDataHandler : ICosmosDbQueryHandler<UpdateProviderFromUkrlpData, Success>
+    public class UpdateProviderFromUkrlpDataHandler :
+        ICosmosDbQueryHandler<UpdateProviderFromUkrlpData, OneOf<NotFound, Success>>
     {
-        public Success Execute(InMemoryDocumentStore inMemoryDocumentStore, UpdateProviderFromUkrlpData request)
+        public OneOf<NotFound, Success> Execute(
+            InMemoryDocumentStore inMemoryDocumentStore,
+            UpdateProviderFromUkrlpData request)
         {
             var provider = inMemoryDocumentStore.Providers.All.SingleOrDefault(p => p.Id == request.ProviderId);
 
-            if (provider != null)
+            if (provider == null)
             {
-                provider.ProviderName = request.ProviderName;
-                provider.ProviderAliases = request.Aliases.ToList();
-                provider.ProviderContact = request.Contacts.ToList();
-                provider.Alias = request.Alias;
-                provider.ProviderStatus = request.ProviderStatus;
-                provider.DateUpdated = request.DateUpdated;
-                provider.UpdatedBy = request.UpdatedBy;
-
-                inMemoryDocumentStore.Providers.Save(provider);
+                return new NotFound();
             }
 
+            provider.ProviderName = request.ProviderName;
+            provider.ProviderAliases = request.Aliases.ToList();
+            provider.ProviderContact = request.Contacts.ToList();
+            provider.Alias = request.Alias;
+            provider.ProviderStatus = request.ProviderStatus;
+            provider.DateUpdated = request.DateUpdated;
+            provider.UpdatedBy = request.UpdatedBy;
+
+            inMemoryDocumentStore.Providers.Save(provider);
 
             return new Success();
         }

--- a/tests/Dfc.CourseDirectory.Testing/DataStore/CosmosDb/QueryHandlers/UpdateProviderInfoHandler.cs
+++ b/tests/Dfc.CourseDirectory.Testing/DataStore/CosmosDb/QueryHandlers/UpdateProviderInfoHandler.cs
@@ -1,14 +1,22 @@
 ﻿using System.Linq;
 using Dfc.CourseDirectory.Core.DataStore.CosmosDb.Queries;
+using OneOf;
 using OneOf.Types;
 
 namespace Dfc.CourseDirectory.Testing.DataStore.CosmosDb.QueryHandlers
 {
-    public class UpdateProviderInfoHandler : ICosmosDbQueryHandler<UpdateProviderInfo, Success>
+    public class UpdateProviderInfoHandler : ICosmosDbQueryHandler<UpdateProviderInfo, OneOf<NotFound, Success>>
     {
-        public Success Execute(InMemoryDocumentStore inMemoryDocumentStore, UpdateProviderInfo request)
+        public OneOf<NotFound, Success> Execute(
+            InMemoryDocumentStore inMemoryDocumentStore,
+            UpdateProviderInfo request)
         {
             var provider = inMemoryDocumentStore.Providers.All.SingleOrDefault(p => p.Id == request.ProviderId);
+
+            if (provider == null)
+            {
+                return new NotFound();
+            }
 
             provider.MarketingInformation = request.MarketingInformation;
             provider.DateUpdated = request.UpdatedOn;


### PR DESCRIPTION
Some of the older DB commands that update data have the signature `IDbCommand<Success>` and they either explode if the specified thing doesn't exist or silently do nothing.

For new commands we've settled on `IDbCommand<OneOf<NotFound, Success>>` so we can consistently return the 'not found'-ness.

This commit brings the older commands into line with the new ones.