### PR TITLE
[PTCD-636] Add Azure Function for fixing corrupt course status data

### DIFF
--- a/src/Dfc.CourseDirectory.Core/DataStore/CosmosDb/Models/Course.cs
+++ b/src/Dfc.CourseDirectory.Core/DataStore/CosmosDb/Models/Course.cs
@@ -10,6 +10,12 @@ namespace Dfc.CourseDirectory.Core.DataStore.CosmosDb.Models
     {
         [JsonProperty("id")]
         public Guid Id { get; set; }
+        /// <summary>
+        /// CosmosDb ETag for optimistic concurrency
+        /// https://github.com/Azure/azure-cosmos-dotnet-v2/blob/master/samples/code-samples/DocumentManagement/Program.cs
+        /// </summary>
+        [JsonProperty("_etag")]
+        public string ETag { get; set; }
         public Guid ProviderId { get; set; }
         public int ProviderUKPRN { get; set; }
         public int? CourseId { get; set; }

--- a/src/Dfc.CourseDirectory.Functions/FixCorruptStatusData.cs
+++ b/src/Dfc.CourseDirectory.Functions/FixCorruptStatusData.cs
@@ -1,0 +1,68 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Dfc.CourseDirectory.Core.DataStore.CosmosDb;
+using Dfc.CourseDirectory.Core.DataStore.CosmosDb.Models;
+using Dfc.CourseDirectory.Core.Models;
+using Microsoft.Azure.Documents.Client;
+using Microsoft.Azure.Documents.Linq;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Extensions.Logging;
+
+namespace Dfc.CourseDirectory.Functions
+{
+    /// <summary>
+    /// In prod CourseStatus has got out of sync with the CourseRuns
+    /// </summary>
+    public class FixCorruptStatusData
+    {
+        private readonly Configuration _configuration;
+        private readonly ILogger _logger;
+        private readonly DocumentClient _documentClient;
+
+        public FixCorruptStatusData(
+            Configuration configuration,
+            ILoggerFactory loggerFactory,
+            DocumentClient documentClient)
+        {
+            _configuration = configuration;
+            _documentClient = documentClient;
+            _logger = loggerFactory.CreateLogger<FixCorruptStatusData>();
+        }
+
+        [FunctionName(nameof(FixCorruptStatusData))]
+        [NoAutomaticTrigger]
+        public async Task Run(string input)
+        {
+            var collectionUri = UriFactory.CreateDocumentCollectionUri(
+                _configuration.DatabaseId,
+                _configuration.CoursesCollectionName);
+
+            var query = _documentClient
+                .CreateDocumentQuery<Course>(collectionUri,
+                    new FeedOptions() {EnableCrossPartitionQuery = true})
+                .Where(c => c.CourseStatus == CourseStatus.BulkUploadReadyToGoLive)
+                .AsDocumentQuery();
+
+            int fixCount = 0;
+            await query.ProcessAll(async courses =>
+            {
+                foreach (var course in courses.Where(c => c.CourseRuns.All(r => r.RecordStatus == CourseStatus.Live)))
+                {
+                    course.CourseStatus = CourseStatus.Live;
+
+                    var documentUri = UriFactory.CreateDocumentUri(
+                        _configuration.DatabaseId,
+                        _configuration.CoursesCollectionName,
+                        course.Id.ToString());
+
+                    _logger.LogDebug($"Updating course with correct status {documentUri}");
+                    await _documentClient.ReplaceDocumentAsync(documentUri, course,
+                        new RequestOptions
+                            {AccessCondition = new AccessCondition {Type = AccessConditionType.IfMatch, Condition = course.ETag}});
+                    fixCount++;
+                }
+            });
+            _logger.LogInformation($"{nameof(FixCorruptStatusData)}: Fixed {fixCount} corrupt course statuses.");
+        }
+    }
+}


### PR DESCRIPTION
Add Azure Function for fixing corrupt course status data

The source of the corruption has already been fixed in https://github.com/SkillsFundingAgency/dfc-providerportal-courses/pull/171

Test locally with

```bash
curl -v http://localhost:7071/admin/functions/FixCorruptStatusData -d "{}" -H "Content-Type:application/json"
```

[PTCD-636](https://skillsfundingagency.atlassian.net/browse/PTCD-636)