### PR TITLE
Use an enum & helper method for setting the active admin nav link

### DIFF
--- a/src/Dfc.CourseDirectory.Web/Views/Report/Index.cshtml
+++ b/src/Dfc.CourseDirectory.Web/Views/Report/Index.cshtml
@@ -5,6 +5,7 @@
 @{
     ViewData["Title"] = "Migration status report";
     Layout = "_Layout_Your_Courses";
+    ViewContext.SetLayoutData(activeAdminTopNavSection: AdminTopNavSection.MigrationReports);
 }
 
 

--- a/src/Dfc.CourseDirectory.Web/Views/SearchProvider/Index.cshtml
+++ b/src/Dfc.CourseDirectory.Web/Views/SearchProvider/Index.cshtml
@@ -4,6 +4,7 @@
 @{
     ViewData["Title"] = "Search Providers";
     Layout = "_Layout_Your_Courses";
+    ViewContext.SetLayoutData(activeAdminTopNavSection: AdminTopNavSection.SearchProviders);
 }
 
 <div>

--- a/src/Dfc.CourseDirectory.Web/Views/_ViewImports.cshtml
+++ b/src/Dfc.CourseDirectory.Web/Views/_ViewImports.cshtml
@@ -1,6 +1,7 @@
 ﻿@using Dfc.CourseDirectory.Web
 @using Dfc.CourseDirectory.Web.ViewModels
 @using Dfc.CourseDirectory.Web.ViewComponents.LarsSearch
+@using Dfc.CourseDirectory.WebV2.SharedViews
 
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @addTagHelper *, Dfc.CourseDirectory.Web

--- a/src/Dfc.CourseDirectory.WebV2/Features/ApprenticeshipQA/_ViewStart.cshtml
+++ b/src/Dfc.CourseDirectory.WebV2/Features/ApprenticeshipQA/_ViewStart.cshtml
@@ -1,3 +1,4 @@
 ﻿@{
     Layout = "_V2LayoutAdmin";
+    ViewContext.SetLayoutData(activeAdminTopNavSection: AdminTopNavSection.QualityAssurance);
 }

--- a/src/Dfc.CourseDirectory.WebV2/Features/HelpdeskDashboard/_ViewStart.cshtml
+++ b/src/Dfc.CourseDirectory.WebV2/Features/HelpdeskDashboard/_ViewStart.cshtml
@@ -1,3 +1,4 @@
 ﻿@{
     Layout = "_V2LayoutAdmin";
+    ViewContext.SetLayoutData(activeAdminTopNavSection: AdminTopNavSection.HelpdeskDashboard);
 }

--- a/src/Dfc.CourseDirectory.WebV2/SharedViews/AdminTopNavSection.cs
+++ b/src/Dfc.CourseDirectory.WebV2/SharedViews/AdminTopNavSection.cs
@@ -1,0 +1,11 @@
+﻿namespace Dfc.CourseDirectory.WebV2.SharedViews
+{
+    public enum AdminTopNavSection
+    {
+        HelpdeskDashboard,
+        QualityAssurance,
+        SearchProviders,
+        ManageUsers,
+        MigrationReports
+    }
+}

--- a/src/Dfc.CourseDirectory.WebV2/SharedViews/Components/AdminTopNav.cshtml
+++ b/src/Dfc.CourseDirectory.WebV2/SharedViews/Components/AdminTopNav.cshtml
@@ -1,24 +1,23 @@
 ﻿@inject IFeatureFlagProvider FeatureFlagProvider
 @inject Settings Settings 
 @{
-    var currentController = (string)ViewContext.RouteData.Values["Controller"];
-    var currentAction = (string)ViewContext.RouteData.Values["Action"];
+    var activeSection = ViewData["ActiveAdminTopNavSection"] as AdminTopNavSection?;
 }
 
 <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
 <nav>
     <ul id="navigation" class="govuk-header__navigation" aria-label="Top Level Navigation">
-        <li class="govuk-header__navigation-item@(currentController == "HelpdeskDashboard" && currentAction == "Dashboard" ? " govuk-header__navigation-item--active" : null)">
+        <li class="govuk-header__navigation-item@(activeSection == AdminTopNavSection.HelpdeskDashboard ? " govuk-header__navigation-item--active" : null)">
             <a asp-action="Dashboard" asp-controller="HelpdeskDashboard" class="govuk-header__link" data-testid="topnav-helpdeskdashboard">
                 Helpdesk dashboard
             </a>
         </li>
-        <li class="govuk-header__navigation-item@(currentController == "ApprenticeshipQA" ? " govuk-header__navigation-item--active" : null)">
+        <li class="govuk-header__navigation-item@(activeSection == AdminTopNavSection.QualityAssurance ? " govuk-header__navigation-item--active" : null)">
             <a asp-action="ListProviders" asp-controller="ApprenticeshipQA" class="govuk-header__link" data-testid="topnav-qa">
                 Quality assurance
             </a>
         </li>
-        <li class="govuk-header__navigation-item@(currentController == "SearchProvider" ? " govuk-header__navigation-item--active" : null)">
+        <li class="govuk-header__navigation-item@(activeSection == AdminTopNavSection.SearchProviders ? " govuk-header__navigation-item--active" : null)">
             <a asp-action="Index" asp-controller="SearchProvider" class="govuk-header__link" data-testid="topnav-searchproviders">
                 Search providers
             </a>
@@ -28,7 +27,7 @@
                 Manage users
             </a>
         </li>
-        <li class="govuk-header__navigation-item@(currentController == "Report" && currentAction == "Index" ? " govuk-header__navigation-item--active" : null)">
+        <li class="govuk-header__navigation-item@(activeSection == AdminTopNavSection.MigrationReports ? " govuk-header__navigation-item--active" : null)">
             <a asp-action="Index" asp-controller="Report" class="govuk-header__link" data-testid="topnav-migrationreports">
                 Migration reports
             </a>

--- a/src/Dfc.CourseDirectory.WebV2/SharedViews/ViewContextExtensions.cs
+++ b/src/Dfc.CourseDirectory.WebV2/SharedViews/ViewContextExtensions.cs
@@ -4,9 +4,20 @@ namespace Dfc.CourseDirectory.WebV2.SharedViews
 {
     public static class ViewContextExtensions
     {
-        public static void SetLayoutData(this ViewContext viewContext, string title)
+        public static void SetLayoutData(
+            this ViewContext viewContext,
+            string title = null,
+            AdminTopNavSection? activeAdminTopNavSection = null)
         {
-            viewContext.ViewData["Title"] = title;
+            if (title != null)
+            {
+                viewContext.ViewData["Title"] = title;
+            }
+
+            if (activeAdminTopNavSection != null)
+            {
+                viewContext.ViewData["ActiveAdminTopNavSection"] = activeAdminTopNavSection;
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes the QA link not being active after splitting the controller.