### PR TITLE
[PTCD-592] Cope gracefully with missing venue

### DIFF
--- a/src/Dfc.CourseDirectory.Web/Controllers/CourseSummaryController.cs
+++ b/src/Dfc.CourseDirectory.Web/Controllers/CourseSummaryController.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Dfc.CourseDirectory.Services.CourseService;
 using Dfc.CourseDirectory.Services.Models.Courses;
 using Dfc.CourseDirectory.Services.Models.Regions;
@@ -33,7 +34,7 @@ namespace Dfc.CourseDirectory.Web.Controllers
             _courseService = courseService;
             _venueService = venueService;
         }
-        public IActionResult Index(Guid? courseId, Guid? courseRunId)
+        public async Task<IActionResult> Index(Guid? courseId, Guid? courseRunId)
         {
             Course course = null;
             CourseRun courseRun = null;
@@ -99,10 +100,8 @@ namespace Dfc.CourseDirectory.Web.Controllers
             {
                 if (vm.VenueId != Guid.Empty)
                 {
-                    vm.VenueName = _venueService
-                        .GetVenueByIdAsync(new GetVenueByIdCriteria(courseRun.VenueId.Value.ToString())).Result.Value
-                        .VenueName;
-
+                    var result = await _venueService.GetVenueByIdAsync(new GetVenueByIdCriteria(courseRun.VenueId.Value.ToString()));
+                    vm.VenueName = result.Value?.VenueName;
                 }
             }
 


### PR DESCRIPTION
Cope gracefully with missing venue

We have some bad data that means venueIds are referenced that don't exist. The venue endpoint returns an empty body, which then becomes null, which then throws a null-ref exception which isn't very helpful.

By just not setting the value if it's null the page now loads and the user can correct the corrupted data.

Also corrected use of async.

# Before

![Selection_20201113-01-83ebc83ebc83ebc](https://user-images.githubusercontent.com/19378/99095771-7405e980-25cd-11eb-841e-7bb3fed6de88.png)

(hidden by generic error on other envs)

# After

![Selection_20201113-01-8c4748c4748c474](https://user-images.githubusercontent.com/19378/99095818-82540580-25cd-11eb-94fd-e127b58fb80c.png)

click change...

![Selection_20201113-01-87aaf87aaf87aaf](https://user-images.githubusercontent.com/19378/99095837-88e27d00-25cd-11eb-90b5-f6f29a53f7c7.png)


