### PR TITLE
Drop the 's' from 'Requires' in RequiresProviderContextAttribute

### DIFF
--- a/src/Dfc.CourseDirectory.WebV2/Features/BulkUpload/BulkUploadController.cs
+++ b/src/Dfc.CourseDirectory.WebV2/Features/BulkUpload/BulkUploadController.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace Dfc.CourseDirectory.WebV2.Features.BulkUpload
 {
-    [RequiresProviderContext]
+    [RequireProviderContext]
     [Route("bulk-upload")]
     public class BulkUploadController : Controller
     {

--- a/src/Dfc.CourseDirectory.WebV2/Features/NewApprenticeshipProvider/NewApprenticeshipProviderController.cs
+++ b/src/Dfc.CourseDirectory.WebV2/Features/NewApprenticeshipProvider/NewApprenticeshipProviderController.cs
@@ -12,7 +12,7 @@ using FindStandard = Dfc.CourseDirectory.WebV2.Features.Apprenticeships.FindStan
 namespace Dfc.CourseDirectory.WebV2.Features.NewApprenticeshipProvider
 {
     [Route("new-apprenticeship-provider")]
-    [RequiresProviderContext]
+    [RequireProviderContext]
     public class NewApprenticeshipProviderController : Controller, IMptxController<FlowModel>
     {
         private readonly IMediator _mediator;

--- a/src/Dfc.CourseDirectory.WebV2/Filters/RedirectToProviderSelectionActionFilter.cs
+++ b/src/Dfc.CourseDirectory.WebV2/Filters/RedirectToProviderSelectionActionFilter.cs
@@ -30,7 +30,7 @@ namespace Dfc.CourseDirectory.WebV2.Filters
                 .Any();
 
             var requiresProviderContext = hasProviderContextParameter ||
-                context.ActionDescriptor.Properties.ContainsKey(typeof(RequiresProviderContextMarker));
+                context.ActionDescriptor.Properties.ContainsKey(typeof(RequireProviderContextMarker));
 
             if (requiresProviderContext)
             {

--- a/src/Dfc.CourseDirectory.WebV2/RequireProviderContextAttribute.cs
+++ b/src/Dfc.CourseDirectory.WebV2/RequireProviderContextAttribute.cs
@@ -4,11 +4,11 @@ using Microsoft.AspNetCore.Mvc.ApplicationModels;
 namespace Dfc.CourseDirectory.WebV2
 {
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false)]
-    public sealed class RequiresProviderContextAttribute : Attribute, IActionModelConvention, IControllerModelConvention
+    public sealed class RequireProviderContextAttribute : Attribute, IActionModelConvention, IControllerModelConvention
     {
         private void AddMetadataToAction(ActionModel action)
         {
-            action.Properties.Add(typeof(RequiresProviderContextMarker), RequiresProviderContextMarker.Instance);
+            action.Properties.Add(typeof(RequireProviderContextMarker), RequireProviderContextMarker.Instance);
         }
 
         void IActionModelConvention.Apply(ActionModel action)
@@ -25,10 +25,10 @@ namespace Dfc.CourseDirectory.WebV2
         }
     }
 
-    public sealed class RequiresProviderContextMarker
+    public sealed class RequireProviderContextMarker
     {
-        private RequiresProviderContextMarker() { }
+        private RequireProviderContextMarker() { }
 
-        public static RequiresProviderContextMarker Instance { get; } = new RequiresProviderContextMarker();
+        public static RequireProviderContextMarker Instance { get; } = new RequireProviderContextMarker();
     }
 }

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FilterTests/RedirectToProviderSelectionActionFilterTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FilterTests/RedirectToProviderSelectionActionFilterTests.cs
@@ -50,7 +50,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FilterTests
         public IActionResult Get(ProviderContext providerContext) => Ok("Yay");
 
         [HttpGet("RedirectToProviderSelectionActionFilterTest/without-parameter")]
-        [RequiresProviderContext]
+        [RequireProviderContext]
         public IActionResult GetWithoutParameter() => Ok("Yay");
     }
 }


### PR DESCRIPTION
Other attributes, including those in ASP.NET, use 'require' not 'requires'.