### PR TITLE
Add a LastSyncedFromCosmos column to SQL tables

### DIFF
--- a/src/Dfc.CourseDirectory.Core/DataStore/Sql/Queries/UpsertApprenticeshipsFromCosmos.cs
+++ b/src/Dfc.CourseDirectory.Core/DataStore/Sql/Queries/UpsertApprenticeshipsFromCosmos.cs
@@ -5,9 +5,10 @@ using OneOf.Types;
 
 namespace Dfc.CourseDirectory.Core.DataStore.Sql.Queries
 {
-    public class UpsertApprenticeships : ISqlQuery<None>
+    public class UpsertApprenticeshipsFromCosmos : ISqlQuery<None>
     {
         public IEnumerable<UpsertApprenticeshipRecord> Records { get; set; }
+        public DateTime LastSyncedFromCosmos { get; set; }
     }
 
     public class UpsertApprenticeshipRecord

--- a/src/Dfc.CourseDirectory.Core/DataStore/Sql/Queries/UpsertCoursesFromCosmos.cs
+++ b/src/Dfc.CourseDirectory.Core/DataStore/Sql/Queries/UpsertCoursesFromCosmos.cs
@@ -5,9 +5,10 @@ using OneOf.Types;
 
 namespace Dfc.CourseDirectory.Core.DataStore.Sql.Queries
 {
-    public class UpsertCourses : ISqlQuery<None>
+    public class UpsertCoursesFromCosmos : ISqlQuery<None>
     {
         public IEnumerable<UpsertCoursesRecord> Records { get; set; }
+        public DateTime LastSyncedFromCosmos { get; set; }
     }
 
     public class UpsertCoursesRecord

--- a/src/Dfc.CourseDirectory.Core/DataStore/Sql/Queries/UpsertProvidersFromCosmos.cs
+++ b/src/Dfc.CourseDirectory.Core/DataStore/Sql/Queries/UpsertProvidersFromCosmos.cs
@@ -5,9 +5,10 @@ using OneOf.Types;
 
 namespace Dfc.CourseDirectory.Core.DataStore.Sql.Queries
 {
-    public class UpsertProviders : ISqlQuery<None>
+    public class UpsertProvidersFromCosmos : ISqlQuery<None>
     {
         public IEnumerable<UpsertProvidersRecord> Records { get; set; }
+        public DateTime LastSyncedFromCosmos { get; set; }
     }
 
     public class UpsertProvidersRecord

--- a/src/Dfc.CourseDirectory.Core/DataStore/Sql/Queries/UpsertVenuesFromCosmos.cs
+++ b/src/Dfc.CourseDirectory.Core/DataStore/Sql/Queries/UpsertVenuesFromCosmos.cs
@@ -5,9 +5,10 @@ using OneOf.Types;
 
 namespace Dfc.CourseDirectory.Core.DataStore.Sql.Queries
 {
-    public class UpsertVenues : ISqlQuery<None>
+    public class UpsertVenuesFromCosmos : ISqlQuery<None>
     {
         public IEnumerable<UpsertVenuesRecord> Records { get; set; }
+        public DateTime LastSyncedFromCosmos { get; set; }
     }
 
     public class UpsertVenuesRecord

--- a/src/Dfc.CourseDirectory.Database/Pttcd/Tables/Apprenticeships.sql
+++ b/src/Dfc.CourseDirectory.Database/Pttcd/Tables/Apprenticeships.sql
@@ -1,6 +1,7 @@
 ﻿CREATE TABLE [Pttcd].[Apprenticeships]
 (
 	[ApprenticeshipId] UNIQUEIDENTIFIER NOT NULL CONSTRAINT [PK_Apprenticeships] PRIMARY KEY,
+	[LastSyncedFromCosmos] DATETIME,
 	[ApprenticeshipStatus] INT,
 	[CreatedOn] DATETIME,
 	[CreatedBy] NVARCHAR(MAX),

--- a/src/Dfc.CourseDirectory.Database/Pttcd/Tables/Courses.sql
+++ b/src/Dfc.CourseDirectory.Database/Pttcd/Tables/Courses.sql
@@ -1,6 +1,7 @@
 ﻿CREATE TABLE [Pttcd].[Courses]
 (
 	[CourseId] UNIQUEIDENTIFIER NOT NULL CONSTRAINT [PK_Courses] PRIMARY KEY,
+	[LastSyncedFromCosmos] DATETIME,
 	[CourseStatus] INT,
 	[CreatedOn] DATETIME,
 	[CreatedBy] NVARCHAR(MAX),

--- a/src/Dfc.CourseDirectory.Database/Pttcd/Tables/Providers.sql
+++ b/src/Dfc.CourseDirectory.Database/Pttcd/Tables/Providers.sql
@@ -1,6 +1,7 @@
 ﻿CREATE TABLE [Pttcd].[Providers]
 (
 	[ProviderId] UNIQUEIDENTIFIER NOT NULL CONSTRAINT PK_Providers PRIMARY KEY,
+	[LastSyncedFromCosmos] DATETIME,
 	[ApprenticeshipQAStatus] TINYINT,
 	[Ukprn] INT,
 	[ProviderStatus] TINYINT,

--- a/src/Dfc.CourseDirectory.Database/Pttcd/Tables/Venues.sql
+++ b/src/Dfc.CourseDirectory.Database/Pttcd/Tables/Venues.sql
@@ -1,6 +1,7 @@
 ﻿CREATE TABLE [Pttcd].[Venues]
 (
 	[VenueId] UNIQUEIDENTIFIER NOT NULL CONSTRAINT [PK_Venues] PRIMARY KEY,
+	[LastSyncedFromCosmos] DATETIME,
 	[VenueStatus] TINYINT,
 	[CreatedOn] DATETIME,
 	[CreatedBy] NVARCHAR(MAX),

--- a/tests/Dfc.CourseDirectory.Core.Tests/SqlDataSyncTests.cs
+++ b/tests/Dfc.CourseDirectory.Core.Tests/SqlDataSyncTests.cs
@@ -75,13 +75,15 @@ namespace Dfc.CourseDirectory.Core.Tests
             var sqlDataSync = new SqlDataSync(
                 Fixture.Services.GetRequiredService<IServiceScopeFactory>(),
                 CosmosDbQueryDispatcher.Object,
+                Clock,
                 new NullLogger<SqlDataSync>());
 
             // Act
             await sqlDataSync.SyncProvider(provider);
 
             // Assert
-            Fixture.DatabaseFixture.SqlQuerySpy.VerifyQuery<UpsertProviders, None>(q =>
+            Fixture.DatabaseFixture.SqlQuerySpy.VerifyQuery<UpsertProvidersFromCosmos, None>(q =>
+                q.LastSyncedFromCosmos == Clock.UtcNow &&
                 q.Records.Any(p =>
                     p.ProviderId == provider.Id &&
                     p.Ukprn == provider.Ukprn &&
@@ -148,13 +150,15 @@ namespace Dfc.CourseDirectory.Core.Tests
             var sqlDataSync = new SqlDataSync(
                 Fixture.Services.GetRequiredService<IServiceScopeFactory>(),
                 CosmosDbQueryDispatcher.Object,
+                Clock,
                 new NullLogger<SqlDataSync>());
 
             // Act
             await sqlDataSync.SyncVenue(venue);
 
             // Assert
-            Fixture.DatabaseFixture.SqlQuerySpy.VerifyQuery<UpsertVenues, None>(q =>
+            Fixture.DatabaseFixture.SqlQuerySpy.VerifyQuery<UpsertVenuesFromCosmos, None>(q =>
+                q.LastSyncedFromCosmos == Clock.UtcNow &&
                 q.Records.Any(v =>
                     v.VenueId == venue.Id &&
                     v.ProviderUkprn == 12345 &&
@@ -240,14 +244,20 @@ namespace Dfc.CourseDirectory.Core.Tests
             var sqlDataSync = new SqlDataSync(
                 Fixture.Services.GetRequiredService<IServiceScopeFactory>(),
                 CosmosDbQueryDispatcher.Object,
+                Clock,
                 new NullLogger<SqlDataSync>());
 
             // Act
             await sqlDataSync.SyncCourse(course);
 
             // Assert
-            Fixture.DatabaseFixture.SqlQuerySpy.VerifyQuery<UpsertCourses, None>(q =>
+            Fixture.DatabaseFixture.SqlQuerySpy.VerifyQuery<UpsertCoursesFromCosmos, None>(q =>
             {
+                if (q.LastSyncedFromCosmos != Clock.UtcNow)
+                {
+                    return false;
+                }
+
                 var record = q.Records.SingleOrDefault();
                 if (record == default)
                 {
@@ -353,14 +363,20 @@ namespace Dfc.CourseDirectory.Core.Tests
             var sqlDataSync = new SqlDataSync(
                 Fixture.Services.GetRequiredService<IServiceScopeFactory>(),
                 CosmosDbQueryDispatcher.Object,
+                Clock,
                 new NullLogger<SqlDataSync>());
 
             // Act
             await sqlDataSync.SyncApprenticeship(apprenticeship);
 
             // Assert
-            Fixture.DatabaseFixture.SqlQuerySpy.VerifyQuery<UpsertApprenticeships, None>(q =>
+            Fixture.DatabaseFixture.SqlQuerySpy.VerifyQuery<UpsertApprenticeshipsFromCosmos, None>(q =>
             {
+                if (q.LastSyncedFromCosmos != Clock.UtcNow)
+                {
+                    return false;
+                }
+
                 var record = q.Records.SingleOrDefault();
                 if (record == default)
                 {


### PR DESCRIPTION
We have some invalid data in our SQL tables currently due to some hard deletes on Cosmos data (the hard deletes have since been fixed). By adding this column so we can identify those records that no longer exist in Cosmos after we re-run the 'sync all' processes and seeing which records haven't been updated.

It also may be useful for the forthcoming Azure Search indexer as the 'high water mark' column (https://docs.microsoft.com/en-us/azure/search/search-howto-connecting-azure-sql-database-to-azure-search-using-indexers#high-water-mark-change-detection-policy)