### PR TITLE
PTCD-756 Add a temporary cleanup function for removing zombie courses from SQL

### DIFF
--- a/src/Dfc.CourseDirectory.Functions/ImportLarsData.cs
+++ b/src/Dfc.CourseDirectory.Functions/ImportLarsData.cs
@@ -15,6 +15,7 @@ namespace Dfc.CourseDirectory.Functions
 
         [FunctionName("ImportLarsData")]
         [NoAutomaticTrigger]
+        [Singleton]
         public Task Run(string input) => _dataImporter.ImportData();
     }
 }

--- a/src/Dfc.CourseDirectory.Functions/RemoveZombieCoursesFromSql.cs
+++ b/src/Dfc.CourseDirectory.Functions/RemoveZombieCoursesFromSql.cs
@@ -1,0 +1,44 @@
+﻿using System.Threading.Tasks;
+using Dapper;
+using Dfc.CourseDirectory.Core.DataStore.Sql;
+using Microsoft.Azure.WebJobs;
+
+namespace Dfc.CourseDirectory.Functions
+{
+    public class RemoveZombieCoursesFromSql
+    {
+        private readonly ISqlQueryDispatcher _sqlQueryDispatcher;
+
+        public RemoveZombieCoursesFromSql(ISqlQueryDispatcher sqlQueryDispatcher)
+        {
+            _sqlQueryDispatcher = sqlQueryDispatcher;
+        }
+
+        [FunctionName(nameof(RemoveZombieCoursesFromSql))]
+        [NoAutomaticTrigger]
+        public Task Run(string input)
+        {
+            var sql = @"
+select CourseId into #CourseIds from Pttcd.Courses where LastSyncedFromCosmos is null
+
+delete Pttcd.CourseRunRegions
+from Pttcd.CourseRunRegions crr
+join Pttcd.CourseRuns cr on crr.CourseRunId = cr.CourseRunId
+join #CourseIds x on x.CourseId = cr.CourseId
+
+delete Pttcd.CourseRuns
+from Pttcd.CourseRuns cr
+join #CourseIds x on x.CourseId = cr.CourseId
+
+delete Pttcd.Courses
+from Pttcd.Courses c
+join #CourseIds x on x.CourseId = c.CourseId
+
+drop table #CourseIds";
+
+            return _sqlQueryDispatcher.Transaction.Connection.ExecuteAsync(
+                sql,
+                transaction: _sqlQueryDispatcher.Transaction);
+        }
+    }
+}

--- a/src/Dfc.CourseDirectory.Functions/SyncCosmosCollectionsToSql.cs
+++ b/src/Dfc.CourseDirectory.Functions/SyncCosmosCollectionsToSql.cs
@@ -4,6 +4,7 @@ using Microsoft.Azure.WebJobs;
 
 namespace Dfc.CourseDirectory.Functions
 {
+    [Singleton]
     public class SyncCosmosCollectionsToSql
     {
         private readonly SqlDataSync _sqlDataSync;

--- a/src/Dfc.CourseDirectory.Functions/SyncUkrlp.cs
+++ b/src/Dfc.CourseDirectory.Functions/SyncUkrlp.cs
@@ -15,6 +15,7 @@ namespace Dfc.CourseDirectory.Functions
         }
 
         [FunctionName("SyncUkrlpChanges")]
+        [Singleton]
         public async Task RunNightly([TimerTrigger("0 0 5 * * *")] TimerInfo timer)
         {
             // Only get records updated in the past week.


### PR DESCRIPTION
These were added to Cosmos then hard deleted so our sync process didn't see' their removal. This uses the new LastSyncedFromCosmos column for figuring out what to delete (which will always be null for these zombie courses). A full sync 'SyncCoursesCosmosCollectionToSql' should be run before running this to ensure legit entries have the LastSyncedFromCosmos column populated.