### PR TITLE
Always assign legacy provider context where possible

### DIFF
--- a/src/Dfc.CourseDirectory.Web/Controllers/ProviderController.cs
+++ b/src/Dfc.CourseDirectory.Web/Controllers/ProviderController.cs
@@ -37,7 +37,6 @@ namespace Dfc.CourseDirectory.Web.Controllers
 
         [Authorize]
         [HttpGet("dashboard")]
-        [AssignLegacyProviderContext]
         public IActionResult Dashboard()
         {
             return View();

--- a/src/Dfc.CourseDirectory.WebV2/Features/DeleteCourseRun/DeleteCourseRunController.cs
+++ b/src/Dfc.CourseDirectory.WebV2/Features/DeleteCourseRun/DeleteCourseRunController.cs
@@ -37,7 +37,6 @@ namespace Dfc.CourseDirectory.WebV2.Features.DeleteCourseRun
                         .WithFormFlowInstanceId(instance)));
 
         [HttpGet("confirmed")]
-        [AssignLegacyProviderContext]
         public async Task<IActionResult> Confirmed(
             [FromServices] IProviderContextProvider providerContextProvider,
             [FromServices] IProviderInfoCache providerInfoCache,

--- a/src/Dfc.CourseDirectory.WebV2/Features/EditVenue/EditVenueController.cs
+++ b/src/Dfc.CourseDirectory.WebV2/Features/EditVenue/EditVenueController.cs
@@ -107,7 +107,6 @@ namespace Dfc.CourseDirectory.WebV2.Features.EditVenue
         }
 
         [HttpPost("")]
-        [AssignLegacyProviderContext]
         public async Task<IActionResult> Save(Guid venueId, Save.Command command)
         {
             command.VenueId = venueId;
@@ -122,7 +121,6 @@ namespace Dfc.CourseDirectory.WebV2.Features.EditVenue
         }
 
         [HttpPost("cancel")]
-        [AssignLegacyProviderContext]
         public IActionResult Cancel(FormFlowInstance formFlowInstance)
         {
             formFlowInstance.Delete();

--- a/src/Dfc.CourseDirectory.WebV2/Features/ProviderDashboard/ProviderDashboardController.cs
+++ b/src/Dfc.CourseDirectory.WebV2/Features/ProviderDashboard/ProviderDashboardController.cs
@@ -15,7 +15,6 @@ namespace Dfc.CourseDirectory.WebV2.Features.ProviderDashboard
         }
 
         [HttpGet("dashboard-beta")]
-        [AssignLegacyProviderContext]
         public async Task<IActionResult> Index(ProviderContext providerContext)
         {
             var query = new Dashboard.Query() { ProviderId = providerContext.ProviderInfo.ProviderId };

--- a/src/Dfc.CourseDirectory.WebV2/Features/Providers/ProvidersController.cs
+++ b/src/Dfc.CourseDirectory.WebV2/Features/Providers/ProvidersController.cs
@@ -6,7 +6,6 @@ using Microsoft.AspNetCore.Mvc;
 namespace Dfc.CourseDirectory.WebV2.Features.Providers
 {
     [Route("providers")]
-    [AssignLegacyProviderContext]
     public class ProvidersController : Controller
     {
         private readonly IMediator _mediator;

--- a/src/Dfc.CourseDirectory.WebV2/Middleware/ProviderContextMiddleware.cs
+++ b/src/Dfc.CourseDirectory.WebV2/Middleware/ProviderContextMiddleware.cs
@@ -36,6 +36,12 @@ namespace Dfc.CourseDirectory.WebV2.Middleware
                 await _next(context);
             }
 
+            // As the layout includes links to pages that require the legacy context we need to always set this
+            if (providerContextProvider.GetProviderContext() != null)
+            {
+                providerContextProvider.AssignLegacyProviderContext();
+            }
+
             async Task TryAssignFeature()
             {
                 // For Provider {Super}Users the provider comes from their identity token.


### PR DESCRIPTION
The AssignLegacyProviderContextAttribute exists to ensure that transitioning from a v2 page (which doesn't require the session-based provider context) to a legacy page (which does) will work correctly and the 'ambient' provider is correct.

This attribute has been sprinkled over selected actions where there have been visible bugs. However, given that the layout produces links to legacy pages we should *always* been assigning this where we can. This commit makes that change.

The AssignLegacyProviderContextAttribute is kept around for the day when the layout no longer links to any legacy pages. At such a time this change can be reverted.