### PR TITLE
Sync Venues to SQL immediately after Cosmos change

### DIFF
--- a/src/Dfc.CourseDirectory.Core/DataStore/CosmosDb/Queries/UpdateVenue.cs
+++ b/src/Dfc.CourseDirectory.Core/DataStore/CosmosDb/Queries/UpdateVenue.cs
@@ -1,11 +1,12 @@
 ﻿using System;
+using Dfc.CourseDirectory.Core.DataStore.CosmosDb.Models;
 using Dfc.CourseDirectory.Core.Models;
 using OneOf;
 using OneOf.Types;
 
 namespace Dfc.CourseDirectory.Core.DataStore.CosmosDb.Queries
 {
-    public class UpdateVenue : ICosmosDbQuery<OneOf<NotFound, Success>>
+    public class UpdateVenue : ICosmosDbQuery<OneOf<NotFound, Venue>>
     {
         public Guid VenueId { get; set; }
         public string Name { get; set; }

--- a/src/Dfc.CourseDirectory.Core/DataStore/CosmosDb/QueryHandlers/UpdateVenueHandler.cs
+++ b/src/Dfc.CourseDirectory.Core/DataStore/CosmosDb/QueryHandlers/UpdateVenueHandler.cs
@@ -9,9 +9,9 @@ using OneOf.Types;
 
 namespace Dfc.CourseDirectory.Core.DataStore.CosmosDb.QueryHandlers
 {
-    public class UpdateVenueHandler : ICosmosDbQueryHandler<UpdateVenue, OneOf<NotFound, Success>>
+    public class UpdateVenueHandler : ICosmosDbQueryHandler<UpdateVenue, OneOf<NotFound, Venue>>
     {
-        public async Task<OneOf<NotFound, Success>> Execute(
+        public async Task<OneOf<NotFound, Venue>> Execute(
             DocumentClient client,
             Configuration configuration,
             UpdateVenue request)
@@ -50,7 +50,7 @@ namespace Dfc.CourseDirectory.Core.DataStore.CosmosDb.QueryHandlers
 
             await client.ReplaceDocumentAsync(documentUri, venue);
 
-            return new Success();
+            return venue;
         }
     }
 }

--- a/src/Dfc.CourseDirectory.Services/Models/Venues/Venue.cs
+++ b/src/Dfc.CourseDirectory.Services/Models/Venues/Venue.cs
@@ -15,7 +15,7 @@ namespace Dfc.CourseDirectory.Services.Models.Venues
     public class Venue
     {
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-        public string ID { get; }
+        public string ID { get; set; }
         public int UKPRN { get; }
         [JsonProperty("PROVIDER_ID", Required = Required.AllowNull)]
         [JsonIgnore]

--- a/src/Dfc.CourseDirectory.Web/SqlDataSyncExtensions.cs
+++ b/src/Dfc.CourseDirectory.Web/SqlDataSyncExtensions.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Threading.Tasks;
+using Dfc.CourseDirectory.Core;
+using Dfc.CourseDirectory.Services.Models.Venues;
+
+namespace Dfc.CourseDirectory.Web
+{
+    public static class SqlDataSyncExtensions
+    {
+        public static Task SyncVenue(this SqlDataSync sqlDataSync, Venue venue) =>
+            sqlDataSync.SyncVenue(new Core.DataStore.CosmosDb.Models.Venue()
+            {
+                AdditionalData = null,
+                AddressLine1 = venue.Address1,
+                AddressLine2 = venue.Address2,
+                County = venue.County,
+                CreatedDate = venue.DateAdded,
+                DateUpdated = venue.DateUpdated,
+                Email = venue.Email,
+                Id = Guid.Parse(venue.ID),
+                Latitude = venue.Latitude,
+                LocationId = venue.LocationId,
+                Longitude = venue.Longitude,
+                PHONE = venue.Telephone,
+                Postcode = venue.PostCode,
+                ProvVenueID = venue.ProvVenueID,
+                Status = (int)venue.Status,
+                Town = venue.Town,
+                Ukprn = venue.UKPRN,
+                UpdatedBy = venue.UpdatedBy,
+                VenueName = venue.VenueName,
+                Website = venue.Website
+            });
+    }
+}

--- a/src/Dfc.CourseDirectory.WebV2/ServiceCollectionExtensions.cs
+++ b/src/Dfc.CourseDirectory.WebV2/ServiceCollectionExtensions.cs
@@ -158,6 +158,7 @@ namespace Dfc.CourseDirectory.WebV2
             services.AddSingleton<IAuthorizationHandler, ProviderTypeAuthorizationHandler>();
             services.Configure<GoogleAnalyticsOptions>(configuration.GetSection("GoogleAnalytics"));
             services.Configure<GoogleTagManagerOptions>(configuration.GetSection("GoogleTagManager"));
+            services.AddTransient<SqlDataSync>();
 
             if (!environment.IsTesting())
             {

--- a/tests/Dfc.CourseDirectory.Testing/DataStore/CosmosDb/QueryHandlers/UpdateVenueHandler.cs
+++ b/tests/Dfc.CourseDirectory.Testing/DataStore/CosmosDb/QueryHandlers/UpdateVenueHandler.cs
@@ -1,13 +1,14 @@
 ﻿using System.Linq;
+using Dfc.CourseDirectory.Core.DataStore.CosmosDb.Models;
 using Dfc.CourseDirectory.Core.DataStore.CosmosDb.Queries;
 using OneOf;
 using OneOf.Types;
 
 namespace Dfc.CourseDirectory.Testing.DataStore.CosmosDb.QueryHandlers
 {
-    public class UpdateVenueHandler : ICosmosDbQueryHandler<UpdateVenue, OneOf<NotFound, Success>>
+    public class UpdateVenueHandler : ICosmosDbQueryHandler<UpdateVenue, OneOf<NotFound, Venue>>
     {
-        public OneOf<NotFound, Success> Execute(InMemoryDocumentStore inMemoryDocumentStore, UpdateVenue request)
+        public OneOf<NotFound, Venue> Execute(InMemoryDocumentStore inMemoryDocumentStore, UpdateVenue request)
         {
             var venue = inMemoryDocumentStore.Venues.All.SingleOrDefault(venue => venue.Id == request.VenueId);
 
@@ -32,7 +33,7 @@ namespace Dfc.CourseDirectory.Testing.DataStore.CosmosDb.QueryHandlers
 
             inMemoryDocumentStore.Venues.Save(venue);
 
-            return new Success();
+            return venue;
         }
     }
 }

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/EditVenue/SaveTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/EditVenue/SaveTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Dfc.CourseDirectory.Core.DataStore.CosmosDb.Models;
 using Dfc.CourseDirectory.Core.DataStore.CosmosDb.Queries;
 using Dfc.CourseDirectory.Testing;
 using Dfc.CourseDirectory.WebV2.Features.EditVenue;
@@ -125,7 +126,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.EditVenue
             response.StatusCode.Should().Be(HttpStatusCode.Found);
             response.Headers.Location.OriginalString.Should().Be("/Venues");
 
-            CosmosDbQueryDispatcher.VerifyExecuteQuery<UpdateVenue, OneOf<NotFound, Success>>(q =>
+            CosmosDbQueryDispatcher.VerifyExecuteQuery<UpdateVenue, OneOf<NotFound, Venue>>(q =>
                 q.VenueId == venueId &&
                 q.Name == "Updated name" &&
                 q.Email == "updated@provider.com" &&


### PR DESCRIPTION
The CFL lag means we cannot build a journey that includes any venue
additions/modifications and use SQL for the data source. If we force a
sync for the updated record synchronously then we can successfully 'read
our writes'.