### PR TITLE
Use enum values in Testing DataStore GetApprenticeshipsByIdsHandler

### DIFF
--- a/src/Dfc.CourseDirectory.Services/Models/Enums.cs
+++ b/src/Dfc.CourseDirectory.Services/Models/Enums.cs
@@ -82,6 +82,12 @@ namespace Dfc.CourseDirectory.Services.Models
         AdvancedLearnerLoan = 2
     }
 
+
+    /// <summary>
+    /// Obsolete,
+    /// use <see cref="Dfc.CourseDirectory.Core.Models.ApprenticeshipStatus"/>
+    /// or <see cref="Dfc.CourseDirectory.Core.Models.CourseStatus"/> instead.
+    /// </summary>
     public enum RecordStatus
     {
         [Description("Undefined")]

--- a/tests/Dfc.CourseDirectory.Testing/DataStore/CosmosDb/QueryHandlers/GetApprenticeshipsByIdsHandler.cs
+++ b/tests/Dfc.CourseDirectory.Testing/DataStore/CosmosDb/QueryHandlers/GetApprenticeshipsByIdsHandler.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Dfc.CourseDirectory.Core.DataStore.CosmosDb.Models;
 using Dfc.CourseDirectory.Core.DataStore.CosmosDb.Queries;
+using Dfc.CourseDirectory.Core.Models;
 
 namespace Dfc.CourseDirectory.Testing.DataStore.CosmosDb.QueryHandlers
 {
@@ -12,7 +13,7 @@ namespace Dfc.CourseDirectory.Testing.DataStore.CosmosDb.QueryHandlers
         public IDictionary<Guid, Apprenticeship> Execute(InMemoryDocumentStore inMemoryDocumentStore, GetApprenticeshipsByIds request) =>
             inMemoryDocumentStore.Apprenticeships.All
                 .Where(p => request.ApprenticeshipIds.Contains(p.Id))
-                .Where(p => p.RecordStatus != 4 && p.RecordStatus != 8)
+                .Where(p => p.RecordStatus != (int)ApprenticeshipStatus.Archived && p.RecordStatus != (int)ApprenticeshipStatus.Deleted)
                 .ToDictionary(p => p.Id, p => p);
     }
 }


### PR DESCRIPTION
Use enum values in Testing DataStore GetApprenticeshipsByIdsHandler

Just a suggestions, I might have missed a reason why we're not doing this.