### PR TITLE
Improve debuggability of integration tests

### DIFF
--- a/src/Dfc.CourseDirectory.WebV2/Features/Error/ErrorController.cs
+++ b/src/Dfc.CourseDirectory.WebV2/Features/Error/ErrorController.cs
@@ -8,7 +8,7 @@ namespace Dfc.CourseDirectory.WebV2.Features.Error
     [Route("error")]
     public class ErrorController : Controller
     {
-        public IActionResult Error(int? code, [FromServices] Settings settings)
+        public IActionResult Error(int? code)
         {
             // If there is no error, return a 404
             // (prevents browsing to this page directly)
@@ -23,7 +23,7 @@ namespace Dfc.CourseDirectory.WebV2.Features.Error
             var statusCode = code ?? 500;
 
             // Treat Forbidden as NotFound so we don't give away our internal URLs
-            if (code == 403 && settings.RewriteForbiddenToNotFound)
+            if (code == 403)
             {
                 statusCode = 404;
             }

--- a/src/Dfc.CourseDirectory.WebV2/Settings.cs
+++ b/src/Dfc.CourseDirectory.WebV2/Settings.cs
@@ -3,6 +3,5 @@
     public class Settings
     {
         public string ManageUsersUrl { get; set; }
-        public bool RewriteForbiddenToNotFound { get; set; } = true;
     }
 }

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/CourseDirectoryApplicationFactory.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/CourseDirectoryApplicationFactory.cs
@@ -6,6 +6,7 @@ using Dfc.CourseDirectory.WebV2.Cookies;
 using Dfc.CourseDirectory.WebV2.MultiPageTransaction;
 using FormFlow.State;
 using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.Session;
@@ -54,8 +55,6 @@ namespace Dfc.CourseDirectory.WebV2.Tests
 
         public SingletonSession Session => ((SingletonSessionStore)Services.GetRequiredService<ISessionStore>()).Instance;
 
-        public Settings Settings => Services.GetRequiredService<Settings>();
-
         public SqlQuerySpy SqlQuerySpy => DatabaseFixture.SqlQuerySpy;
 
         public TestData TestData => DatabaseFixture.TestData;
@@ -77,9 +76,6 @@ namespace Dfc.CourseDirectory.WebV2.Tests
             ResetMocks();
 
             MemoryCache.Clear();
-
-            // Restore HostingOptions values to default
-            Settings.RewriteForbiddenToNotFound = false;
 
             Clock.UtcNow = MutableClock.Start;
 
@@ -104,6 +100,10 @@ namespace Dfc.CourseDirectory.WebV2.Tests
             await User.Reset();
         }
 
+        protected virtual void ConfigureServices(IServiceCollection services)
+        {
+        }
+
         protected override void ConfigureWebHost(IWebHostBuilder builder) => builder.UseContentRoot(".");
 
         protected override IWebHostBuilder CreateWebHostBuilder() => WebHost
@@ -113,6 +113,8 @@ namespace Dfc.CourseDirectory.WebV2.Tests
             .UseStartup<Startup>()
             .ConfigureServices(services =>
             {
+                ConfigureServices(services);
+
                 services.AddSingleton<ISearchClient<Onspd>>(OnspdSearchClient.Object);
             });
 

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FilterTests/RestrictProviderTypesAttributeTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FilterTests/RestrictProviderTypesAttributeTests.cs
@@ -14,7 +14,6 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FilterTests
         public RestrictProviderTypesAttributeTests(CourseDirectoryApplicationFactory factory)
             : base(factory)
         {
-            Factory.Settings.RewriteForbiddenToNotFound = false;
         }
 
         [Fact]

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/Startup.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/Startup.cs
@@ -5,7 +5,6 @@ using Dfc.CourseDirectory.WebV2.Middleware;
 using Dfc.CourseDirectory.WebV2.MultiPageTransaction;
 using Dfc.CourseDirectory.WebV2.Tests.ValidationTests;
 using FormFlow.State;
-using GovUk.Frontend.AspNetCore;
 using MediatR;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -30,8 +29,6 @@ namespace Dfc.CourseDirectory.WebV2.Tests
         public void Configure(IApplicationBuilder app)
         {
             app.UseCommitSqlTransaction();
-
-            app.UseCourseDirectoryErrorHandling();
 
             app.UseSession();
 


### PR DESCRIPTION
By default TestServer allows unhandled exceptions to bubble up to the Request sender (HttpClient.SendAsync in our case). This is useful for debugging test failures since you get the stack trace from the source exception in failure messages instead of the stack trace from HttpResponseMessage.EnsureSuccessCode (or similar). Our custom error handling is masking this, however.

Given that we don't rely on our custom error behaviours in our tests (indeed we disable one of its behaviours) turn off custom errors for tests.