### PR TITLE
Refactor - return full Venue from TestData creation

### DIFF
--- a/tests/Dfc.CourseDirectory.Testing/TestData/TestData.CreateVenue.cs
+++ b/tests/Dfc.CourseDirectory.Testing/TestData/TestData.CreateVenue.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Dfc.CourseDirectory.Core.DataStore.CosmosDb.Models;
 using Dfc.CourseDirectory.Core.DataStore.CosmosDb.Queries;
 using Dfc.CourseDirectory.Testing.DataStore.CosmosDb.Queries;
 
@@ -7,7 +8,7 @@ namespace Dfc.CourseDirectory.Testing
 {
     public partial class TestData
     {
-        public async Task<Guid> CreateVenue(
+        public async Task<Venue> CreateVenue(
             Guid providerId,
             string venueName = "Test Venue",
             string addressLine1 = "Venue address line 1",
@@ -53,7 +54,7 @@ namespace Dfc.CourseDirectory.Testing
             var venue = await _cosmosDbQueryDispatcher.ExecuteQuery(new GetVenueById() { VenueId = venueId });
             await _sqlDataSync.SyncVenue(venue);
 
-            return venueId;
+            return venue;
         }
     }
 }

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/Apprenticeships/ClassroomLocationTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/Apprenticeships/ClassroomLocationTests.cs
@@ -173,7 +173,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Apprenticeships
             // Arrange
             var providerId = await TestData.CreateProvider(providerType: ProviderType.Apprenticeships);
 
-            var venueId = await TestData.CreateVenue(providerId);
+            var venueId = (await TestData.CreateVenue(providerId)).Id;
 
             var parentMptxInstance = MptxManager.CreateInstance(new ParentFlow());
             var childMptxInstance = MptxManager.CreateInstance<FlowModel, IFlowModelCallback>(
@@ -210,7 +210,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Apprenticeships
             // Arrange
             var providerId = await TestData.CreateProvider(providerType: ProviderType.Apprenticeships);
 
-            var venueId = await TestData.CreateVenue(providerId);
+            var venueId = (await TestData.CreateVenue(providerId)).Id;
 
             var parentMptxInstance = MptxManager.CreateInstance(new ParentFlow());
             var childMptxInstance = MptxManager.CreateInstance<FlowModel, IFlowModelCallback>(
@@ -246,7 +246,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Apprenticeships
             // Arrange
             var providerId = await TestData.CreateProvider(providerType: ProviderType.Apprenticeships);
 
-            var venueId = await TestData.CreateVenue(providerId);
+            var venueId = (await TestData.CreateVenue(providerId)).Id;
 
             var parentMptxInstance = MptxManager.CreateInstance(new ParentFlow());
             var childMptxInstance = MptxManager.CreateInstance<FlowModel, IFlowModelCallback>(
@@ -287,7 +287,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Apprenticeships
             // Arrange
             var providerId = await TestData.CreateProvider(providerType: ProviderType.Apprenticeships);
 
-            var venueId = await TestData.CreateVenue(providerId, venueName: "The Venue");
+            await TestData.CreateVenue(providerId, venueName: "The Venue");
 
             var parentMptxInstance = MptxManager.CreateInstance(new ParentFlow());
             var childMptxInstance = MptxManager.CreateInstance<FlowModel, IFlowModelCallback>(
@@ -314,7 +314,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Apprenticeships
             // Arrange
             var providerId = await TestData.CreateProvider(providerType: ProviderType.Apprenticeships);
 
-            var venueId = await TestData.CreateVenue(providerId, venueName: "The Venue");
+            var venueId = (await TestData.CreateVenue(providerId, venueName: "The Venue")).Id;
 
             var parentMptxInstance = MptxManager.CreateInstance(new ParentFlow());
             var childMptxInstance = MptxManager.CreateInstance<FlowModel, IFlowModelCallback>(
@@ -376,7 +376,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Apprenticeships
             // Arrange
             var providerId = await TestData.CreateProvider(providerType: ProviderType.Apprenticeships);
 
-            var venueId = await TestData.CreateVenue(providerId);
+            var venueId = (await TestData.CreateVenue(providerId)).Id;
 
             var parentMptxInstance = MptxManager.CreateInstance(new ParentFlow());
             var childMptxInstance = MptxManager.CreateInstance<FlowModel, IFlowModelCallback>(

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/DeleteCourseRunTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/DeleteCourseRunTests.cs
@@ -71,7 +71,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
         {
             // Arrange
             var anotherProviderId = await TestData.CreateProvider(ukprn: 23456);
-            
+
             var providerId = await TestData.CreateProvider(ukprn: 12345);
             var courseId = await TestData.CreateCourse(providerId, createdBy: User.ToUserInfo());
             var courseRunId = Guid.NewGuid();
@@ -124,7 +124,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
             // Arrange
             var providerId = await TestData.CreateProvider();
 
-            var venueId = await TestData.CreateVenue(providerId, venueName: "Test Venue");
+            var venueId = (await TestData.CreateVenue(providerId, venueName: "Test Venue")).Id;
 
             var courseId = await TestData.CreateCourse(
                 providerId,
@@ -160,7 +160,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
             // Arrange
             var providerId = await TestData.CreateProvider();
 
-            var venueId = await TestData.CreateVenue(providerId, venueName: "Test Venue");
+            await TestData.CreateVenue(providerId, venueName: "Test Venue");
 
             var courseId = await TestData.CreateCourse(
                 providerId,
@@ -197,7 +197,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
             // Arrange
             var providerId = await TestData.CreateProvider();
 
-            var venueId = await TestData.CreateVenue(providerId, venueName: "Test Venue");
+            await TestData.CreateVenue(providerId, venueName: "Test Venue");
 
             var courseId = await TestData.CreateCourse(
                 providerId,
@@ -234,7 +234,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
             // Arrange
             var providerId = await TestData.CreateProvider();
 
-            var venueId = await TestData.CreateVenue(providerId, venueName: "Test Venue");
+            await TestData.CreateVenue(providerId, venueName: "Test Venue");
 
             var courseId = await TestData.CreateCourse(
                 providerId,
@@ -271,7 +271,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
             // Arrange
             var providerId = await TestData.CreateProvider();
 
-            var venueId = await TestData.CreateVenue(providerId, venueName: "Test Venue");
+            await TestData.CreateVenue(providerId, venueName: "Test Venue");
 
             var courseId = await TestData.CreateCourse(
                 providerId,
@@ -308,7 +308,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
             // Arrange
             var providerId = await TestData.CreateProvider();
 
-            var venueId = await TestData.CreateVenue(providerId, venueName: "Test Venue");
+            await TestData.CreateVenue(providerId, venueName: "Test Venue");
 
             var courseId = await TestData.CreateCourse(
                 providerId,

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/EditVenue/AddressTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/EditVenue/AddressTests.cs
@@ -29,13 +29,13 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.EditVenue
         {
             // Arrange
             var providerId = await TestData.CreateProvider();
-            var venueId = await TestData.CreateVenue(
+            var venueId = (await TestData.CreateVenue(
                 providerId,
                 addressLine1: "Test Venue line 1",
                 addressLine2: "Test Venue line 2",
                 town: "Town",
                 county: "County",
-                postcode: "AB1 2DE");
+                postcode: "AB1 2DE")).Id;
 
             var request = new HttpRequestMessage(HttpMethod.Get, $"venues/{venueId}/address");
 
@@ -61,7 +61,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.EditVenue
         {
             // Arrange
             var providerId = await TestData.CreateProvider();
-            var venueId = await TestData.CreateVenue(providerId);
+            var venueId = (await TestData.CreateVenue(providerId)).Id;
 
             var journeyInstance = await CreateJourneyInstance(venueId);
             journeyInstance.UpdateState(state =>
@@ -99,7 +99,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.EditVenue
         {
             // Arrange
             var providerId = await TestData.CreateProvider(ukprn: 12345);
-            var venueId = await TestData.CreateVenue(providerId);
+            var venueId = (await TestData.CreateVenue(providerId)).Id;
 
             var anotherProviderId = await TestData.CreateProvider(ukprn: 67890);
 
@@ -202,7 +202,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.EditVenue
         {
             // Arrange
             var providerId = await TestData.CreateProvider();
-            var venueId = await TestData.CreateVenue(providerId);
+            var venueId = (await TestData.CreateVenue(providerId)).Id;
 
             OnspdSearchClient
                 .Setup(c => c.Search(It.Is<OnspdSearchQuery>(q => q.Postcode == "CV1 2AA")))
@@ -255,7 +255,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.EditVenue
         {
             // Arrange
             var providerId = await TestData.CreateProvider();
-            var venueId = await TestData.CreateVenue(providerId);
+            var venueId = (await TestData.CreateVenue(providerId)).Id;
 
             OnspdSearchClient
                 .Setup(c => c.Search(It.Is<OnspdSearchQuery>(q => q.Postcode == "CV1 2AA")))

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/EditVenue/CommonVenueTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/EditVenue/CommonVenueTests.cs
@@ -31,7 +31,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.EditVenue
         {
             // Arrange
             var providerId = await TestData.CreateProvider(ukprn: 12345);
-            var venueId = await TestData.CreateVenue(providerId);
+            var venueId = (await TestData.CreateVenue(providerId)).Id;
 
             var anotherProviderId = await TestData.CreateProvider(ukprn: 67890);
 

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/EditVenue/DetailsTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/EditVenue/DetailsTests.cs
@@ -24,7 +24,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.EditVenue
         {
             // Arrange
             var providerId = await TestData.CreateProvider();
-            var venueId = await TestData.CreateVenue(
+            var venueId = (await TestData.CreateVenue(
                 providerId,
                 venueName: "Test Venue",
                 email: "test-venue@provider.com",
@@ -32,7 +32,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.EditVenue
                 website: "provider.com/test-venue",
                 addressLine1: "Test Venue line 1",
                 town: "Town",
-                postcode: "AB1 2DE");
+                postcode: "AB1 2DE")).Id;
 
             var request = new HttpRequestMessage(HttpMethod.Get, $"venues/{venueId}");
 
@@ -60,7 +60,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.EditVenue
         {
             // Arrange
             var providerId = await TestData.CreateProvider();
-            var venueId = await TestData.CreateVenue(providerId);
+            var venueId = (await TestData.CreateVenue(providerId)).Id;
 
             var journeyInstance = await CreateJourneyInstance(venueId);
             journeyInstance.UpdateState(state =>
@@ -106,7 +106,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.EditVenue
         {
             // Arrange
             var providerId = await TestData.CreateProvider();
-            var venueId = await TestData.CreateVenue(providerId);
+            var venueId = (await TestData.CreateVenue(providerId)).Id;
 
             var journeyInstance = await CreateJourneyInstance(venueId);
             journeyInstance.UpdateState(state =>

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/EditVenue/EmailTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/EditVenue/EmailTests.cs
@@ -23,7 +23,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.EditVenue
         {
             // Arrange
             var providerId = await TestData.CreateProvider();
-            var venueId = await TestData.CreateVenue(providerId, email: "person@provider.com");
+            var venueId = (await TestData.CreateVenue(providerId, email: "person@provider.com")).Id;
 
             var request = new HttpRequestMessage(HttpMethod.Get, $"venues/{venueId}/email");
 
@@ -44,7 +44,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.EditVenue
         {
             // Arrange
             var providerId = await TestData.CreateProvider();
-            var venueId = await TestData.CreateVenue(providerId, email: "person@provider.com");
+            var venueId = (await TestData.CreateVenue(providerId, email: "person@provider.com")).Id;
 
             var journeyInstance = await CreateJourneyInstance(venueId);
             journeyInstance.UpdateState(state => state.Email = existingValue);
@@ -68,7 +68,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.EditVenue
         {
             // Arrange
             var providerId = await TestData.CreateProvider(ukprn: 12345);
-            var venueId = await TestData.CreateVenue(providerId);
+            var venueId = (await TestData.CreateVenue(providerId)).Id;
 
             var anotherProviderId = await TestData.CreateProvider(ukprn: 67890);
 
@@ -117,7 +117,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.EditVenue
         {
             // Arrange
             var providerId = await TestData.CreateProvider();
-            var venueId = await TestData.CreateVenue(providerId);
+            var venueId = (await TestData.CreateVenue(providerId)).Id;
 
             var requestContent = new FormUrlEncodedContentBuilder()
                 .Add("Email", "bademail")
@@ -145,7 +145,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.EditVenue
         {
             // Arrange
             var providerId = await TestData.CreateProvider();
-            var venueId = await TestData.CreateVenue(providerId);
+            var venueId = (await TestData.CreateVenue(providerId)).Id;
 
             var requestContent = new FormUrlEncodedContentBuilder()
                 .Add("Email", email)

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/EditVenue/NameTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/EditVenue/NameTests.cs
@@ -24,7 +24,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.EditVenue
         {
             // Arrange
             var providerId = await TestData.CreateProvider();
-            var venueId = await TestData.CreateVenue(providerId, venueName: "Test Venue");
+            var venueId = (await TestData.CreateVenue(providerId, venueName: "Test Venue")).Id;
 
             var request = new HttpRequestMessage(HttpMethod.Get, $"venues/{venueId}/name");
 
@@ -44,7 +44,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.EditVenue
         {
             // Arrange
             var providerId = await TestData.CreateProvider();
-            var venueId = await TestData.CreateVenue(providerId, venueName: "Test Venue");
+            var venueId = (await TestData.CreateVenue(providerId, venueName: "Test Venue")).Id;
 
             var journeyInstance = await CreateJourneyInstance(venueId);
             journeyInstance.UpdateState(state => state.Name = existingValue);
@@ -68,7 +68,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.EditVenue
         {
             // Arrange
             var providerId = await TestData.CreateProvider(ukprn: 12345);
-            var venueId = await TestData.CreateVenue(providerId);
+            var venueId = (await TestData.CreateVenue(providerId)).Id;
 
             var anotherProviderId = await TestData.CreateProvider(ukprn: 67890);
 
@@ -117,7 +117,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.EditVenue
         {
             // Arrange
             var providerId = await TestData.CreateProvider();
-            var venueId = await TestData.CreateVenue(providerId);
+            var venueId = (await TestData.CreateVenue(providerId)).Id;
 
             var requestContent = new FormUrlEncodedContentBuilder()
                 .Add("Name", "")
@@ -143,7 +143,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.EditVenue
         {
             // Arrange
             var providerId = await TestData.CreateProvider();
-            var venueId = await TestData.CreateVenue(providerId);
+            var venueId = (await TestData.CreateVenue(providerId)).Id;
 
             var requestContent = new FormUrlEncodedContentBuilder()
                 .Add("Name", new string('x', 251))  // limit is 250
@@ -169,7 +169,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.EditVenue
         {
             // Arrange
             var providerId = await TestData.CreateProvider();
-            var venueId = await TestData.CreateVenue(providerId);
+            var venueId = (await TestData.CreateVenue(providerId)).Id;
 
             await TestData.CreateVenue(providerId, venueName: "Venue B");
 
@@ -197,7 +197,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.EditVenue
         {
             // Arrange
             var providerId = await TestData.CreateProvider();
-            var venueId = await TestData.CreateVenue(providerId);
+            var venueId = (await TestData.CreateVenue(providerId)).Id;
 
             var requestContent = new FormUrlEncodedContentBuilder()
                 .Add("Name", "Another Venue")

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/EditVenue/PhoneNumberTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/EditVenue/PhoneNumberTests.cs
@@ -23,7 +23,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.EditVenue
         {
             // Arrange
             var providerId = await TestData.CreateProvider();
-            var venueId = await TestData.CreateVenue(providerId, telephone: "020 7946 0000");
+            var venueId = (await TestData.CreateVenue(providerId, telephone: "020 7946 0000")).Id;
 
             var request = new HttpRequestMessage(HttpMethod.Get, $"venues/{venueId}/phone-number");
 
@@ -44,7 +44,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.EditVenue
         {
             // Arrange
             var providerId = await TestData.CreateProvider();
-            var venueId = await TestData.CreateVenue(providerId, telephone: "020 7946 0000");
+            var venueId = (await TestData.CreateVenue(providerId, telephone: "020 7946 0000")).Id;
 
             var journeyInstance = await CreateJourneyInstance(venueId);
             journeyInstance.UpdateState(state => state.PhoneNumber = existingValue);
@@ -68,7 +68,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.EditVenue
         {
             // Arrange
             var providerId = await TestData.CreateProvider(ukprn: 12345);
-            var venueId = await TestData.CreateVenue(providerId);
+            var venueId = (await TestData.CreateVenue(providerId)).Id;
 
             var anotherProviderId = await TestData.CreateProvider(ukprn: 67890);
 
@@ -117,7 +117,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.EditVenue
         {
             // Arrange
             var providerId = await TestData.CreateProvider();
-            var venueId = await TestData.CreateVenue(providerId);
+            var venueId = (await TestData.CreateVenue(providerId)).Id;
 
             var requestContent = new FormUrlEncodedContentBuilder()
                 .Add("PhoneNumber", "xxx")
@@ -145,7 +145,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.EditVenue
         {
             // Arrange
             var providerId = await TestData.CreateProvider();
-            var venueId = await TestData.CreateVenue(providerId);
+            var venueId = (await TestData.CreateVenue(providerId)).Id;
 
             var requestContent = new FormUrlEncodedContentBuilder()
                 .Add("PhoneNumber", phoneNumber)

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/EditVenue/SaveTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/EditVenue/SaveTests.cs
@@ -30,7 +30,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.EditVenue
         {
             // Arrange
             var providerId = await TestData.CreateProvider(ukprn: 12345);
-            var venueId = await TestData.CreateVenue(providerId, email: "person@provider.com");
+            var venueId = (await TestData.CreateVenue(providerId, email: "person@provider.com")).Id;
 
             var anotherProviderId = await TestData.CreateProvider(ukprn: 67890);
 
@@ -93,7 +93,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.EditVenue
         {
             // Arrange
             var providerId = await TestData.CreateProvider();
-            var venueId = await TestData.CreateVenue(providerId);
+            var venueId = (await TestData.CreateVenue(providerId)).Id;
 
             var journeyInstance = await CreateJourneyInstance(venueId);
             journeyInstance.UpdateState(state =>

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/EditVenue/WebsiteTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/EditVenue/WebsiteTests.cs
@@ -24,7 +24,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.EditVenue
         {
             // Arrange
             var providerId = await TestData.CreateProvider();
-            var venueId = await TestData.CreateVenue(providerId, website: "provider.com");
+            var venueId = (await TestData.CreateVenue(providerId, website: "provider.com")).Id;
 
             var request = new HttpRequestMessage(HttpMethod.Get, $"venues/{venueId}/website");
 
@@ -45,7 +45,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.EditVenue
         {
             // Arrange
             var providerId = await TestData.CreateProvider();
-            var venueId = await TestData.CreateVenue(providerId, website: "provider.com");
+            var venueId = (await TestData.CreateVenue(providerId, website: "provider.com")).Id;
 
             var journeyInstance = await CreateJourneyInstance(venueId);
             journeyInstance.UpdateState(state => state.Website = existingValue);
@@ -69,7 +69,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.EditVenue
         {
             // Arrange
             var providerId = await TestData.CreateProvider(ukprn: 12345);
-            var venueId = await TestData.CreateVenue(providerId);
+            var venueId = (await TestData.CreateVenue(providerId)).Id;
 
             var anotherProviderId = await TestData.CreateProvider(ukprn: 67890);
 
@@ -118,7 +118,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.EditVenue
         {
             // Arrange
             var providerId = await TestData.CreateProvider();
-            var venueId = await TestData.CreateVenue(providerId);
+            var venueId = (await TestData.CreateVenue(providerId)).Id;
 
             var requestContent = new FormUrlEncodedContentBuilder()
                 .Add("Website", ":bad/website")
@@ -148,7 +148,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.EditVenue
         {
             // Arrange
             var providerId = await TestData.CreateProvider();
-            var venueId = await TestData.CreateVenue(providerId);
+            var venueId = (await TestData.CreateVenue(providerId)).Id;
 
             var requestContent = new FormUrlEncodedContentBuilder()
                 .Add("Website", website)

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/NewApprenticeshipProvider/ApprenticeshipEmployerLocationsRegionsTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/NewApprenticeshipProvider/ApprenticeshipEmployerLocationsRegionsTests.cs
@@ -84,7 +84,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
             // Assert
             Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
         }
-        
+
         [Fact]
         public async Task Get_NoPersistedStateRendersExpectedOutput()
         {
@@ -171,7 +171,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
             // Assert
             Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
         }
-        
+
         [Theory]
         [InlineData(ApprenticeshipQAStatus.Submitted)]
         [InlineData(ApprenticeshipQAStatus.InProgress)]
@@ -322,7 +322,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             if (gotClassroomLocation)
             {
-                var venueId = await TestData.CreateVenue(providerId);
+            var venueId = (await TestData.CreateVenue(providerId)).Id;
 
                 mptxInstance.Update(s => s.SetClassroomLocationForVenue(
                     venueId,

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/NewApprenticeshipProvider/ApprenticeshipEmployerLocationsTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/NewApprenticeshipProvider/ApprenticeshipEmployerLocationsTests.cs
@@ -256,7 +256,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             if (gotClassroomLocation)
             {
-                var venueId = await TestData.CreateVenue(providerId);
+            var venueId = (await TestData.CreateVenue(providerId)).Id;
 
                 mptxInstance.Update(s => s.SetClassroomLocationForVenue(
                     venueId,

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/NewApprenticeshipProvider/ApprenticeshipSummaryTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/NewApprenticeshipProvider/ApprenticeshipSummaryTests.cs
@@ -573,7 +573,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
             var standardVersion = 1;
             var standard = await TestData.CreateStandard(standardCode, standardVersion, standardName: "My standard");
 
-            var venueId = await TestData.CreateVenue(providerId);
+            var venueId = (await TestData.CreateVenue(providerId)).Id;
 
             await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
 
@@ -624,7 +624,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
             var standardVersion = 1;
             var standard = await TestData.CreateStandard(standardCode, standardVersion, standardName: "My standard");
 
-            var venueId = await TestData.CreateVenue(providerId);
+            var venueId = (await TestData.CreateVenue(providerId)).Id;
 
             await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
 
@@ -706,7 +706,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
                 {
                     CreateApprenticeshipLocation.CreateRegions(regions)
                 });
-            var venueId = await TestData.CreateVenue(providerId);
+            var venueId = (await TestData.CreateVenue(providerId)).Id;
 
             await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
 

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/NewApprenticeshipProvider/FlowModelInitializerTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/NewApprenticeshipProvider/FlowModelInitializerTests.cs
@@ -125,7 +125,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
                 });
 
             var standardsAndFrameworksCache = new StandardsAndFrameworksCache(CosmosDbQueryDispatcher.Object);
-            
+
             var submissionId = await TestData.CreateApprenticeshipQASubmission(
                 providerId,
                 submittedOn: Clock.UtcNow,
@@ -289,7 +289,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
             var user = await TestData.CreateUser(providerUserId, "somebody@provider1.com", "Provider 1", "Person", providerId);
             var adminUser = await TestData.CreateUser(adminUserId, "admin@provider.com", "admin", "admin", null);
             var framework = await TestData.CreateFramework(1, 1, 1, "Test Framework");
-            var venueId = await TestData.CreateVenue(providerId);
+            var venueId = (await TestData.CreateVenue(providerId)).Id;
 
             var venue = await CosmosDbQueryDispatcher.Object.ExecuteQuery(new GetVenueById() { VenueId = venueId });
 
@@ -308,7 +308,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
                         venue,
                         radius,
                         new[] { deliveryMode })
-                }); 
+                });
 
             var standardsAndFrameworksCache = new StandardsAndFrameworksCache(CosmosDbQueryDispatcher.Object);
 

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FilterTests/AuthorizeVenueAttributeTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FilterTests/AuthorizeVenueAttributeTests.cs
@@ -22,7 +22,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FilterTests
         {
             // Arrange
             var providerId = await TestData.CreateProvider();
-            var venueId = await TestData.CreateVenue(providerId);
+            var venueId = (await TestData.CreateVenue(providerId)).Id;
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
@@ -44,7 +44,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FilterTests
         {
             // Arrange
             var providerId = await TestData.CreateProvider();
-            var venueId = await TestData.CreateVenue(providerId);
+            var venueId = (await TestData.CreateVenue(providerId)).Id;
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
@@ -67,7 +67,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FilterTests
             // Arrange
             var anotherProviderId = await TestData.CreateProvider(ukprn: 23456);
             var providerId = await TestData.CreateProvider(ukprn: 12345);
-            var venueId = await TestData.CreateVenue(providerId);
+            var venueId = (await TestData.CreateVenue(providerId)).Id;
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
@@ -87,7 +87,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FilterTests
         {
             // Arrange
             var providerId = await TestData.CreateProvider(ukprn: 12345);
-            var venueId = await TestData.CreateVenue(providerId);
+            var venueId = (await TestData.CreateVenue(providerId)).Id;
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,


### PR DESCRIPTION
Refactor - return full Venue from TestData creation

Fixup usages:

* Remove unused venueId variables.
* Pluck Id out for all exisiting usages.

This allows using default values for the generated Venue in the rest of a test without doing another round-trip to fetch the entity.