### PR TITLE
Don't fail the build if referencing [Obsolete] code

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,5 +2,6 @@
   <PropertyGroup>
     <TreatWarningsAsErrors Condition="'$(Configuration)' == 'Release'">true</TreatWarningsAsErrors>
     <LangVersion>8.0</LangVersion>
+    <WarningsNotAsErrors>CS0612;CS0618</WarningsNotAsErrors>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
We want to use this for annotating old/legacy code that we shouldn't be
touching but 'warnings as errors' means build fails. Add an exception
for the obsolete error diagnostic codes. If [Obsolete(error = true)] is
used then build will still fail with an error.