### PR TITLE
Fix SetProviderDisplayNameSourceHandler return value

### DIFF
--- a/src/Dfc.CourseDirectory.Core/DataStore/Sql/QueryHandlers/SetProviderDisplayNameSourceHandler.cs
+++ b/src/Dfc.CourseDirectory.Core/DataStore/Sql/QueryHandlers/SetProviderDisplayNameSourceHandler.cs
@@ -20,7 +20,7 @@ namespace Dfc.CourseDirectory.Core.DataStore.Sql.QueryHandlers
                 ProviderId = query.ProviderId
             };
 
-            var updated = (await transaction.Connection.ExecuteAsync(sql, paramz, transaction)) == 1;
+            var updated = (await transaction.Connection.ExecuteAsync(sql, paramz, transaction)) != 0;
 
             if (updated)
             {


### PR DESCRIPTION
Now that FindACourseIndex table is updated via a trigger the row count from a single row update is no longer necessarily 1. Invert the condition in this handler to account for this.