### PR TITLE
Change default isolation level to RepeatableRead

### DIFF
--- a/src/Dfc.CourseDirectory.Core/DataStore/Sql/ServiceCollectionExtensions.cs
+++ b/src/Dfc.CourseDirectory.Core/DataStore/Sql/ServiceCollectionExtensions.cs
@@ -25,7 +25,7 @@ namespace Dfc.CourseDirectory.Core.DataStore.Sql
                 {
                     connection.Open();
                 }
-                var transaction = connection.BeginTransaction(IsolationLevel.ReadCommitted);
+                var transaction = connection.BeginTransaction(IsolationLevel.RepeatableRead);
 
                 var marker = sp.GetRequiredService<SqlTransactionMarker>();
                 marker.OnTransactionCreated(transaction);


### PR DESCRIPTION
1465e321d1583b33e5a85529e591fff4bc291988 reduced the isolation level from `Snapshot` to `ReadCommitted` (to resolve deadlocking). This isolation level is not quite strong enough and we're seeing intermittent sync issues with the FAC index table which look to be solved by moving to `RepeatableRead`.