### PR TITLE
Disable TimerTrigger function apps for local development

### DIFF
--- a/src/Dfc.CourseDirectory.Functions/local.settings.json
+++ b/src/Dfc.CourseDirectory.Functions/local.settings.json
@@ -1,6 +1,8 @@
 {
   "IsEncrypted": false,
   "Values": {
+    "AzureWebJobs.SyncUkrlpChanges.Disabled": "true",
+    "AzureWebJobs.ImportLarsData.Disabled": "true",
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet"
   }


### PR DESCRIPTION
Otherwise they start running when you `func start` locally which is disruptive and possibly will mess with data you care about.

https://docs.microsoft.com/en-us/azure/azure-functions/disable-function#localsettingsjson