### PR TITLE
Only refresh FAC entries for changed provider when necessary

### DIFF
--- a/src/Dfc.CourseDirectory.Database/Pttcd/Triggers/TRG_Providers_UpdateFindACourseIndex.sql
+++ b/src/Dfc.CourseDirectory.Database/Pttcd/Triggers/TRG_Providers_UpdateFindACourseIndex.sql
@@ -10,7 +10,12 @@ BEGIN
 	SELECT cr.CourseRunId FROM Pttcd.CourseRuns cr
 	JOIN Pttcd.Courses c ON cr.CourseId = c.CourseId
 	JOIN inserted x ON c.ProviderUkprn = x.Ukprn
+	JOIN deleted y ON y.ProviderId = x.ProviderId
 	WHERE cr.CourseRunStatus = 1
+	-- Check that at least one mutable field used by FAC index has actually changed
+	AND (y.Alias <> x.Alias
+		OR y.ProviderName <> x.ProviderName
+		OR y.DisplayNameSource <> x.DisplayNameSource)
 
 	EXEC Pttcd.RefreshFindACourseIndex @ProviderLiveCourseRuns
 


### PR DESCRIPTION
Previously we would refresh the live course runs for a given provider when any field on the Provider record was changed. In reality, only 3 fields there are actually used so we only need to regenerate when those fields have changed.