### PR TITLE
PTCD-793 Live T Levels Report Use FindACourseIndex Table

### DIFF
--- a/src/Dfc.CourseDirectory.Core/DataStore/Sql/Queries/GetLiveTLevelsReport.cs
+++ b/src/Dfc.CourseDirectory.Core/DataStore/Sql/Queries/GetLiveTLevelsReport.cs
@@ -9,7 +9,7 @@ namespace Dfc.CourseDirectory.Core.DataStore.Sql.Queries
 
     public class LiveTLevelsReportItem
     {
-        public int Ukprn { get; set; }
+        public int ProviderUkprn { get; set; }
         public string ProviderName { get; set; }
         public string TLevelName { get; set; }
         public string VenueName { get; set; }

--- a/src/Dfc.CourseDirectory.WebV2/Features/TLevels/Reporting/LiveTLevelsReport.cs
+++ b/src/Dfc.CourseDirectory.WebV2/Features/TLevels/Reporting/LiveTLevelsReport.cs
@@ -16,7 +16,7 @@ namespace Dfc.CourseDirectory.WebV2.Features.TLevels.Reporting.LiveTLevelsReport
     public class Csv
     {
         [Name("UKPRN")]
-        public int Ukprn { get; set; }
+        public int ProviderUkprn { get; set; }
 
         [Name("Provider Name")]
         public string ProviderName { get; set; }
@@ -51,7 +51,7 @@ namespace Dfc.CourseDirectory.WebV2.Features.TLevels.Reporting.LiveTLevelsReport
                 {
                     yield return new Csv
                     {
-                        Ukprn = result.Ukprn,
+                        ProviderUkprn = result.ProviderUkprn,
                         ProviderName = result.ProviderName,
                         TLevelName = result.TLevelName,
                         VenueName = result.VenueName,

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/TLevels/Reporting/LiveTLevelsReportTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/TLevels/Reporting/LiveTLevelsReportTests.cs
@@ -90,13 +90,13 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.Reporting
 
                 return new Features.TLevels.Reporting.LiveTLevelsReport.Csv
                 {
-                    Ukprn = p.Ukprn,
+                    ProviderUkprn = p.Ukprn,
                     ProviderName = p.ProviderName,
                     TLevelName = t.TLevelDefinition.Name,
                     VenueName = t.Locations.Single().VenueName,
                     StartDate = t.StartDate
                 };
-            }).OrderBy(r => r.Ukprn).ThenBy(r => r.TLevelName).ThenBy(r => r.VenueName).ThenBy(r => r.StartDate));
+            }).OrderBy(r => r.ProviderUkprn).ThenBy(r => r.TLevelName).ThenBy(r => r.VenueName).ThenBy(r => r.StartDate));
         }
     }
 }


### PR DESCRIPTION
Update Live T Levels Report to read data from Pttcd.FindACourseIndex

This is a bit of future-proofing to avoid the need to maintain the Live T Levels Report query in line with the rules applied to the FAC index. (As of course, this report should be representative of the data in the FAC index.)

Can't ship until #1870 is merged.