### PR TITLE
Fixed GetAddressAddressSearchService ID Generation

### DIFF
--- a/src/Dfc.CourseDirectory.WebV2/AddressSearch/GetAddressAddressSearchService.cs
+++ b/src/Dfc.CourseDirectory.WebV2/AddressSearch/GetAddressAddressSearchService.cs
@@ -123,7 +123,7 @@ namespace Dfc.CourseDirectory.WebV2.AddressSearch
 
         private class FindAddressResultItem
         {
-            public string Id => string.Join(" ", AddressLines).Trim().GetHashCode().ToString("X");
+            public string Id => string.Join(" ", AddressLines).Trim();
 
             public IEnumerable<string> AddressLines => new[] { Line1, Line2, Line3, Line4, Locality };
 

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/AddressSearch/GetAddressAddressSearchServiceTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/AddressSearch/GetAddressAddressSearchServiceTests.cs
@@ -103,15 +103,15 @@ namespace Dfc.CourseDirectory.WebV2.Tests.AddressSearch
             // Assert
             Assert.Equal(3, result.Count);
 
-            Assert.Equal($"XX2 00X::{"658 Mitcham Road".GetHashCode():X}", result.First().Id);
+            Assert.Equal($"XX2 00X::658 Mitcham Road", result.First().Id);
             Assert.Equal("658 Mitcham Road", result.First().StreetAddress);
             Assert.Equal("Croydon", result.First().Place);
 
-            Assert.Equal($"XX2 00X::{"660 Mitcham Road".GetHashCode():X}", result.Skip(1).First().Id);
+            Assert.Equal($"XX2 00X::660 Mitcham Road", result.Skip(1).First().Id);
             Assert.Equal("660 Mitcham Road", result.Skip(1).First().StreetAddress);
             Assert.Equal("Croydon", result.Skip(1).First().Place);
 
-            Assert.Equal($"XX2 00X::{"Lanfranc School House Mitcham Road".GetHashCode():X}", result.Skip(2).First().Id);
+            Assert.Equal($"XX2 00X::Lanfranc School House Mitcham Road", result.Skip(2).First().Id);
             Assert.Equal("Lanfranc School House Mitcham Road", result.Skip(2).First().StreetAddress);
             Assert.Equal("Croydon", result.Skip(2).First().Place);
         }
@@ -289,7 +289,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.AddressSearch
             var service = new GetAddressAddressSearchService(httpClient, options.Object);
 
             // Act
-            var result = await service.GetById($"XX2 00X::{"660 Mitcham Road".GetHashCode():X}");
+            var result = await service.GetById($"XX2 00X::660 Mitcham Road");
 
             // Assert
             Assert.NotNull(result);


### PR DESCRIPTION
`GetHashCode()` is not guaranteed across multiple .NET processes, and thus can potentially fail in a multi-server environment.

https://docs.microsoft.com/en-us/dotnet/api/system.string.gethashcode?view=netcore-3.1