### PR TITLE
Filter Out Archived Venues in DataStore.Cosmos Handlers

### DIFF
--- a/src/Dfc.CourseDirectory.Core/DataStore/CosmosDb/QueryHandlers/GetVenueByIdHandler.cs
+++ b/src/Dfc.CourseDirectory.Core/DataStore/CosmosDb/QueryHandlers/GetVenueByIdHandler.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Dfc.CourseDirectory.Core.DataStore.CosmosDb.Models;
 using Dfc.CourseDirectory.Core.DataStore.CosmosDb.Queries;
+using Dfc.CourseDirectory.Core.Models;
 using Microsoft.Azure.Documents.Client;
 using Microsoft.Azure.Documents.Linq;
 
@@ -16,6 +17,7 @@ namespace Dfc.CourseDirectory.Core.DataStore.CosmosDb.QueryHandlers
                 configuration.VenuesCollectionName);
 
             var query = client.CreateDocumentQuery<Venue>(collectionUri, new FeedOptions() { EnableCrossPartitionQuery = true })
+                .Where(v => v.Status != (int)VenueStatus.Archived)
                 .Where(v => v.Id == request.VenueId)
                 .AsDocumentQuery();
 

--- a/src/Dfc.CourseDirectory.Core/DataStore/CosmosDb/QueryHandlers/GetVenuesByProviderHandler.cs
+++ b/src/Dfc.CourseDirectory.Core/DataStore/CosmosDb/QueryHandlers/GetVenuesByProviderHandler.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Dfc.CourseDirectory.Core.DataStore.CosmosDb.Models;
 using Dfc.CourseDirectory.Core.DataStore.CosmosDb.Queries;
+using Dfc.CourseDirectory.Core.Models;
 using Microsoft.Azure.Documents.Client;
 using Microsoft.Azure.Documents.Linq;
 
@@ -19,11 +20,12 @@ namespace Dfc.CourseDirectory.Core.DataStore.CosmosDb.QueryHandlers
                 configuration.DatabaseId,
                 configuration.VenuesCollectionName);
 
-            var query = client.CreateDocumentQuery<Venue>(collectionUri, new FeedOptions() { EnableCrossPartitionQuery = true })
+            return client
+                .CreateDocumentQuery<Venue>(collectionUri, new FeedOptions { EnableCrossPartitionQuery = true })
+                .Where(v => v.Status != (int)VenueStatus.Archived)
                 .Where(v => v.Ukprn == request.ProviderUkprn)
-                .AsDocumentQuery();
-
-            return query.FetchAll();
+                .AsDocumentQuery()
+                .FetchAll();
         }
     }
 }


### PR DESCRIPTION
As discussed on slack, there is no use case for returning archived Venues

Resurrection of original PR: https://github.com/SkillsFundingAgency/dfc-coursedirectory/pull/1869 and extended following analysis of impact to changes.

The only potential issue we might see is on FAC where an active course has an Archived Venue attached to it, in which case we'll need to fix the data and establish how that came to be.