### PR TITLE
PTCD-603 Use ProviderName instead of CourseDirectoryName in search results

### DIFF
--- a/src/Dfc.CourseDirectory.Web/ViewComponents/SearchProviderResults/Default.cshtml
+++ b/src/Dfc.CourseDirectory.Web/ViewComponents/SearchProviderResults/Default.cshtml
@@ -24,7 +24,7 @@
                 {
                     <tr class="govuk-table__row">
                         <td class="govuk-table__cell">@p.UKPRN</td>
-                        <td class="govuk-table__cell">@p.CourseDirectoryName</td>
+                        <td class="govuk-table__cell">@p.Name</td>
                         <td class="govuk-table__cell">@p.Town</td>
                         <td class="govuk-table__cell">@p.Postcode</td>
                         <td class="govuk-table__cell">@p.ProviderStatus</td>
@@ -36,7 +36,7 @@
                             }
                             else if (p.Status == ProviderStatus.Registered && p.ProviderStatus.Equals("Active", StringComparison.InvariantCultureIgnoreCase))
                             {
-                            <a id="btnOnboardProvider" style="margin: auto;" onclick="OnBoardProvider('@p.UKPRN','@p.Id'); return false;" href="#" class="govuk-link"><span id="btnOnboardProviderText">Add provider</span> <span class="govuk-visually-hidden">@p.CourseDirectoryName</span></a>
+                            <a id="btnOnboardProvider" style="margin: auto;" onclick="OnBoardProvider('@p.UKPRN','@p.Id'); return false;" href="#" class="govuk-link"><span id="btnOnboardProviderText">Add provider</span> <span class="govuk-visually-hidden">@p.Name</span></a>
                             }                           
                         </td>
                     </tr>

--- a/src/Dfc.CourseDirectory.Web/ViewModels/SearchProvider/SearchProviderResultViewModel.cs
+++ b/src/Dfc.CourseDirectory.Web/ViewModels/SearchProvider/SearchProviderResultViewModel.cs
@@ -21,8 +21,6 @@ namespace Dfc.CourseDirectory.Web.ViewModels.SearchProvider
 
         public string ProviderStatus { get; set; }
 
-        public string CourseDirectoryName { get; set; }
-
         public string TradingName { get; set; }
 
         public string ProviderAlias { get; set; }
@@ -39,7 +37,6 @@ namespace Dfc.CourseDirectory.Web.ViewModels.SearchProvider
                 UKPRN = provider.UKPRN,
                 Status = (ProviderStatus)provider.Status,
                 ProviderStatus = provider.ProviderStatus,
-                CourseDirectoryName = provider.CourseDirectoryName,
                 TradingName = provider.TradingName,
                 ProviderAlias = provider.ProviderAlias
             };


### PR DESCRIPTION
CourseDirectoryName is an old thing that's not always populated, leading
to empty columns in the Provider Search UI. Provider Name will always be
populated (via UKRLP) and is what we want to show here.