### PR TITLE
[PTCD-822] Update add-apprenticeship-published designs

### DIFF
--- a/src/Dfc.CourseDirectory.Web/Controllers/ApprenticeshipsController.cs
+++ b/src/Dfc.CourseDirectory.Web/Controllers/ApprenticeshipsController.cs
@@ -745,7 +745,7 @@ namespace Dfc.CourseDirectory.Web.Controllers
 
             var apprenticeship = _session.GetObject<Apprenticeship>("selectedApprenticeship");
 
-            model.ApprenticeshipName = apprenticeship.ApprenticeshipTitle;
+            model.ApprenticeshipName = apprenticeship?.ApprenticeshipTitle;
 
             _session.Remove("selectedApprenticeship");
             _session.Remove("ApprenticeshipMode");

--- a/src/Dfc.CourseDirectory.Web/Controllers/ApprenticeshipsController.cs
+++ b/src/Dfc.CourseDirectory.Web/Controllers/ApprenticeshipsController.cs
@@ -293,7 +293,7 @@ namespace Dfc.CourseDirectory.Web.Controllers
                             x.ApprenticeshipLocationType == ApprenticeshipLocationType.EmployerBased);
                         apprenticeship.ApprenticeshipLocations.Add(CreateRegionLocation(new string[0], true));
                     }
-                    
+
                     _session.SetObject("selectedApprenticeship", apprenticeship);
                     return RedirectToAction("Summary", "Apprenticeships", new {});
 
@@ -379,7 +379,7 @@ namespace Dfc.CourseDirectory.Web.Controllers
 
             var model = new SummaryViewModel();
 
-            if (requestModel.Mode != ApprenticeshipMode.Undefined) 
+            if (requestModel.Mode != ApprenticeshipMode.Undefined)
             {
                 _session.SetObject("ApprenticeshipMode", requestModel.Mode);
             }
@@ -457,7 +457,7 @@ namespace Dfc.CourseDirectory.Web.Controllers
 
             model.SummaryOnly = requestModel.SummaryOnly;
             model.Mode = mode;
-            
+
             return View("../Apprenticeships/Summary/Index", model);
         }
 
@@ -616,7 +616,7 @@ namespace Dfc.CourseDirectory.Web.Controllers
 
             return RedirectToAction("DeliveryOptionsCombined", "Apprenticeships");
         }
-        
+
         [HttpPost]
         public async Task<IActionResult> Add(AddDeliveryOptionViewModel model)
         {
@@ -735,7 +735,7 @@ namespace Dfc.CourseDirectory.Web.Controllers
                 ApprenticeshipLocationType.ClassroomBasedAndEmployerBased));
 
             _session.SetObject("selectedApprenticeship", apprenticeship);
-           
+
             return Json(Url.Action("Summary", "Apprenticeships", new {}));
         }
 
@@ -850,7 +850,7 @@ namespace Dfc.CourseDirectory.Web.Controllers
             {
                 return RedirectToAction("Index", "ProviderApprenticeships", new { });
             }
-            
+
             var model = new DeleteDeliveryOptionViewModel();
 
             model.Combined = Location.ApprenticeshipLocationType == ApprenticeshipLocationType.ClassroomBasedAndEmployerBased;
@@ -883,10 +883,10 @@ namespace Dfc.CourseDirectory.Web.Controllers
         {
             _session.SetString("Option", type == ApprenticeshipLocationType.ClassroomBasedAndEmployerBased ?
                 "AddNewVenueForApprenticeshipsCombined" :"AddNewVenueForApprenticeships");
-            
+
             return Json(Url.Action("AddVenue", "Venues"));
         }
-        
+
         private Dictionary<string, List<string>> SubRegionCodesToDictionary(IEnumerable<string> subRegions)
         {
             SelectRegionModel selectRegionModel = new SelectRegionModel();

--- a/src/Dfc.CourseDirectory.Web/Views/Apprenticeships/Complete/Index.cshtml
+++ b/src/Dfc.CourseDirectory.Web/Views/Apprenticeships/Complete/Index.cshtml
@@ -4,35 +4,35 @@
     Layout = "_V2LayoutProviderContext";
 }
 
-<div class="govuk-panel govuk-panel--confirmation">
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <div class="govuk-panel govuk-panel--confirmation">
+            <div class="govuk-panel__body">
+                <h1 class="govuk-panel__title">
+                    Apprenticeship published
+                </h1>
+                <div class="govuk-panel__body">
+                    @Model.ApprenticeshipName
+                </div>
+            </div>
+        </div>
 
-    <div class="govuk-panel__body">
-        <h1 class="govuk-panel__title">
-            Apprenticeship published
-        </h1>
+        <p class="govuk-body">
+            Your apprenticeship will be available on Find an apprenticeship training provider
+            for employers who want to take on an apprentice.
+        </p>
 
-        <div class="govuk-panel__body">
-            @Model.ApprenticeshipName
+        <div class="Publish-Complete">
+            <div class="govuk-!-margin-top-6">
+                <h2 class="govuk-heading-l govuk-!-font-size-36">What next?</h2>
+            </div>
+        </div>
+        <div class="govuk-form-group">
+            @Html.ActionLink("Add a new apprenticeship", "AddAnotherApprenticeship", "Apprenticeships", new { }, new { @class = "govuk-link" })
+            <br/>
+            @Html.ActionLink("View, edit, copy or delete an apprenticeship", "Index", "ProviderApprenticeships", new { }, new { @class = "govuk-link" })
+            <br/>
+            @Html.ActionLink("Back to the home screen", "Index", "Home", new { }, new { @class = "govuk-link" })
         </div>
     </div>
-
 </div>
-<p class="govuk-body">
-    Your apprenticeship will be available on Find an apprenticeship training provider
-    for employers who want to take on an apprentice.
-</p>
-<div class="Publish-Complete">
-    <div class="govuk-!-margin-top-6">
-        <h2 class="govuk-heading-l govuk-!-font-size-36">What next?</h2>
-    </div>
-</div>
-<div class="govuk-form-group">
-    @Html.ActionLink("Add a new apprenticeship", "AddAnotherApprenticeship", "Apprenticeships", new { }, new { @class = "govuk-link" })
-    <br/>
-    @Html.ActionLink("View, edit, copy or delete an apprenticeship", "Index", "ProviderApprenticeships", new { }, new { @class = "govuk-link" })
-    <br/>
-    @Html.ActionLink("Back to the home screen", "Index", "Home", new { }, new { @class = "govuk-link" })
-
-</div>
-
-

--- a/src/Dfc.CourseDirectory.Web/Views/Apprenticeships/Complete/Index.cshtml
+++ b/src/Dfc.CourseDirectory.Web/Views/Apprenticeships/Complete/Index.cshtml
@@ -11,19 +11,27 @@
             Apprenticeship published
         </h1>
 
-        @Model.ApprenticeshipName has been added to the Course directory
+        <div class="govuk-panel__body">
+            @Model.ApprenticeshipName
+        </div>
     </div>
 
 </div>
+<p class="govuk-body">
+    Your apprenticeship is available to employers who want to take on apprentices on
+    Find apprenticeship training for your apprentice.
+</p>
 <div class="Publish-Complete">
     <div class="govuk-!-margin-top-6">
-        <h2 class="govuk-heading-l govuk-!-font-size-36">Next steps</h2>
+        <h2 class="govuk-heading-l govuk-!-font-size-36">What next?</h2>
     </div>
 </div>
 <div class="govuk-form-group">
-    @Html.ActionLink("Add another apprenticeship", "AddAnotherApprenticeship", "Apprenticeships", new { }, new { @class = "govuk-link" })
+    @Html.ActionLink("Add a new apprenticeship", "AddAnotherApprenticeship", "Apprenticeships", new { }, new { @class = "govuk-link" })
     <br/>
-    @Html.ActionLink("Return to dashboard", "Index", "Home", new { }, new { @class = "govuk-link" })
+    @Html.ActionLink("View, edit, copy or delete an apprenticeship", "Index", "ProviderApprenticeships", new { }, new { @class = "govuk-link" })
+    <br/>
+    @Html.ActionLink("Back to the home screen", "Index", "Home", new { }, new { @class = "govuk-link" })
 
 </div>
 

--- a/src/Dfc.CourseDirectory.Web/Views/Apprenticeships/Complete/Index.cshtml
+++ b/src/Dfc.CourseDirectory.Web/Views/Apprenticeships/Complete/Index.cshtml
@@ -1,7 +1,7 @@
 ﻿@model Dfc.CourseDirectory.Web.ViewModels.Apprenticeships.CompleteViewModel
 @{
     ViewData["Title"] = Model.ApprenticeshipName + " has been added to the Course directory";
-    Layout = "_Layout_Your_Courses";
+    Layout = "_V2LayoutProviderContext";
 }
 
 <div class="govuk-panel govuk-panel--confirmation">

--- a/src/Dfc.CourseDirectory.Web/Views/Apprenticeships/Complete/Index.cshtml
+++ b/src/Dfc.CourseDirectory.Web/Views/Apprenticeships/Complete/Index.cshtml
@@ -1,4 +1,5 @@
-﻿@model Dfc.CourseDirectory.Web.ViewModels.Apprenticeships.CompleteViewModel
+﻿@addTagHelper *, GovUk.Frontend.AspNetCore
+@model Dfc.CourseDirectory.Web.ViewModels.Apprenticeships.CompleteViewModel
 @{
     ViewData["Title"] = Model.ApprenticeshipName + " has been added to the Course directory";
     Layout = "_V2LayoutProviderContext";
@@ -6,16 +7,11 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        <div class="govuk-panel govuk-panel--confirmation">
-            <div class="govuk-panel__body">
-                <h1 class="govuk-panel__title">
-                    Apprenticeship published
-                </h1>
-                <div class="govuk-panel__body">
-                    @Model.ApprenticeshipName
-                </div>
-            </div>
-        </div>
+        <govuk-panel>
+            <govuk-panel-title>Apprenticeship published</govuk-panel-title>
+
+            @Model.ApprenticeshipName
+        </govuk-panel>
 
         <p class="govuk-body">
             Your apprenticeship will be available on Find an apprenticeship training provider
@@ -28,11 +24,14 @@
             </div>
         </div>
         <div class="govuk-form-group">
-            @Html.ActionLink("Add a new apprenticeship", "AddAnotherApprenticeship", "Apprenticeships", new { }, new { @class = "govuk-link" })
+            <a asp-controller="Apprenticeships" asp-action="AddAnotherApprenticeship"
+               class="govuk-link">Add a new apprenticeship</a>
             <br/>
-            @Html.ActionLink("View, edit, copy or delete an apprenticeship", "Index", "ProviderApprenticeships", new { }, new { @class = "govuk-link" })
+            <a asp-controller="ProviderApprenticeships" asp-action="Index"
+               class="govuk-link">View, edit, copy or delete an apprenticeship</a>
             <br/>
-            @Html.ActionLink("Back to the home screen", "Index", "Home", new { }, new { @class = "govuk-link" })
+            <a asp-controller="Home" asp-action="Index"
+               class="govuk-link">Back to the home screen</a>
         </div>
     </div>
 </div>

--- a/src/Dfc.CourseDirectory.Web/Views/Apprenticeships/Complete/Index.cshtml
+++ b/src/Dfc.CourseDirectory.Web/Views/Apprenticeships/Complete/Index.cshtml
@@ -1,9 +1,6 @@
-﻿@using Microsoft.AspNetCore.Authorization;
-@using Microsoft.AspNetCore.Identity
-@using Dfc.CourseDirectory.Services.Models
-@model Dfc.CourseDirectory.Web.ViewModels.Apprenticeships.CompleteViewModel
+﻿@model Dfc.CourseDirectory.Web.ViewModels.Apprenticeships.CompleteViewModel
 @{
-    ViewData["Title"] = Model.ApprenticeshipName + " has been added to the Course directory"; 
+    ViewData["Title"] = Model.ApprenticeshipName + " has been added to the Course directory";
     Layout = "_Layout_Your_Courses";
 }
 

--- a/src/Dfc.CourseDirectory.Web/Views/Apprenticeships/Complete/Index.cshtml
+++ b/src/Dfc.CourseDirectory.Web/Views/Apprenticeships/Complete/Index.cshtml
@@ -18,8 +18,8 @@
 
 </div>
 <p class="govuk-body">
-    Your apprenticeship is available to employers who want to take on apprentices on
-    Find apprenticeship training for your apprentice.
+    Your apprenticeship will be available on Find an apprenticeship training provider
+    for employers who want to take on an apprentice.
 </p>
 <div class="Publish-Complete">
     <div class="govuk-!-margin-top-6">


### PR DESCRIPTION
* Update add-apprenticeship-published to new design system and make 2/3 width.
* Update copy/links/layout to match prototype (with new content from Clair, see ticket).
* Null-proof the page so it doesn't explode when refreshed (still loses the name, but slightly less bad UX now).

[PTCD-822](https://skillsfundingagency.atlassian.net/browse/PTCD-822)

![Selection_20210204-01-72c2e72c2e72c2e](https://user-images.githubusercontent.com/19378/106894845-62714100-66e7-11eb-9f22-270dadb231ba.png)
