### PR TITLE
Use UserId for audit fields instead of email

### DIFF
--- a/src/Dfc.CourseDirectory.Core/DataStore/CosmosDb/QueryHandlers/CreateApprenticeshipHandler.cs
+++ b/src/Dfc.CourseDirectory.Core/DataStore/CosmosDb/QueryHandlers/CreateApprenticeshipHandler.cs
@@ -33,7 +33,7 @@ namespace Dfc.CourseDirectory.Core.DataStore.CosmosDb.QueryHandlers
                 {
                     Address = l.Address,
                     ApprenticeshipLocationType = l.ApprenticeshipLocationType,
-                    CreatedBy = request.CreatedByUser.Email,
+                    CreatedBy = request.CreatedByUser.UserId,
                     CreatedDate = request.CreatedDate,
                     DeliveryModes = l.DeliveryModes.ToList(),
                     Id = Guid.NewGuid(),
@@ -45,15 +45,15 @@ namespace Dfc.CourseDirectory.Core.DataStore.CosmosDb.QueryHandlers
                     Radius = l.Radius,
                     RecordStatus = 1,
                     Regions = l.Regions,
-                    UpdatedBy = request.CreatedByUser.Email,
+                    UpdatedBy = request.CreatedByUser.UserId,
                     UpdatedDate = request.CreatedDate,
                     VenueId = l.VenueId
                 }).ToList(),
                 RecordStatus = request.Status,
                 CreatedDate = request.CreatedDate,
-                CreatedBy = request.CreatedByUser.Email,
+                CreatedBy = request.CreatedByUser.UserId,
                 UpdatedDate = request.CreatedDate,
-                UpdatedBy = request.CreatedByUser.Email,
+                UpdatedBy = request.CreatedByUser.UserId,
                 BulkUploadErrors = new List<BulkUploadError>(),
                 ValidationErrors = Array.Empty<string>(),
                 LocationValidationErrors = Array.Empty<string>()

--- a/src/Dfc.CourseDirectory.Core/DataStore/CosmosDb/QueryHandlers/UpdateApprenticeshipHandler.cs
+++ b/src/Dfc.CourseDirectory.Core/DataStore/CosmosDb/QueryHandlers/UpdateApprenticeshipHandler.cs
@@ -49,7 +49,7 @@ namespace Dfc.CourseDirectory.Core.DataStore.CosmosDb.QueryHandlers
             {
                 Address = l.Address,
                 ApprenticeshipLocationType = l.ApprenticeshipLocationType,
-                CreatedBy = request.UpdatedBy.Email,
+                CreatedBy = request.UpdatedBy.UserId,
                 CreatedDate = request.UpdatedDate,
                 DeliveryModes = l.DeliveryModes.ToList(),
                 Id = Guid.NewGuid(),
@@ -61,12 +61,12 @@ namespace Dfc.CourseDirectory.Core.DataStore.CosmosDb.QueryHandlers
                 Radius = l.Radius,
                 RecordStatus = 1,
                 Regions = l.Regions,
-                UpdatedBy = request.UpdatedBy.Email,
+                UpdatedBy = request.UpdatedBy.UserId,
                 UpdatedDate = request.UpdatedDate,
                 VenueId = l.VenueId
             }).ToList();
             apprenticeship.UpdatedDate = request.UpdatedDate;
-            apprenticeship.UpdatedBy = request.UpdatedBy.Email;
+            apprenticeship.UpdatedBy = request.UpdatedBy.UserId;
 
             request.StandardOrFramework.Switch(
                 standard =>

--- a/src/Dfc.CourseDirectory.Core/DataStore/CosmosDb/QueryHandlers/UpdateProviderInfoHandler.cs
+++ b/src/Dfc.CourseDirectory.Core/DataStore/CosmosDb/QueryHandlers/UpdateProviderInfoHandler.cs
@@ -36,7 +36,7 @@ namespace Dfc.CourseDirectory.Core.DataStore.CosmosDb.QueryHandlers
 
             provider.MarketingInformation = request.MarketingInformation;
             provider.DateUpdated = request.UpdatedOn;
-            provider.UpdatedBy = request.UpdatedBy.Email;
+            provider.UpdatedBy = request.UpdatedBy.UserId;
 
             await client.ReplaceDocumentAsync(documentUri, provider);
 

--- a/src/Dfc.CourseDirectory.Core/DataStore/CosmosDb/QueryHandlers/UpdateVenueHandler.cs
+++ b/src/Dfc.CourseDirectory.Core/DataStore/CosmosDb/QueryHandlers/UpdateVenueHandler.cs
@@ -45,7 +45,7 @@ namespace Dfc.CourseDirectory.Core.DataStore.CosmosDb.QueryHandlers
             venue.Postcode = request.Postcode;
             venue.Latitude = request.Latitude;
             venue.Longitude = request.Longitude;
-            venue.UpdatedBy = request.UpdatedBy.Email;
+            venue.UpdatedBy = request.UpdatedBy.UserId;
             venue.DateUpdated = request.UpdatedDate;
 
             await client.ReplaceDocumentAsync(documentUri, venue);

--- a/tests/Dfc.CourseDirectory.Testing/DataStore/CosmosDb/QueryHandlers/CreateApprenticeshipHandler.cs
+++ b/tests/Dfc.CourseDirectory.Testing/DataStore/CosmosDb/QueryHandlers/CreateApprenticeshipHandler.cs
@@ -27,7 +27,7 @@ namespace Dfc.CourseDirectory.Testing.DataStore.CosmosDb.QueryHandlers
                 {
                     Address = l.Address,
                     ApprenticeshipLocationType = l.ApprenticeshipLocationType,
-                    CreatedBy = request.CreatedByUser.Email,
+                    CreatedBy = request.CreatedByUser.UserId,
                     CreatedDate = request.CreatedDate,
                     DeliveryModes = l.DeliveryModes.ToList(),
                     Id = Guid.NewGuid(),
@@ -39,15 +39,15 @@ namespace Dfc.CourseDirectory.Testing.DataStore.CosmosDb.QueryHandlers
                     Radius = l.Radius,
                     RecordStatus = 1,
                     Regions = l.Regions,
-                    UpdatedBy = request.CreatedByUser.Email,
+                    UpdatedBy = request.CreatedByUser.UserId,
                     UpdatedDate = request.CreatedDate,
                     VenueId = l.VenueId
                 }).ToList(),
                 RecordStatus = request.Status,
                 CreatedDate = request.CreatedDate,
-                CreatedBy = request.CreatedByUser.Email,
+                CreatedBy = request.CreatedByUser.UserId,
                 UpdatedDate = request.CreatedDate,
-                UpdatedBy = request.CreatedByUser.Email,
+                UpdatedBy = request.CreatedByUser.UserId,
                 BulkUploadErrors = new List<BulkUploadError>(),
                 ValidationErrors = Array.Empty<string>(),
                 LocationValidationErrors = Array.Empty<string>()

--- a/tests/Dfc.CourseDirectory.Testing/DataStore/CosmosDb/QueryHandlers/CreateCourseHandler.cs
+++ b/tests/Dfc.CourseDirectory.Testing/DataStore/CosmosDb/QueryHandlers/CreateCourseHandler.cs
@@ -47,15 +47,15 @@ namespace Dfc.CourseDirectory.Testing.DataStore.CosmosDb.QueryHandlers
                     Regions = cr.Regions,
                     RecordStatus = request.CourseStatus,
                     CreatedDate = request.CreatedDate,
-                    CreatedBy = request.CreatedByUser.Email,
+                    CreatedBy = request.CreatedByUser.UserId,
                     UpdatedDate = request.CreatedDate,
-                    UpdatedBy = request.CreatedByUser.Email,
+                    UpdatedBy = request.CreatedByUser.UserId,
                     ProviderCourseID = cr.ProviderCourseId
                 }),
                 CourseStatus = request.CourseStatus,
-                CreatedBy = request.CreatedByUser.Email,
+                CreatedBy = request.CreatedByUser.UserId,
                 CreatedDate = request.CreatedDate,
-                UpdatedBy = request.CreatedByUser.Email,
+                UpdatedBy = request.CreatedByUser.UserId,
                 UpdatedDate = request.CreatedDate
             };
 

--- a/tests/Dfc.CourseDirectory.Testing/DataStore/CosmosDb/QueryHandlers/UpdateApprenticeshipHandler.cs
+++ b/tests/Dfc.CourseDirectory.Testing/DataStore/CosmosDb/QueryHandlers/UpdateApprenticeshipHandler.cs
@@ -33,7 +33,7 @@ namespace Dfc.CourseDirectory.Testing.DataStore.CosmosDb.QueryHandlers
             {
                 Address = l.Address,
                 ApprenticeshipLocationType = l.ApprenticeshipLocationType,
-                CreatedBy = request.UpdatedBy.Email,
+                CreatedBy = request.UpdatedBy.UserId,
                 CreatedDate = request.UpdatedDate,
                 DeliveryModes = l.DeliveryModes.ToList(),
                 Id = Guid.NewGuid(),
@@ -45,13 +45,13 @@ namespace Dfc.CourseDirectory.Testing.DataStore.CosmosDb.QueryHandlers
                 Radius = l.Radius,
                 RecordStatus = 1,
                 Regions = l.Regions,
-                UpdatedBy = request.UpdatedBy.Email,
+                UpdatedBy = request.UpdatedBy.UserId,
                 UpdatedDate = request.UpdatedDate,
                 VenueId = l.VenueId
             }).ToList();
             apprenticeship.RecordStatus = (int)ApprenticeshipStatus.Live;
             apprenticeship.UpdatedDate = request.UpdatedDate;
-            apprenticeship.UpdatedBy = request.UpdatedBy.Email;
+            apprenticeship.UpdatedBy = request.UpdatedBy.UserId;
 
             request.StandardOrFramework.Switch(
                 standard =>

--- a/tests/Dfc.CourseDirectory.Testing/DataStore/CosmosDb/QueryHandlers/UpdateProviderInfoHandler.cs
+++ b/tests/Dfc.CourseDirectory.Testing/DataStore/CosmosDb/QueryHandlers/UpdateProviderInfoHandler.cs
@@ -20,7 +20,7 @@ namespace Dfc.CourseDirectory.Testing.DataStore.CosmosDb.QueryHandlers
 
             provider.MarketingInformation = request.MarketingInformation;
             provider.DateUpdated = request.UpdatedOn;
-            provider.UpdatedBy = request.UpdatedBy.Email;
+            provider.UpdatedBy = request.UpdatedBy.UserId;
 
             inMemoryDocumentStore.Providers.Save(provider);
 

--- a/tests/Dfc.CourseDirectory.Testing/DataStore/CosmosDb/QueryHandlers/UpdateVenueHandler.cs
+++ b/tests/Dfc.CourseDirectory.Testing/DataStore/CosmosDb/QueryHandlers/UpdateVenueHandler.cs
@@ -28,7 +28,7 @@ namespace Dfc.CourseDirectory.Testing.DataStore.CosmosDb.QueryHandlers
             venue.Postcode = request.Postcode;
             venue.Latitude = request.Latitude;
             venue.Longitude = request.Longitude;
-            venue.UpdatedBy = request.UpdatedBy.Email;
+            venue.UpdatedBy = request.UpdatedBy.UserId;
             venue.DateUpdated = request.UpdatedDate;
 
             inMemoryDocumentStore.Venues.Save(venue);


### PR DESCRIPTION
As per discussions around [PTCD-563](https://skillsfundingagency.atlassian.net/browse/PTCD-563) etc.

This will be stable in the face of changes in a user's email address in DfE Sign-in, and also avoids storing any extra copies of personally identifiable information.

This is probably not everything but it was the things that were easy to find in a limited time.