### PR TITLE
[PTCD-846] Copytext change for edit apprenticeship link

### DIFF
--- a/src/Dfc.CourseDirectory.Web/Views/Apprenticeships/Complete/Index.cshtml
+++ b/src/Dfc.CourseDirectory.Web/Views/Apprenticeships/Complete/Index.cshtml
@@ -28,7 +28,7 @@
                class="govuk-link">Add a new apprenticeship</a>
             <br/>
             <a asp-controller="ProviderApprenticeships" asp-action="Index"
-               class="govuk-link">View, edit, copy or delete an apprenticeship</a>
+               class="govuk-link">View edit or delete an apprenticeship</a>
             <br/>
             <a asp-controller="Home" asp-action="Index"
                class="govuk-link">Back to the home screen</a>


### PR DESCRIPTION
[PTCD-846](https://skillsfundingagency.atlassian.net/browse/PTCD-846)

Add apprenticeship journey, "published" page.
Changed because you can't copy an apprenticeship.

After:

![Selection_20210216-01-4662e4662e4662e](https://user-images.githubusercontent.com/19378/108100412-cc8dcc80-707d-11eb-9253-6526ca6bd998.png)
