### PR TITLE
[PTCD-823] New provider-search SQL view and azure search index

### DIFF
--- a/Dfc.CourseDirectory/Resources/AzureSearch/SearchDatasource.json
+++ b/Dfc.CourseDirectory/Resources/AzureSearch/SearchDatasource.json
@@ -16,20 +16,20 @@
         }
     },
     {
-        "name" : "cdb-providerportal-ukrlp-contacttypep",
-        "type" : "documentdb",
-        "description": "Cosmos DB, providerportal database, ukrlp collection, only contact type P",
+        "name" : "sql-coursedirectory-providers",
+        "type":  "azuresql",
+        "description": "Provider list",
         "credentials" :
         {
-            "connectionString": "__providerPortalCosmosDbConnectionString__"
+            "connectionString":  "__sqlCourseDirectoryConnectionString__"
         },
         "container": {
-            "name": "ukrlp",
-            "query": "SELECT VALUE { 'id':c.id, '_ts':c._ts, 'UKPRN':c.UnitedKingdomProviderReferenceNumber, 'Name':c.ProviderName,'Status':c.Status,'ProviderStatus':c.ProviderStatus,'CourseDirectoryName':IS_DEFINED(c.CourseDirectoryName)?IS_NULL(c.CourseDirectoryName)?c.ProviderName:c.CourseDirectoryName:c.ProviderName,'ProviderAlias':c.Alias,'TradingName':c.TradingName, 'Region':c.Region, 'DateUpdated':c.DateUpdated, 'DateOnboarded':c.DateOnboarded, 'ContactType':(c.ProviderContact[1].ContactType='P')?c.ProviderContact[1].ContactType:c.ProviderContact[0].ContactType,'PostCode': (c.ProviderContact[1].ContactType='P')?c.ProviderContact[1].ContactAddress.PostCode:c.ProviderContact[0].ContactAddress.PostCode,  'Towns':(c.ProviderContact[1].ContactType='P')?c.ProviderContact[1].ContactAddress.Items:c.ProviderContact[0].ContactAddress.Items  , 'Town': (c.ProviderContact[1].ContactType='P')?c.ProviderContact[1].ContactAddress.Items[0]:c.ProviderContact[0].ContactAddress.Items[0]  } FROM c WHERE c._ts >= @HighWaterMark ORDER BY c._ts"
+            "name": "Pttcd.vwProviderSearchIndex",
+            "query": null
         },
         "dataChangeDetectionPolicy": {
             "@odata.type" : "#Microsoft.Azure.Search.HighWaterMarkChangeDetectionPolicy",
-            "highWaterMarkColumnName" : "_ts"
+            "highWaterMarkColumnName":  "Version"
         }
     }
 ]

--- a/Dfc.CourseDirectory/Resources/AzureSearch/SearchDatasource.json
+++ b/Dfc.CourseDirectory/Resources/AzureSearch/SearchDatasource.json
@@ -14,5 +14,22 @@
             "@odata.type":  "#Microsoft.Azure.Search.HighWaterMarkChangeDetectionPolicy",
             "highWaterMarkColumnName":  "updated"
         }
+    },
+    {
+        "name" : "cdb-providerportal-ukrlp-contacttypep",
+        "type" : "documentdb",
+        "description": "Cosmos DB, providerportal database, ukrlp collection, only contact type P",
+        "credentials" :
+        {
+            "connectionString": "__providerPortalCosmosDbConnectionString__"
+        },
+        "container": {
+            "name": "ukrlp",
+            "query": "SELECT VALUE { 'id':c.id, '_ts':c._ts, 'UKPRN':c.UnitedKingdomProviderReferenceNumber, 'Name':c.ProviderName,'Status':c.Status,'ProviderStatus':c.ProviderStatus,'CourseDirectoryName':IS_DEFINED(c.CourseDirectoryName)?IS_NULL(c.CourseDirectoryName)?c.ProviderName:c.CourseDirectoryName:c.ProviderName,'ProviderAlias':c.Alias,'TradingName':c.TradingName, 'Region':c.Region, 'DateUpdated':c.DateUpdated, 'DateOnboarded':c.DateOnboarded, 'ContactType':(c.ProviderContact[1].ContactType='P')?c.ProviderContact[1].ContactType:c.ProviderContact[0].ContactType,'PostCode': (c.ProviderContact[1].ContactType='P')?c.ProviderContact[1].ContactAddress.PostCode:c.ProviderContact[0].ContactAddress.PostCode,  'Towns':(c.ProviderContact[1].ContactType='P')?c.ProviderContact[1].ContactAddress.Items:c.ProviderContact[0].ContactAddress.Items  , 'Town': (c.ProviderContact[1].ContactType='P')?c.ProviderContact[1].ContactAddress.Items[0]:c.ProviderContact[0].ContactAddress.Items[0]  } FROM c WHERE c._ts >= @HighWaterMark ORDER BY c._ts"
+        },
+        "dataChangeDetectionPolicy": {
+            "@odata.type" : "#Microsoft.Azure.Search.HighWaterMarkChangeDetectionPolicy",
+            "highWaterMarkColumnName" : "_ts"
+        }
     }
 ]

--- a/Dfc.CourseDirectory/Resources/AzureSearch/SearchIndex.json
+++ b/Dfc.CourseDirectory/Resources/AzureSearch/SearchIndex.json
@@ -24,10 +24,10 @@
 		]
 	},
 	{
-		"name": "provider",
+		"name": "providers",
 		"fields": [
 			{
-				"name": "id",
+				"name": "ProviderId",
 				"type": "Edm.String",
 				"key": true,
 				"sortable": false,
@@ -35,12 +35,12 @@
 				"searchable": false
 			},
 			{
-				"name": "UKPRN",
+				"name": "Ukprn",
 				"type": "Edm.String",
 				"facetable": false
 			},
 			{
-				"name": "Name",
+				"name": "ProviderName",
 				"type": "Edm.String",
 				"facetable": false,
 				"analyzer": "en.microsoft"
@@ -56,47 +56,13 @@
 				"facetable": false
 			},
 			{
-				"name": "Region",
-				"type": "Edm.String"
-			},
-			{
-				"name": "DateUpdated",
-				"type": "Edm.DateTimeOffset",
-				"sortable": false,
-				"facetable": false
-			},
-			{
-				"name": "DateOnboarded",
-				"type": "Edm.DateTimeOffset",
-				"sortable": false,
-				"facetable": false
-			},
-			{
-				"name": "Status",
+				"name": "ProviderStatus",
 				"type": "Edm.Int32",
 				"sortable": false,
 				"facetable": false
 			},
 			{
-				"name": "ProviderStatus",
-				"type": "Edm.String",
-				"sortable": false,
-				"facetable": false
-			},
-			{
-				"name": "CourseDirectoryName",
-				"type": "Edm.String",
-				"sortable": false,
-				"facetable": false
-			},
-			{
-				"name": "TradingName",
-				"type": "Edm.String",
-				"sortable": false,
-				"facetable": false
-			},
-			{
-				"name": "ProviderAlias",
+				"name": "UkrlpProviderStatusDescription",
 				"type": "Edm.String",
 				"sortable": false,
 				"facetable": false

--- a/Dfc.CourseDirectory/Resources/AzureSearch/SearchIndex.json
+++ b/Dfc.CourseDirectory/Resources/AzureSearch/SearchIndex.json
@@ -22,5 +22,85 @@
 			{ "name": "Country", "type": "Edm.String", "searchable": false, "filterable": false, "sortable": false, "facetable": false },
 			{ "name": "updated", "type": "Edm.DateTimeOffset", "filterable": false, "sortable": false, "facetable": false }
 		]
+	},
+	{
+		"name": "provider",
+		"fields": [
+			{
+				"name": "id",
+				"type": "Edm.String",
+				"key": true,
+				"sortable": false,
+				"facetable": false,
+				"searchable": false
+			},
+			{
+				"name": "UKPRN",
+				"type": "Edm.String",
+				"facetable": false
+			},
+			{
+				"name": "Name",
+				"type": "Edm.String",
+				"facetable": false,
+				"analyzer": "en.microsoft"
+			},
+			{
+				"name": "Town",
+				"type": "Edm.String"
+			},
+			{
+				"name": "Postcode",
+				"type": "Edm.String",
+				"sortable": false,
+				"facetable": false
+			},
+			{
+				"name": "Region",
+				"type": "Edm.String"
+			},
+			{
+				"name": "DateUpdated",
+				"type": "Edm.DateTimeOffset",
+				"sortable": false,
+				"facetable": false
+			},
+			{
+				"name": "DateOnboarded",
+				"type": "Edm.DateTimeOffset",
+				"sortable": false,
+				"facetable": false
+			},
+			{
+				"name": "Status",
+				"type": "Edm.Int32",
+				"sortable": false,
+				"facetable": false
+			},
+			{
+				"name": "ProviderStatus",
+				"type": "Edm.String",
+				"sortable": false,
+				"facetable": false
+			},
+			{
+				"name": "CourseDirectoryName",
+				"type": "Edm.String",
+				"sortable": false,
+				"facetable": false
+			},
+			{
+				"name": "TradingName",
+				"type": "Edm.String",
+				"sortable": false,
+				"facetable": false
+			},
+			{
+				"name": "ProviderAlias",
+				"type": "Edm.String",
+				"sortable": false,
+				"facetable": false
+			}
+		]
 	}
 ]

--- a/Dfc.CourseDirectory/Resources/AzureSearch/SearchIndexer.json
+++ b/Dfc.CourseDirectory/Resources/AzureSearch/SearchIndexer.json
@@ -15,16 +15,16 @@
         ]
     },
     {
-        "name": "providerupdate",
-        "description": "Update provider index",
-        "dataSourceName": "cdb-providerportal-ukrlp-contacttypep",
-        "targetIndexName": "provider",
+        "name": "providers-update",
+        "description": "Update providers index",
+        "dataSourceName": "sql-coursedirectory-providers",
+        "targetIndexName": "providers",
         "schedule": {
             "interval": "PT5M",
             "startTime": "2019-08-08T08:00:00Z"
         },
         "parameters": {
-            "configuration": { "assumeOrderByHighWaterMarkColumn": true }
+            "configuration": { "convertHighWaterMarkToRowVersion": true }
         }
     }
 ]

--- a/Dfc.CourseDirectory/Resources/AzureSearch/SearchIndexer.json
+++ b/Dfc.CourseDirectory/Resources/AzureSearch/SearchIndexer.json
@@ -13,5 +13,18 @@
                 }
             }
         ]
+    },
+    {
+        "name": "providerupdate",
+        "description": "Update provider index",
+        "dataSourceName": "cdb-providerportal-ukrlp-contacttypep",
+        "targetIndexName": "provider",
+        "schedule": {
+            "interval": "PT5M",
+            "startTime": "2019-08-08T08:00:00Z"
+        },
+        "parameters": {
+            "configuration": { "assumeOrderByHighWaterMarkColumn": true }
+        }
     }
 ]

--- a/src/Dfc.CourseDirectory.Database/Dfc.CourseDirectory.Database.sqlproj
+++ b/src/Dfc.CourseDirectory.Database/Dfc.CourseDirectory.Database.sqlproj
@@ -133,6 +133,7 @@
     <Folder Include="Pttcd\Types" />
     <Folder Include="Scripts\" />
     <Folder Include="Pttcd\Triggers" />
+    <Folder Include="Pttcd\Views" />
   </ItemGroup>
   <ItemGroup>
     <Build Include="LARS\Tables\AwardOrgCode.sql">
@@ -265,6 +266,7 @@
     <Build Include="Pttcd\Indexes\IX_CourseRuns_Status.sql" />
     <Build Include="Pttcd\Triggers\TRG_Venues_UpdateFindACourseIndex.sql" />
     <Build Include="Pttcd\StoredProcedures\RefreshFindACourseIndexForTLevels.sql" />
+    <Build Include="Pttcd\Views\vwProviderSearchIndex.sql" />
   </ItemGroup>
   <ItemGroup>
     <RefactorLog Include="dfc-coursedirectory.refactorlog" />

--- a/src/Dfc.CourseDirectory.Database/Pttcd/Views/vwProviderSearchIndex.sql
+++ b/src/Dfc.CourseDirectory.Database/Pttcd/Views/vwProviderSearchIndex.sql
@@ -1,0 +1,19 @@
+create
+    --or alter -- not supported by dacpac
+    view Pttcd.vwProviderSearchIndex
+as
+select
+    p.ProviderId,
+    p.Ukprn,
+    p.ProviderName,
+    p.ProviderStatus,
+    p.UkrlpProviderStatusDescription,
+    p_contact.AddressPostcode Postcode,
+    p_contact.AddressPostTown Town,
+    p.Version -- Timestamp (RowVersion) type, used here for cosmos HighWaterMark
+from Pttcd.Providers p
+left outer join (
+        select top 1 pc.ProviderId, pc.ContactType, pc.AddressItems, pc.AddressPostTown, pc.AddressPostcode
+        from Pttcd.ProviderContacts pc
+        where pc.ContactType = 'P'
+    ) p_contact on p_contact.ProviderId = p.ProviderId


### PR DESCRIPTION
Create a new azure-search index (aka azure cognitive search) for the list of providers.

This is a sub-task of [PTCD-841](https://skillsfundingagency.atlassian.net/browse/PTCD-841)

The intention is to deploy the two indexes side-by-side with this PR; then in future work move the calling code over and then remove the old index.

# Details
(from second commit)

This is index not being kept compatible with the existing search index so when we switch calls over to this the models will need to be updated.  I think the switch to a replacement index is a convenient moment to eliminate the arbitrary variation in naming, unused fields, and confusing mappings.

Note that the "status" field names are confusing, in this version I've opted to keep the names aligned with those in the sql table as I think that will be cleaner in the end.

This replacement index has all the fields needed to display the search results for admin users at `/provider-search?SearchQuery=xxx`

Information on the relevant CosmosDB to SQL mappings can be found in Dfc.CourseDirectory.Core\SqlDataSync.cs lines 193-230

The intention is to deploy the two indexes side-by-side, move the calling code over, and then remove the old index.

Using `assumeOrderByHighWaterMarkColumn` for SQL indexing as per Dfc.CourseDirectory.FindACourseApi/Resources/AzureSearch/SearchIndexer.json:12 which already works. `convertHighWaterMarkToRowVersion` is for CosmosDB.  See https://docs.microsoft.com/en-us/azure/search/search-howto-connecting-azure-sql-database-to-azure-search-using-indexers#converthighwatermarktorowversion vs https://docs.microsoft.com/en-us/azure/search/search-howto-index-cosmosdb#incremental-progress-and-custom-queries


# Page that uses the existing index

(just for reference, no changes yet):

![provider search Selection_20210218-01-679186791867918](https://user-images.githubusercontent.com/19378/108345189-e6422780-71d5-11eb-8d5b-c399481a3595.png)

# Test deployment in dev env

![Selection_20210219-01-2f8ca2f8ca2f8ca](https://user-images.githubusercontent.com/19378/108519396-7d37de00-72c1-11eb-9351-9b8f0dfab03e.png)

![Selection_20210219-01-f75b1f75b1f75b1](https://user-images.githubusercontent.com/19378/108519416-83c65580-72c1-11eb-8f11-f7d8ab6b0b0b.png)

![Selection_20210219-01-f7a6df7a6df7a6d](https://user-images.githubusercontent.com/19378/108519516-9b9dd980-72c1-11eb-8ed1-9cb3e061ab62.png)


# Tasks

- [x] test deployment to dev
- [x] squash commits
