### PR TITLE
Include town/postcode in new providers search index

### DIFF
--- a/src/Dfc.CourseDirectory.Database/Pttcd/Views/vwProviderSearchIndex.sql
+++ b/src/Dfc.CourseDirectory.Database/Pttcd/Views/vwProviderSearchIndex.sql
@@ -9,7 +9,7 @@ select
     p.ProviderStatus,
     p.UkrlpProviderStatusDescription,
     p_contact.AddressPostcode Postcode,
-    p_contact.AddressPostTown Town,
+    p_contact.AddressItems Town, -- for approximate compatibility, the old index was reading Items[0] which has been squashed into this field in sql
     p.Version -- Timestamp (RowVersion) type, used here for cosmos HighWaterMark
 from Pttcd.Providers p
 outer apply (

--- a/src/Dfc.CourseDirectory.Database/Pttcd/Views/vwProviderSearchIndex.sql
+++ b/src/Dfc.CourseDirectory.Database/Pttcd/Views/vwProviderSearchIndex.sql
@@ -12,8 +12,8 @@ select
     p_contact.AddressPostTown Town,
     p.Version -- Timestamp (RowVersion) type, used here for cosmos HighWaterMark
 from Pttcd.Providers p
-left outer join (
-        select top 1 pc.ProviderId, pc.ContactType, pc.AddressItems, pc.AddressPostTown, pc.AddressPostcode
-        from Pttcd.ProviderContacts pc
-        where pc.ContactType = 'P'
-    ) p_contact on p_contact.ProviderId = p.ProviderId
+outer apply (
+    select top 1 pc.ProviderId, pc.ContactType, pc.AddressItems, pc.AddressPostTown, pc.AddressPostcode
+    from Pttcd.ProviderContacts pc
+    where pc.ProviderId = p.ProviderId and pc.ContactType = 'P'
+) p_contact


### PR DESCRIPTION
This fixes the subquery to ProviderContacts and pulls in the best approximation of "town" that we currently have.