### PR TITLE
PTCD-864 Use new sql-based provider search index

### DIFF
--- a/src/Dfc.CourseDirectory.Core/Search/Models/Provider.cs
+++ b/src/Dfc.CourseDirectory.Core/Search/Models/Provider.cs
@@ -1,23 +1,15 @@
 ﻿using System;
-using System.Text.Json.Serialization;
 
 namespace Dfc.CourseDirectory.Core.Search.Models
 {
     public class Provider
     {
-        [JsonPropertyName("id")]
-        public Guid Id { get; set; }
-
-        public string Name { get; set; }
-
+        public Guid ProviderId { get; set; }
+        public string Ukprn { get; set; }
+        public string ProviderName { get; set; }
+        public int ProviderStatus { get; set; }
+        public string UkrlpProviderStatusDescription { get; set; }
         public string Postcode { get; set; }
-
         public string Town { get; set; }
-
-        public string UKPRN { get; set; }
-
-        public int Status { get; set; }
-
-        public string ProviderStatus { get; set; }
     }
 }

--- a/src/Dfc.CourseDirectory.Web/appsettings.json
+++ b/src/Dfc.CourseDirectory.Web/appsettings.json
@@ -78,7 +78,7 @@
     "FindAddressesBaseUrl": "https://services.postcodeanywhere.co.uk/PostcodeAnywhere/Interactive/FindByPostcode/v1.00/json3.ws?",
     "RetrieveAddressBaseUrl": "https://services.postcodeanywhere.co.uk/PostcodeAnywhere/Interactive/RetrieveById/v1.30/json3.ws?"
   },
-  "ProvidersAzureSearchIndexName": "providers",
+  "ProviderAzureSearchIndexName": "providers",
   "LarsAzureSearchIndexName": "lars",
   "GetAddressSettings": {
     "UseGetAddress": true,

--- a/src/Dfc.CourseDirectory.Web/appsettings.json
+++ b/src/Dfc.CourseDirectory.Web/appsettings.json
@@ -78,7 +78,7 @@
     "FindAddressesBaseUrl": "https://services.postcodeanywhere.co.uk/PostcodeAnywhere/Interactive/FindByPostcode/v1.00/json3.ws?",
     "RetrieveAddressBaseUrl": "https://services.postcodeanywhere.co.uk/PostcodeAnywhere/Interactive/RetrieveById/v1.30/json3.ws?"
   },
-  "ProviderAzureSearchIndexName": "provider",
+  "ProvidersAzureSearchIndexName": "providers",
   "LarsAzureSearchIndexName": "lars",
   "GetAddressSettings": {
     "UseGetAddress": true,

--- a/src/Dfc.CourseDirectory.WebV2/Features/ProviderSearch/ProviderSearch.cs
+++ b/src/Dfc.CourseDirectory.WebV2/Features/ProviderSearch/ProviderSearch.cs
@@ -92,13 +92,13 @@ namespace Dfc.CourseDirectory.WebV2.Features.ProviderSearch
             {
                 ProviderSearchResults = result.Items.Select(r => r.Record).Select(p => new ProviderSearchResultViewModel
                 {
-                    ProviderId = p.Id,
-                    Name = p.Name,
+                    ProviderId = p.ProviderId,
+                    Name = p.ProviderName,
                     Postcode = p.Postcode,
                     Town = p.Town,
-                    Ukprn = p.UKPRN,
-                    Status = (ProviderStatus)p.Status,
-                    ProviderStatus = p.ProviderStatus
+                    Ukprn = p.Ukprn,
+                    Status = (ProviderStatus)p.ProviderStatus,
+                    ProviderStatus = p.UkrlpProviderStatusDescription
                 }).ToArray()
             };
         }

--- a/src/Dfc.CourseDirectory.WebV2/ServiceCollectionExtensions.cs
+++ b/src/Dfc.CourseDirectory.WebV2/ServiceCollectionExtensions.cs
@@ -94,13 +94,13 @@ namespace Dfc.CourseDirectory.WebV2
                     AuthorizationPolicyNames.Admin,
                     policy => policy.RequireRole(RoleNames.Developer, RoleNames.Helpdesk));
             });
-            
+
             // SignInActions - order here is the order they're executed in
             services.AddTransient<ISignInAction, DfeUserInfoHelper>();
             services.AddTransient<ISignInAction, EnsureProviderExistsSignInAction>();
             services.AddTransient<ISignInAction, SignInTracker>();
             services.AddTransient<ISignInAction, EnsureApprenticeshipQAStatusSetSignInAction>();
-            
+
             services.AddSqlDataStore(configuration.GetConnectionString("DefaultConnection"));
 
             if (!environment.IsTesting())
@@ -111,7 +111,7 @@ namespace Dfc.CourseDirectory.WebV2
 
                 services.AddSingleton<IBinaryStorageProvider, BlobStorageBinaryStorageProvider>();
             }
-			
+
             // HostedService to execute startup tasks.
             // N.B. it's important this is the first HostedService to run; it may set up dependencies for other services.
             services.Insert(
@@ -184,7 +184,7 @@ namespace Dfc.CourseDirectory.WebV2
 				services.AddAzureSearchClient<Provider>(
 	                new Uri(configuration["AzureSearchUrl"]),
 	                configuration["AzureSearchQueryKey"],
-	                configuration["ProviderAzureSearchIndexName"]);
+	                configuration["ProvidersAzureSearchIndexName"]);
 
                 services.AddAzureSearchClient<Lars>(
                     new Uri(configuration["AzureSearchUrl"]),

--- a/src/Dfc.CourseDirectory.WebV2/ServiceCollectionExtensions.cs
+++ b/src/Dfc.CourseDirectory.WebV2/ServiceCollectionExtensions.cs
@@ -184,7 +184,7 @@ namespace Dfc.CourseDirectory.WebV2
 				services.AddAzureSearchClient<Provider>(
 	                new Uri(configuration["AzureSearchUrl"]),
 	                configuration["AzureSearchQueryKey"],
-	                configuration["ProvidersAzureSearchIndexName"]);
+	                configuration["ProviderAzureSearchIndexName"]);
 
                 services.AddAzureSearchClient<Lars>(
                     new Uri(configuration["AzureSearchUrl"]),

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/ProviderSearch/ProviderSearchTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/ProviderSearch/ProviderSearchTests.cs
@@ -123,27 +123,27 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ProviderSearch
 
             doc.GetElementByTestId("search-query-input").Attributes["value"].Value.Should().Be(searchQuery);
 
-            var provider1SearchResultRow = doc.GetElementByTestId($"search-result-row-{providerSearchResult1.Id}");
-            var provider2SearchResultRow = doc.GetElementByTestId($"search-result-row-{providerSearchResult2.Id}");
-            var provider3SearchResultRow = doc.GetElementByTestId($"search-result-row-{providerSearchResult3.Id}");
-            var provider4SearchResultRow = doc.GetElementByTestId($"search-result-row-{providerSearchResult4.Id}");
+            var provider1SearchResultRow = doc.GetElementByTestId($"search-result-row-{providerSearchResult1.ProviderId}");
+            var provider2SearchResultRow = doc.GetElementByTestId($"search-result-row-{providerSearchResult2.ProviderId}");
+            var provider3SearchResultRow = doc.GetElementByTestId($"search-result-row-{providerSearchResult3.ProviderId}");
+            var provider4SearchResultRow = doc.GetElementByTestId($"search-result-row-{providerSearchResult4.ProviderId}");
 
             using (new AssertionScope())
             {
                 provider1SearchResultRow.Should().NotBeNull();
-                provider1SearchResultRow.GetElementByTestId("provider-name").TextContent.Should().Be(providerSearchResult1.Name);
+                provider1SearchResultRow.GetElementByTestId("provider-name").TextContent.Should().Be(providerSearchResult1.ProviderName);
                 provider1SearchResultRow.GetElementByTestId("provider-action").TextContent.Trim().Should().Be("View dashboard");
 
                 provider2SearchResultRow.Should().NotBeNull();
-                provider2SearchResultRow.GetElementByTestId("provider-name").TextContent.Should().Be(providerSearchResult2.Name);
+                provider2SearchResultRow.GetElementByTestId("provider-name").TextContent.Should().Be(providerSearchResult2.ProviderName);
                 provider2SearchResultRow.GetElementByTestId("provider-action").TextContent.Trim().Should().Be("Add provider");
 
                 provider3SearchResultRow.Should().NotBeNull();
-                provider3SearchResultRow.GetElementByTestId("provider-name").TextContent.Should().Be(providerSearchResult3.Name);
+                provider3SearchResultRow.GetElementByTestId("provider-name").TextContent.Should().Be(providerSearchResult3.ProviderName);
                 provider3SearchResultRow.GetElementByTestId("provider-action").TextContent.Trim().Should().BeEmpty();
 
                 provider4SearchResultRow.Should().NotBeNull();
-                provider4SearchResultRow.GetElementByTestId("provider-name").TextContent.Should().Be(providerSearchResult4.Name);
+                provider4SearchResultRow.GetElementByTestId("provider-name").TextContent.Should().Be(providerSearchResult4.ProviderName);
                 provider4SearchResultRow.GetElementByTestId("provider-action").TextContent.Trim().Should().BeEmpty();
             }
         }
@@ -228,13 +228,13 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ProviderSearch
         {
             return new Provider
             {
-                Id = Guid.NewGuid(),
-                Name = $"TestSearchResult{seed}",
+                ProviderId = Guid.NewGuid(),
+                ProviderName = $"TestSearchResult{seed}",
                 Postcode = $"TE1 {seed}ST",
                 Town = $"TestTown{seed}",
-                UKPRN = seed.ToString("00000000"),
-                Status = (int)status,
-                ProviderStatus = providerStatus
+                Ukprn = seed.ToString("00000000"),
+                ProviderStatus = (int)status,
+                UkrlpProviderStatusDescription = providerStatus
             };
         }
     }


### PR DESCRIPTION
* Update provider search model to match new index -  This makes the field names consistent all the way down to the data store.
* Configure provider search to use new index. - New index is "providers", old is "provider".
* Config key name changed to avoid being overridden by any existing production configuration.

Depends on #1944

[PTCD-864](https://skillsfundingagency.atlassian.net/browse/PTCD-864)

# Todo

- [x] Resolve question of whether this can go out side-by-side with the changes to the index in #1944
- [x] QA
- [x] Wait for index changes to be released to production before merging this