### PR TITLE
PTCD-866 Remove unused `NewAddressId

### DIFF
--- a/src/Dfc.CourseDirectory.Services/BulkUploadService/BulkUploadService.cs
+++ b/src/Dfc.CourseDirectory.Services/BulkUploadService/BulkUploadService.cs
@@ -73,7 +73,7 @@ namespace Dfc.CourseDirectory.Services.BulkUploadService
             string previousLearnAimRef = string.Empty;
 
             try {
-                cachedVenues = Task.Run(async () => await _venueService.SearchAsync(new VenueSearchCriteria(providerUKPRN.ToString(), string.Empty)))
+                cachedVenues = Task.Run(async () => await _venueService.SearchAsync(new VenueSearchCriteria(providerUKPRN.ToString())))
                                                                        .Result
                                                                        .Value
                                                                        .Value

--- a/src/Dfc.CourseDirectory.Services/VenueService/VenueSearchCriteria.cs
+++ b/src/Dfc.CourseDirectory.Services/VenueService/VenueSearchCriteria.cs
@@ -5,11 +5,9 @@ namespace Dfc.CourseDirectory.Services.VenueService
     public class VenueSearchCriteria
     {
         public string Search { get; }
-        public string NewAddressId { get; }
 
         public VenueSearchCriteria(
-            string search,
-            string newAddressId)
+            string search)
         {
             if (string.IsNullOrWhiteSpace(search))
             {
@@ -17,7 +15,6 @@ namespace Dfc.CourseDirectory.Services.VenueService
             }
 
             Search = search;
-            NewAddressId = newAddressId;
         }
     }
 }

--- a/src/Dfc.CourseDirectory.Services/VenueService/VenueService.cs
+++ b/src/Dfc.CourseDirectory.Services/VenueService/VenueService.cs
@@ -167,15 +167,6 @@ namespace Dfc.CourseDirectory.Services.VenueService
                     };
                     var venues = JsonConvert.DeserializeObject<IEnumerable<Venue>>(json, settings).OrderBy(x => x.VenueName).ToList();
 
-                    if (!string.IsNullOrEmpty(criteria.NewAddressId))
-                    {
-                        var newVenueIndex = venues.FindIndex(x => x.ID == criteria.NewAddressId);
-                        var newVenueItem = venues[newVenueIndex];
-
-                        venues.RemoveAt(newVenueIndex);
-                        venues.Insert(0, newVenueItem);
-                    }
-
                     return Result.Ok(new VenueSearchResult(venues));
                 }
                 else

--- a/src/Dfc.CourseDirectory.Web/ApprenticeshipBulkUpload/ApprenticeshipBulkUploadService.cs
+++ b/src/Dfc.CourseDirectory.Web/ApprenticeshipBulkUpload/ApprenticeshipBulkUploadService.cs
@@ -339,7 +339,7 @@ namespace Dfc.CourseDirectory.Web.ApprenticeshipBulkUpload
                 {
                     if (_cachedVenues == null)
                     {
-                        _cachedVenues = Task.Run(async () => await _venueService.SearchAsync(new VenueSearchCriteria(_ukprn.ToString(), string.Empty)))
+                        _cachedVenues = Task.Run(async () => await _venueService.SearchAsync(new VenueSearchCriteria(_ukprn.ToString())))
                             .Result
                             .Value
                             .Value

--- a/src/Dfc.CourseDirectory.Web/Controllers/CopyCourse/CopyCourseRunController.cs
+++ b/src/Dfc.CourseDirectory.Web/Controllers/CopyCourse/CopyCourseRunController.cs
@@ -276,7 +276,7 @@ namespace Dfc.CourseDirectory.Web.Controllers.CopyCourse
                 return NotFound();
             }
 
-            var venues = await _venueService.SearchAsync(new VenueSearchCriteria(ukprn.ToString(), null));
+            var venues = await _venueService.SearchAsync(new VenueSearchCriteria(ukprn.ToString()));
             var regions = _courseService.GetRegions();
 
             foreach (var subRegion in regions.RegionItems.SelectMany(r => r.SubRegion))

--- a/src/Dfc.CourseDirectory.Web/Controllers/ProviderController.cs
+++ b/src/Dfc.CourseDirectory.Web/Controllers/ProviderController.cs
@@ -48,7 +48,7 @@ namespace Dfc.CourseDirectory.Web.Controllers
             int? UKPRN = Session.GetInt32("UKPRN");
 
             var courseResult = (await _courseService.GetCoursesByLevelForUKPRNAsync(new CourseSearchCriteria(UKPRN))).Value;
-            var venueResult = (await _venueService.SearchAsync(new VenueSearchCriteria(UKPRN.ToString(), string.Empty))).Value;
+            var venueResult = (await _venueService.SearchAsync(new VenueSearchCriteria(UKPRN.ToString()))).Value;
             var allRegions = _courseService.GetRegions().RegionItems;
 
 

--- a/src/Dfc.CourseDirectory.Web/Controllers/ProviderCourses/ProviderCoursesController.cs
+++ b/src/Dfc.CourseDirectory.Web/Controllers/ProviderCourses/ProviderCoursesController.cs
@@ -118,7 +118,7 @@ namespace Dfc.CourseDirectory.Web.Controllers.ProviderCourses
             }
 
             var courseResult = (await _courseService.GetCoursesByLevelForUKPRNAsync(new CourseSearchCriteria(UKPRN))).Value;
-            var venueResult = (await _venueService.SearchAsync(new VenueSearchCriteria(UKPRN.ToString(), string.Empty))).Value;
+            var venueResult = (await _venueService.SearchAsync(new VenueSearchCriteria(UKPRN.ToString()))).Value;
             var allRegions = _courseService.GetRegions().RegionItems;
 
             var allCourses = courseResult.Value.SelectMany(o => o.Value).SelectMany(i => i.Value).ToList();
@@ -375,7 +375,7 @@ namespace Dfc.CourseDirectory.Web.Controllers.ProviderCourses
             model.ProviderCourseRuns = Session.GetObject<List<ProviderCourseRunViewModel>>("ProviderCourses");
 
             //var courseResult = (await _courseService.GetCoursesByLevelForUKPRNAsync(new CourseSearchCriteria(UKPRN))).Value;
-            var venueResult = (await _venueService.SearchAsync(new VenueSearchCriteria(UKPRN.ToString(), string.Empty))).Value;
+            var venueResult = (await _venueService.SearchAsync(new VenueSearchCriteria(UKPRN.ToString()))).Value;
             var allRegions = _courseService.GetRegions().RegionItems;
 
             List<ProviderCoursesFilterItemModel> levelFilterItems = new List<ProviderCoursesFilterItemModel>();

--- a/src/Dfc.CourseDirectory.Web/Controllers/YourCoursesController.cs
+++ b/src/Dfc.CourseDirectory.Web/Controllers/YourCoursesController.cs
@@ -119,7 +119,7 @@ namespace Dfc.CourseDirectory.Web.Controllers
             }
 
             var courseResult = (await _courseService.GetCoursesByLevelForUKPRNAsync(new CourseSearchCriteria(UKPRN))).Value;
-            var venueResult = (await _venueService.SearchAsync(new VenueSearchCriteria(UKPRN.ToString(), string.Empty))).Value;
+            var venueResult = (await _venueService.SearchAsync(new VenueSearchCriteria(UKPRN.ToString()))).Value;
             var allRegions = _courseService.GetRegions().RegionItems;
 
             var levelFilters = courseResult

--- a/src/Dfc.CourseDirectory.Web/Helpers/VenueSearchHelper.cs
+++ b/src/Dfc.CourseDirectory.Web/Helpers/VenueSearchHelper.cs
@@ -21,7 +21,7 @@ namespace Dfc.CourseDirectory.Web.Helpers
                 throw new ArgumentNullException(nameof(venueSearchRequestModel));
             }
 
-            var criteria = new VenueSearchCriteria(venueSearchRequestModel.SearchTerm, venueSearchRequestModel.NewAddressId);
+            var criteria = new VenueSearchCriteria(venueSearchRequestModel.SearchTerm, null);
             return criteria;
         }
         public IEnumerable<VenueSearchResultItemModel> GetVenueSearchResultItemModels(

--- a/src/Dfc.CourseDirectory.Web/Helpers/VenueSearchHelper.cs
+++ b/src/Dfc.CourseDirectory.Web/Helpers/VenueSearchHelper.cs
@@ -21,7 +21,7 @@ namespace Dfc.CourseDirectory.Web.Helpers
                 throw new ArgumentNullException(nameof(venueSearchRequestModel));
             }
 
-            var criteria = new VenueSearchCriteria(venueSearchRequestModel.SearchTerm, null);
+            var criteria = new VenueSearchCriteria(venueSearchRequestModel.SearchTerm);
             return criteria;
         }
         public IEnumerable<VenueSearchResultItemModel> GetVenueSearchResultItemModels(

--- a/src/Dfc.CourseDirectory.Web/ViewComponents/RequestModels/VenueSearchRequestModel.cs
+++ b/src/Dfc.CourseDirectory.Web/ViewComponents/RequestModels/VenueSearchRequestModel.cs
@@ -1,17 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace Dfc.CourseDirectory.Web.RequestModels
+﻿namespace Dfc.CourseDirectory.Web.RequestModels
 {
     public class VenueSearchRequestModel
     {
         public string SearchTerm { get; set; }
-        public string NewAddressId { get; set; }
-        public VenueSearchRequestModel()
-        {
-
-        }
     }
 }


### PR DESCRIPTION
A smaller piece of the overall bypass of `IVenueService`.

Removing this is only possible with the work on branch `PTCD-832-add-venue`, without that this doesn't compile so we can't go straight to `main` with this cleanup.

Ideally we'd merge this on the way to make the final removal a smaller patch to comprehend. The existence of the is extra unused search criteria makes the code to be removed harder to follow.

[PTCD-866](https://skillsfundingagency.atlassian.net/browse/PTCD-866)

## Todo

- [x] Retarget PR at `main` when `PTCD-832-add-venue` merged