### PR TITLE
PTCD-866 Remove unused GetVenuesByPRNAndNameAsync

### DIFF
--- a/src/Dfc.CourseDirectory.Services/VenueService/IVenueService.cs
+++ b/src/Dfc.CourseDirectory.Services/VenueService/IVenueService.cs
@@ -7,7 +7,6 @@ namespace Dfc.CourseDirectory.Services.VenueService
     public interface IVenueService
     {
         Task<Result<Venue>> GetVenueByIdAsync(GetVenueByIdCriteria criteria);
-        Task<Result<VenueSearchResult>> GetVenuesByPRNAndNameAsync(GetVenuesByPRNAndNameCriteria criteria);
         Task<Result<VenueSearchResult>> SearchAsync(VenueSearchCriteria criteria);
     }
 }

--- a/src/Dfc.CourseDirectory.Services/VenueService/VenueService.cs
+++ b/src/Dfc.CourseDirectory.Services/VenueService/VenueService.cs
@@ -95,51 +95,6 @@ namespace Dfc.CourseDirectory.Services.VenueService
             }
         }
 
-        public async Task<Result<VenueSearchResult>> GetVenuesByPRNAndNameAsync(GetVenuesByPRNAndNameCriteria criteria)
-        {
-            if (criteria == null)
-            {
-                throw new ArgumentNullException(nameof(criteria));
-            }
-
-
-            try
-            {
-                var response = await _httpClient.GetAsync(_getVenueByPRNAndNameUri + $"?prn={criteria.PRN}&name={criteria.Name}");
-
-                if (response.IsSuccessStatusCode)
-                {
-                    string json = await response.Content.ReadAsStringAsync();
-
-                    if (string.IsNullOrEmpty(json))
-                        json = "[]";
-
-                    JsonSerializerSettings settings = new JsonSerializerSettings
-                    {
-                        ContractResolver = new VenueSearchResultContractResolver()
-                    };
-                    IEnumerable<Venue> venues = JsonConvert.DeserializeObject<IEnumerable<Venue>>(json, settings);
-                    return Result.Ok(new VenueSearchResult(venues));
-
-                }
-                else
-                {
-                    return Result.Fail<VenueSearchResult>("Get Venue By PRN & Name service unsuccessful http response");
-                }
-            }
-
-            catch (HttpRequestException hre)
-            {
-                _logger.LogError(hre, "Get Venue By PRN and Name service http request error");
-                return Result.Fail<VenueSearchResult>("Get Venue By PRN and Name service http request error.");
-            }
-            catch (Exception e)
-            {
-                _logger.LogError(e, "Get Venue By PRN and Name service unknown error.");
-                return Result.Fail<VenueSearchResult>("Get Venue By PRN and Name service unknown error.");
-            }
-        }
-
         public async Task<Result<VenueSearchResult>> SearchAsync(VenueSearchCriteria criteria)
         {
             if (criteria == null)


### PR DESCRIPTION
A smaller piece of the overall bypass of `IVenueService`.

Removing this is only possible with the work on branch `PTCD-832-add-venue` which removes the final reference to this method, without that this doesn't compile so we can't go straight to `main` with this cleanup.


[PTCD-866](https://skillsfundingagency.atlassian.net/browse/PTCD-866)

## Todo

- [x] Retarget PR at `main` when `PTCD-832-add-venue` merged