### PR TITLE
Ensure TestData.Create{Provider|User} creates unique data

### DIFF
--- a/tests/Dfc.CourseDirectory.Testing/DatabaseFixture.cs
+++ b/tests/Dfc.CourseDirectory.Testing/DatabaseFixture.cs
@@ -71,6 +71,7 @@ namespace Dfc.CourseDirectory.Testing
             services.AddSingleton<IClock, MutableClock>();
             services.AddSingleton<InMemoryDocumentStore>();
             services.AddTransient<TestData>();
+            services.AddSingleton<UniqueIdHelper>();
             services.AddSingleton<SqlQuerySpy>();
             services.Decorate<ISqlQueryDispatcher, SqlQuerySpyDecorator>();
             services.AddTransient<SqlDataSync>();

--- a/tests/Dfc.CourseDirectory.Testing/Dfc.CourseDirectory.Testing.csproj
+++ b/tests/Dfc.CourseDirectory.Testing/Dfc.CourseDirectory.Testing.csproj
@@ -23,6 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Faker.Net" Version="1.4.108" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="3.1.3" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="Respawn" Version="3.3.0" />

--- a/tests/Dfc.CourseDirectory.Testing/TestData/TestData.CreateProvider.cs
+++ b/tests/Dfc.CourseDirectory.Testing/TestData/TestData.CreateProvider.cs
@@ -7,13 +7,13 @@ using Dfc.CourseDirectory.Core.DataStore.Sql.Queries;
 using Dfc.CourseDirectory.Core.Models;
 using Dfc.CourseDirectory.Testing.DataStore.CosmosDb.Queries;
 using Xunit;
+using Provider = Dfc.CourseDirectory.Core.DataStore.Sql.Models.Provider;
 
 namespace Dfc.CourseDirectory.Testing
 {
     public partial class TestData
     {
-        public async Task<Guid> CreateProvider(
-            int ukprn = 12345,
+        public async Task<Provider> CreateProvider(
             string providerName = "Test Provider",
             ProviderType providerType = ProviderType.FE | ProviderType.Apprenticeships,
             string providerStatus = "Active",
@@ -36,6 +36,7 @@ namespace Dfc.CourseDirectory.Testing
             }
 
             var providerId = Guid.NewGuid();
+            var ukprn = _uniqueIdHelper.GenerateProviderUkprn();
 
             var result = await _cosmosDbQueryDispatcher.ExecuteQuery(new CreateProvider()
             {
@@ -107,7 +108,8 @@ namespace Dfc.CourseDirectory.Testing
                 await SetProviderTLevelDefinitions(providerId, tLevelDefinitionIds);
             }
 
-            return providerId;
+            return await WithSqlQueryDispatcher(
+                dispatcher => dispatcher.ExecuteQuery(new GetProviderById() { ProviderId = providerId }));
         }
     }
 

--- a/tests/Dfc.CourseDirectory.Testing/TestData/TestData.CreateUser.cs
+++ b/tests/Dfc.CourseDirectory.Testing/TestData/TestData.CreateUser.cs
@@ -8,12 +8,15 @@ namespace Dfc.CourseDirectory.Testing
     public partial class TestData
     {
         public async Task<UserInfo> CreateUser(
-            string userId = "bobby-tables",
-            string email = "bobby.tables@example.org",
-            string firstName = "Bobby",
-            string lastName = "Tables",
+            string firstName = null,
+            string lastName = null,
             Guid? providerId = default)
         {
+            var userId = _uniqueIdHelper.GenerateUserId();
+            var email = _uniqueIdHelper.GenerateUserEmail();
+            firstName ??= Faker.Name.First();
+            lastName ??= Faker.Name.Last();
+
             await WithSqlQueryDispatcher(dispatcher => dispatcher.ExecuteQuery(
                 new Query()
                 {

--- a/tests/Dfc.CourseDirectory.Testing/TestData/TestData.cs
+++ b/tests/Dfc.CourseDirectory.Testing/TestData/TestData.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Data.SqlClient;
 using System.Threading;
 using System.Threading.Tasks;
 using Dfc.CourseDirectory.Core;
@@ -15,18 +14,21 @@ namespace Dfc.CourseDirectory.Testing
         private readonly SqlDataSync _sqlDataSync;
         private readonly IServiceProvider _serviceProvider;
         private readonly IClock _clock;
+        private readonly UniqueIdHelper _uniqueIdHelper;
         private readonly SemaphoreSlim _dispatcherLock = new SemaphoreSlim(1, 1);
 
         public TestData(
             ICosmosDbQueryDispatcher cosmosDbQueryDispatcher,
             SqlDataSync sqlDataSync,
             IServiceProvider serviceProvider,
-            IClock clock)
+            IClock clock,
+            UniqueIdHelper uniqueIdHelper)
         {
             _cosmosDbQueryDispatcher = cosmosDbQueryDispatcher;
             _sqlDataSync = sqlDataSync;
             _serviceProvider = serviceProvider;
             _clock = clock;
+            _uniqueIdHelper = uniqueIdHelper;
         }
 
         protected Task WithSqlQueryDispatcher(Func<ISqlQueryDispatcher, Task> action) =>

--- a/tests/Dfc.CourseDirectory.Testing/TestData/UniqueIdHelper.cs
+++ b/tests/Dfc.CourseDirectory.Testing/TestData/UniqueIdHelper.cs
@@ -1,0 +1,60 @@
+﻿using System.Collections.Generic;
+using Faker;
+
+namespace Dfc.CourseDirectory.Testing
+{
+    public class UniqueIdHelper
+    {
+        private readonly HashSet<int> _providerUkprns = new HashSet<int>();
+        private readonly HashSet<string> _userEmails = new HashSet<string>();
+        private readonly HashSet<string> _userIds = new HashSet<string>();
+
+        public int GenerateProviderUkprn()
+        {
+            int ukprn;
+
+            lock (_providerUkprns)
+            {
+                do
+                {
+                    ukprn = RandomNumber.Next(1000000, 9999999);
+                }
+                while (!_providerUkprns.Add(ukprn));
+            }
+
+            return ukprn;
+        }
+
+        public string GenerateUserEmail()
+        {
+            string email;
+
+            lock (_userEmails)
+            {
+                do
+                {
+                    email = Internet.Email();
+                }
+                while (!_userEmails.Add(email));
+            }
+
+            return email;
+        }
+
+        public string GenerateUserId()
+        {
+            string userId;
+
+            lock (_userIds)
+            {
+                do
+                {
+                    userId = Internet.UserName();
+                }
+                while (_userIds.Add(userId));
+            }
+
+            return userId;
+        }
+    }
+}

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/ApprenticeshipQA/ApprenticeshipAssessmentTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/ApprenticeshipQA/ApprenticeshipAssessmentTests.cs
@@ -26,28 +26,24 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ApprenticeshipQA
         public async Task Get_ProviderUser_ReturnsForbidden(TestUserType userType)
         {
             // Arrange
-            var ukprn = 12345;
-
-            var providerId = await TestData.CreateProvider(
-                ukprn: ukprn,
+            var provider = await TestData.CreateProvider(
                 providerName: "Provider 1",
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.Submitted);
 
-            var providerUserId = $"{ukprn}-user";
-            await TestData.CreateUser(providerUserId, "somebody@provider1.com", "Provider 1", "Person", providerId);
+            var providerUser = await TestData.CreateUser(providerId: provider.ProviderId);
 
             var standard = await TestData.CreateStandard(standardCode: 1234, version: 1, standardName: "Test Standard");
 
-            var apprenticeshipId = (await TestData.CreateApprenticeship(providerId, standard, createdBy: User.ToUserInfo())).Id;
+            var apprenticeshipId = (await TestData.CreateApprenticeship(provider.ProviderId, standard, createdBy: User.ToUserInfo())).Id;
 
             await TestData.CreateApprenticeshipQASubmission(
-                providerId,
+                provider.ProviderId,
                 submittedOn: Clock.UtcNow,
-                submittedByUserId: providerUserId,
+                submittedByUserId: providerUser.UserId,
                 providerMarketingInformation: "The overview",
                 apprenticeshipIds: new[] { apprenticeshipId });
 
-            await User.AsTestUser(userType, providerId);
+            await User.AsTestUser(userType, provider.ProviderId);
 
             // Act
             var response = await HttpClient.GetAsync(
@@ -77,16 +73,13 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ApprenticeshipQA
         public async Task Get_NoSubmission_ReturnsBadRequest()
         {
             // Arrange
-            var ukprn = 12345;
-
-            var providerId = await TestData.CreateProvider(
-                ukprn: ukprn,
+            var provider = await TestData.CreateProvider(
                 providerName: "Provider 1",
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.Submitted);
 
             var standard = await TestData.CreateStandard(standardCode: 1234, version: 1, standardName: "Test Standard");
 
-            var apprenticeshipId = (await TestData.CreateApprenticeship(providerId, standard, createdBy: User.ToUserInfo())).Id;
+            var apprenticeshipId = (await TestData.CreateApprenticeship(provider.ProviderId, standard, createdBy: User.ToUserInfo())).Id;
 
             await User.AsHelpdesk();
 
@@ -103,24 +96,20 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ApprenticeshipQA
         public async Task Get_InvalidQAStatus_ReturnsBadRequest(ApprenticeshipQAStatus qaStatus)
         {
             // Arrange
-            var ukprn = 12345;
-
-            var providerId = await TestData.CreateProvider(
-                ukprn: ukprn,
+            var provider = await TestData.CreateProvider(
                 providerName: "Provider 1",
                 apprenticeshipQAStatus: qaStatus);
 
-            var providerUserId = $"{ukprn}-user";
-            await TestData.CreateUser(providerUserId, "somebody@provider1.com", "Provider 1", "Person", providerId);
+            var providerUser = await TestData.CreateUser(providerId: provider.ProviderId);
 
             var standard = await TestData.CreateStandard(standardCode: 1234, version: 1, standardName: "Test Standard");
 
-            var apprenticeshipId = (await TestData.CreateApprenticeship(providerId, standard, createdBy: User.ToUserInfo())).Id;
+            var apprenticeshipId = (await TestData.CreateApprenticeship(provider.ProviderId, standard, createdBy: User.ToUserInfo())).Id;
 
             await TestData.CreateApprenticeshipQASubmission(
-                providerId,
+                provider.ProviderId,
                 submittedOn: Clock.UtcNow,
-                submittedByUserId: providerUserId,
+                submittedByUserId: providerUser.UserId,
                 providerMarketingInformation: "The overview",
                 apprenticeshipIds: new[] { apprenticeshipId });
 
@@ -140,24 +129,20 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ApprenticeshipQA
         public async Task Get_NewSubmission_RendersExpectedOutput()
         {
             // Arrange
-            var ukprn = 12345;
-
-            var providerId = await TestData.CreateProvider(
-                ukprn: ukprn,
+            var provider = await TestData.CreateProvider(
                 providerName: "Provider 1",
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.Submitted);
 
-            var providerUserId = $"{ukprn}-user";
-            await TestData.CreateUser(providerUserId, "somebody@provider1.com", "Provider 1", "Person", providerId);
+            var providerUser = await TestData.CreateUser(providerId: provider.ProviderId);
 
             var standard = await TestData.CreateStandard(standardCode: 1234, version: 1, standardName: "Test Standard");
 
-            var apprenticeshipId = (await TestData.CreateApprenticeship(providerId, standard, createdBy: User.ToUserInfo())).Id;
+            var apprenticeshipId = (await TestData.CreateApprenticeship(provider.ProviderId, standard, createdBy: User.ToUserInfo())).Id;
 
             await TestData.CreateApprenticeshipQASubmission(
-                providerId,
+                provider.ProviderId,
                 submittedOn: Clock.UtcNow,
-                submittedByUserId: providerUserId,
+                submittedByUserId: providerUser.UserId,
                 providerMarketingInformation: "The overview",
                 apprenticeshipIds: new[] { apprenticeshipId });
 
@@ -185,24 +170,20 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ApprenticeshipQA
         public async Task Get_AlreadyAssessedSubmission_RendersExpectedOutput()
         {
             // Arrange
-            var ukprn = 12345;
-
-            var providerId = await TestData.CreateProvider(
-                ukprn: ukprn,
+            var provider = await TestData.CreateProvider(
                 providerName: "Provider 1",
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.Submitted);
 
-            var providerUserId = $"{ukprn}-user";
-            await TestData.CreateUser(providerUserId, "somebody@provider1.com", "Provider 1", "Person", providerId);
+            var providerUser = await TestData.CreateUser(providerId: provider.ProviderId);
 
             var standard = await TestData.CreateStandard(standardCode: 1234, version: 1, standardName: "Test Standard");
 
-            var apprenticeshipId = (await TestData.CreateApprenticeship(providerId, standard, createdBy: User.ToUserInfo())).Id;
+            var apprenticeshipId = (await TestData.CreateApprenticeship(provider.ProviderId, standard, createdBy: User.ToUserInfo())).Id;
 
             var submissionId = await TestData.CreateApprenticeshipQASubmission(
-                providerId,
+                provider.ProviderId,
                 submittedOn: Clock.UtcNow,
-                submittedByUserId: providerUserId,
+                submittedByUserId: providerUser.UserId,
                 providerMarketingInformation: "The overview",
                 apprenticeshipIds: new[] { apprenticeshipId });
 
@@ -244,24 +225,20 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ApprenticeshipQA
         public async Task Get_CannotCreateSubmission_RendersReadOnly(bool passed, ApprenticeshipQAStatus qaStatus)
         {
             // Arrange
-            var ukprn = 12345;
-
-            var providerId = await TestData.CreateProvider(
-                ukprn: ukprn,
+            var provider = await TestData.CreateProvider(
                 providerName: "Provider 1",
                 apprenticeshipQAStatus: qaStatus);
 
-            var providerUserId = $"{ukprn}-user";
-            await TestData.CreateUser(providerUserId, "somebody@provider1.com", "Provider 1", "Person", providerId);
+            var providerUser = await TestData.CreateUser(providerId: provider.ProviderId);
 
             var standard = await TestData.CreateStandard(standardCode: 1234, version: 1, standardName: "Test Standard");
 
-            var apprenticeshipId = (await TestData.CreateApprenticeship(providerId, standard, createdBy: User.ToUserInfo())).Id;
+            var apprenticeshipId = (await TestData.CreateApprenticeship(provider.ProviderId, standard, createdBy: User.ToUserInfo())).Id;
 
             var submissionId = await TestData.CreateApprenticeshipQASubmission(
-                providerId,
+                provider.ProviderId,
                 submittedOn: Clock.UtcNow,
-                submittedByUserId: providerUserId,
+                submittedByUserId: providerUser.UserId,
                 providerMarketingInformation: "The overview",
                 apprenticeshipIds: new[] { apprenticeshipId });
 
@@ -295,30 +272,26 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ApprenticeshipQA
         public async Task Post_ProviderUser_ReturnsForbidden(TestUserType userType)
         {
             // Arrange
-            var ukprn = 12345;
-
-            var providerId = await TestData.CreateProvider(
-                ukprn: ukprn,
+            var provider = await TestData.CreateProvider(
                 providerName: "Provider 1",
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.Submitted);
 
-            var providerUserId = $"{ukprn}-user";
-            await TestData.CreateUser(providerUserId, "somebody@provider1.com", "Provider 1", "Person", providerId);
+            var providerUser = await TestData.CreateUser(providerId: provider.ProviderId);
 
             var standard = await TestData.CreateStandard(standardCode: 1234, version: 1, standardName: "Test Standard");
 
-            var apprenticeshipId = (await TestData.CreateApprenticeship(providerId, standard, createdBy: User.ToUserInfo())).Id;
+            var apprenticeshipId = (await TestData.CreateApprenticeship(provider.ProviderId, standard, createdBy: User.ToUserInfo())).Id;
 
             await TestData.CreateApprenticeshipQASubmission(
-                providerId,
+                provider.ProviderId,
                 submittedOn: Clock.UtcNow,
-                submittedByUserId: providerUserId,
+                submittedByUserId: providerUser.UserId,
                 providerMarketingInformation: "The overview",
                 apprenticeshipIds: new[] { apprenticeshipId });
 
             await CreateJourneyInstance(apprenticeshipId);
 
-            await User.AsTestUser(userType, providerId);
+            await User.AsTestUser(userType, provider.ProviderId);
 
             var requestContent = new FormUrlEncodedContentBuilder()
                 .Add("CompliancePassed", false)
@@ -342,24 +315,20 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ApprenticeshipQA
         public async Task Post_InvalidQAStatus_ReturnsBadRequest(ApprenticeshipQAStatus qaStatus)
         {
             // Arrange
-            var ukprn = 12345;
-
-            var providerId = await TestData.CreateProvider(
-                ukprn: ukprn,
+            var provider = await TestData.CreateProvider(
                 providerName: "Provider 1",
                 apprenticeshipQAStatus: qaStatus);
 
-            var providerUserId = $"{ukprn}-user";
-            await TestData.CreateUser(providerUserId, "somebody@provider1.com", "Provider 1", "Person", providerId);
+            var providerUser = await TestData.CreateUser(providerId: provider.ProviderId);
 
             var standard = await TestData.CreateStandard(standardCode: 1234, version: 1, standardName: "Test Standard");
 
-            var apprenticeshipId = (await TestData.CreateApprenticeship(providerId, standard, createdBy: User.ToUserInfo())).Id;
+            var apprenticeshipId = (await TestData.CreateApprenticeship(provider.ProviderId, standard, createdBy: User.ToUserInfo())).Id;
 
             await TestData.CreateApprenticeshipQASubmission(
-                providerId,
+                provider.ProviderId,
                 submittedOn: Clock.UtcNow,
-                submittedByUserId: providerUserId,
+                submittedByUserId: providerUser.UserId,
                 providerMarketingInformation: "The overview",
                 apprenticeshipIds: new[] { apprenticeshipId });
 
@@ -385,24 +354,20 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ApprenticeshipQA
         public async Task Post_MissingCompliancePassed_RendersErrorMessage()
         {
             // Arrange
-            var ukprn = 12345;
-
-            var providerId = await TestData.CreateProvider(
-                ukprn: ukprn,
+            var provider = await TestData.CreateProvider(
                 providerName: "Provider 1",
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.Submitted);
 
-            var providerUserId = $"{ukprn}-user";
-            await TestData.CreateUser(providerUserId, "somebody@provider1.com", "Provider 1", "Person", providerId);
+            var providerUser = await TestData.CreateUser(providerId: provider.ProviderId);
 
             var standard = await TestData.CreateStandard(standardCode: 1234, version: 1, standardName: "Test Standard");
 
-            var apprenticeshipId = (await TestData.CreateApprenticeship(providerId, standard, createdBy: User.ToUserInfo())).Id;
+            var apprenticeshipId = (await TestData.CreateApprenticeship(provider.ProviderId, standard, createdBy: User.ToUserInfo())).Id;
 
             await TestData.CreateApprenticeshipQASubmission(
-                providerId,
+                provider.ProviderId,
                 submittedOn: Clock.UtcNow,
-                submittedByUserId: providerUserId,
+                submittedByUserId: providerUser.UserId,
                 providerMarketingInformation: "The overview",
                 apprenticeshipIds: new[] { apprenticeshipId });
 
@@ -430,24 +395,20 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ApprenticeshipQA
         public async Task Post_MissingComplianceFailedReasonsWhenFailed_RendersErrorMessage()
         {
             // Arrange
-            var ukprn = 12345;
-
-            var providerId = await TestData.CreateProvider(
-                ukprn: ukprn,
+            var provider = await TestData.CreateProvider(
                 providerName: "Provider 1",
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.Submitted);
 
-            var providerUserId = $"{ukprn}-user";
-            await TestData.CreateUser(providerUserId, "somebody@provider1.com", "Provider 1", "Person", providerId);
+            var providerUser = await TestData.CreateUser(providerId: provider.ProviderId);
 
             var standard = await TestData.CreateStandard(standardCode: 1234, version: 1, standardName: "Test Standard");
 
-            var apprenticeshipId = (await TestData.CreateApprenticeship(providerId, standard, createdBy: User.ToUserInfo())).Id;
+            var apprenticeshipId = (await TestData.CreateApprenticeship(provider.ProviderId, standard, createdBy: User.ToUserInfo())).Id;
 
             await TestData.CreateApprenticeshipQASubmission(
-                providerId,
+                provider.ProviderId,
                 submittedOn: Clock.UtcNow,
-                submittedByUserId: providerUserId,
+                submittedByUserId: providerUser.UserId,
                 providerMarketingInformation: "The overview",
                 apprenticeshipIds: new[] { apprenticeshipId });
 
@@ -476,24 +437,20 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ApprenticeshipQA
         public async Task Post_MissingComplianceCommentsWhenReasonContainsOther_RendersErrorMessage()
         {
             // Arrange
-            var ukprn = 12345;
-
-            var providerId = await TestData.CreateProvider(
-                ukprn: ukprn,
+            var provider = await TestData.CreateProvider(
                 providerName: "Provider 1",
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.Submitted);
 
-            var providerUserId = $"{ukprn}-user";
-            await TestData.CreateUser(providerUserId, "somebody@provider1.com", "Provider 1", "Person", providerId);
+            var providerUser = await TestData.CreateUser(providerId: provider.ProviderId);
 
             var standard = await TestData.CreateStandard(standardCode: 1234, version: 1, standardName: "Test Standard");
 
-            var apprenticeshipId = (await TestData.CreateApprenticeship(providerId, standard, createdBy: User.ToUserInfo())).Id;
+            var apprenticeshipId = (await TestData.CreateApprenticeship(provider.ProviderId, standard, createdBy: User.ToUserInfo())).Id;
 
             await TestData.CreateApprenticeshipQASubmission(
-                providerId,
+                provider.ProviderId,
                 submittedOn: Clock.UtcNow,
-                submittedByUserId: providerUserId,
+                submittedByUserId: providerUser.UserId,
                 providerMarketingInformation: "The overview",
                 apprenticeshipIds: new[] { apprenticeshipId });
 
@@ -523,24 +480,20 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ApprenticeshipQA
         public async Task Post_MissingStylePassed_RendersErrorMessage()
         {
             // Arrange
-            var ukprn = 12345;
-
-            var providerId = await TestData.CreateProvider(
-                ukprn: ukprn,
+            var provider = await TestData.CreateProvider(
                 providerName: "Provider 1",
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.Submitted);
 
-            var providerUserId = $"{ukprn}-user";
-            await TestData.CreateUser(providerUserId, "somebody@provider1.com", "Provider 1", "Person", providerId);
+            var providerUser = await TestData.CreateUser(providerId: provider.ProviderId);
 
             var standard = await TestData.CreateStandard(standardCode: 1234, version: 1, standardName: "Test Standard");
 
-            var apprenticeshipId = (await TestData.CreateApprenticeship(providerId, standard, createdBy: User.ToUserInfo())).Id;
+            var apprenticeshipId = (await TestData.CreateApprenticeship(provider.ProviderId, standard, createdBy: User.ToUserInfo())).Id;
 
             await TestData.CreateApprenticeshipQASubmission(
-                providerId,
+                provider.ProviderId,
                 submittedOn: Clock.UtcNow,
-                submittedByUserId: providerUserId,
+                submittedByUserId: providerUser.UserId,
                 providerMarketingInformation: "The overview",
                 apprenticeshipIds: new[] { apprenticeshipId });
 
@@ -568,24 +521,20 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ApprenticeshipQA
         public async Task Post_MissingStyleFailedReasonsWhenFailed_RendersErrorMessage()
         {
             // Arrange
-            var ukprn = 12345;
-
-            var providerId = await TestData.CreateProvider(
-                ukprn: ukprn,
+            var provider = await TestData.CreateProvider(
                 providerName: "Provider 1",
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.Submitted);
 
-            var providerUserId = $"{ukprn}-user";
-            await TestData.CreateUser(providerUserId, "somebody@provider1.com", "Provider 1", "Person", providerId);
+            var providerUser = await TestData.CreateUser(providerId: provider.ProviderId);
 
             var standard = await TestData.CreateStandard(standardCode: 1234, version: 1, standardName: "Test Standard");
 
-            var apprenticeshipId = (await TestData.CreateApprenticeship(providerId, standard, createdBy: User.ToUserInfo())).Id;
+            var apprenticeshipId = (await TestData.CreateApprenticeship(provider.ProviderId, standard, createdBy: User.ToUserInfo())).Id;
 
             await TestData.CreateApprenticeshipQASubmission(
-                providerId,
+                provider.ProviderId,
                 submittedOn: Clock.UtcNow,
-                submittedByUserId: providerUserId,
+                submittedByUserId: providerUser.UserId,
                 providerMarketingInformation: "The overview",
                 apprenticeshipIds: new[] { apprenticeshipId });
 
@@ -614,24 +563,20 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ApprenticeshipQA
         public async Task Post_MissingStyleCommentsWhenReasonContainsOther_RendersErrorMessage()
         {
             // Arrange
-            var ukprn = 12345;
-
-            var providerId = await TestData.CreateProvider(
-                ukprn: ukprn,
+            var provider = await TestData.CreateProvider(
                 providerName: "Provider 1",
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.Submitted);
 
-            var providerUserId = $"{ukprn}-user";
-            await TestData.CreateUser(providerUserId, "somebody@provider1.com", "Provider 1", "Person", providerId);
+            var providerUser = await TestData.CreateUser(providerId: provider.ProviderId);
 
             var standard = await TestData.CreateStandard(standardCode: 1234, version: 1, standardName: "Test Standard");
 
-            var apprenticeshipId = (await TestData.CreateApprenticeship(providerId, standard, createdBy: User.ToUserInfo())).Id;
+            var apprenticeshipId = (await TestData.CreateApprenticeship(provider.ProviderId, standard, createdBy: User.ToUserInfo())).Id;
 
             await TestData.CreateApprenticeshipQASubmission(
-                providerId,
+                provider.ProviderId,
                 submittedOn: Clock.UtcNow,
-                submittedByUserId: providerUserId,
+                submittedByUserId: providerUser.UserId,
                 providerMarketingInformation: "The overview",
                 apprenticeshipIds: new[] { apprenticeshipId });
 
@@ -661,24 +606,20 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ApprenticeshipQA
         public async Task Post_CompliancePassedAndStylePassed_RedirectsToConfirmationPage()
         {
             // Arrange
-            var ukprn = 12345;
-
-            var providerId = await TestData.CreateProvider(
-                ukprn: ukprn,
+            var provider = await TestData.CreateProvider(
                 providerName: "Provider 1",
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.Submitted);
 
-            var providerUserId = $"{ukprn}-user";
-            await TestData.CreateUser(providerUserId, "somebody@provider1.com", "Provider 1", "Person", providerId);
+            var providerUser = await TestData.CreateUser(providerId: provider.ProviderId);
 
             var standard = await TestData.CreateStandard(standardCode: 1234, version: 1, standardName: "Test Standard");
 
-            var apprenticeshipId = (await TestData.CreateApprenticeship(providerId, standard, createdBy: User.ToUserInfo())).Id;
+            var apprenticeshipId = (await TestData.CreateApprenticeship(provider.ProviderId, standard, createdBy: User.ToUserInfo())).Id;
 
             await TestData.CreateApprenticeshipQASubmission(
-                providerId,
+                provider.ProviderId,
                 submittedOn: Clock.UtcNow,
-                submittedByUserId: providerUserId,
+                submittedByUserId: providerUser.UserId,
                 providerMarketingInformation: "The overview",
                 apprenticeshipIds: new[] { apprenticeshipId });
 
@@ -707,24 +648,20 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ApprenticeshipQA
         public async Task Post_CompliancePassedAndStyleFailed_RedirectsToConfirmationPage()
         {
             // Arrange
-            var ukprn = 12345;
-
-            var providerId = await TestData.CreateProvider(
-                ukprn: ukprn,
+            var provider = await TestData.CreateProvider(
                 providerName: "Provider 1",
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.Submitted);
 
-            var providerUserId = $"{ukprn}-user";
-            await TestData.CreateUser(providerUserId, "somebody@provider1.com", "Provider 1", "Person", providerId);
+            var providerUser = await TestData.CreateUser(providerId: provider.ProviderId);
 
             var standard = await TestData.CreateStandard(standardCode: 1234, version: 1, standardName: "Test Standard");
 
-            var apprenticeshipId = (await TestData.CreateApprenticeship(providerId, standard, createdBy: User.ToUserInfo())).Id;
+            var apprenticeshipId = (await TestData.CreateApprenticeship(provider.ProviderId, standard, createdBy: User.ToUserInfo())).Id;
 
             await TestData.CreateApprenticeshipQASubmission(
-                providerId,
+                provider.ProviderId,
                 submittedOn: Clock.UtcNow,
-                submittedByUserId: providerUserId,
+                submittedByUserId: providerUser.UserId,
                 providerMarketingInformation: "The overview",
                 apprenticeshipIds: new[] { apprenticeshipId });
 
@@ -756,24 +693,20 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ApprenticeshipQA
         public async Task Post_ComplianceFailedAndStylePassed_RedirectsToConfirmationPage()
         {
             // Arrange
-            var ukprn = 12345;
-
-            var providerId = await TestData.CreateProvider(
-                ukprn: ukprn,
+            var provider = await TestData.CreateProvider(
                 providerName: "Provider 1",
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.Submitted);
 
-            var providerUserId = $"{ukprn}-user";
-            await TestData.CreateUser(providerUserId, "somebody@provider1.com", "Provider 1", "Person", providerId);
+            var providerUser = await TestData.CreateUser(providerId: provider.ProviderId);
 
             var standard = await TestData.CreateStandard(standardCode: 1234, version: 1, standardName: "Test Standard");
 
-            var apprenticeshipId = (await TestData.CreateApprenticeship(providerId, standard, createdBy: User.ToUserInfo())).Id;
+            var apprenticeshipId = (await TestData.CreateApprenticeship(provider.ProviderId, standard, createdBy: User.ToUserInfo())).Id;
 
             await TestData.CreateApprenticeshipQASubmission(
-                providerId,
+                provider.ProviderId,
                 submittedOn: Clock.UtcNow,
-                submittedByUserId: providerUserId,
+                submittedByUserId: providerUser.UserId,
                 providerMarketingInformation: "The overview",
                 apprenticeshipIds: new[] { apprenticeshipId });
 
@@ -805,24 +738,20 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ApprenticeshipQA
         public async Task Post_ComplianceFailedAndStyleFailed_RedirectsToConfirmationPage()
         {
             // Arrange
-            var ukprn = 12345;
-
-            var providerId = await TestData.CreateProvider(
-                ukprn: ukprn,
+            var provider = await TestData.CreateProvider(
                 providerName: "Provider 1",
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.Submitted);
 
-            var providerUserId = $"{ukprn}-user";
-            await TestData.CreateUser(providerUserId, "somebody@provider1.com", "Provider 1", "Person", providerId);
+            var providerUser = await TestData.CreateUser(providerId: provider.ProviderId);
 
             var standard = await TestData.CreateStandard(standardCode: 1234, version: 1, standardName: "Test Standard");
 
-            var apprenticeshipId = (await TestData.CreateApprenticeship(providerId, standard, createdBy: User.ToUserInfo())).Id;
+            var apprenticeshipId = (await TestData.CreateApprenticeship(provider.ProviderId, standard, createdBy: User.ToUserInfo())).Id;
 
             await TestData.CreateApprenticeshipQASubmission(
-                providerId,
+                provider.ProviderId,
                 submittedOn: Clock.UtcNow,
-                submittedByUserId: providerUserId,
+                submittedByUserId: providerUser.UserId,
                 providerMarketingInformation: "The overview",
                 apprenticeshipIds: new[] { apprenticeshipId });
 
@@ -860,24 +789,20 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ApprenticeshipQA
         public async Task Post_QAStatusNotValidReturnsBadRequest(bool passed, ApprenticeshipQAStatus qaStatus)
         {
             // Arrange
-            var ukprn = 12345;
-
-            var providerId = await TestData.CreateProvider(
-                ukprn: ukprn,
+            var provider = await TestData.CreateProvider(
                 providerName: "Provider 1",
                 apprenticeshipQAStatus: qaStatus);
 
-            var providerUserId = $"{ukprn}-user";
-            await TestData.CreateUser(providerUserId, "somebody@provider1.com", "Provider 1", "Person", providerId);
+            var providerUser = await TestData.CreateUser(providerId: provider.ProviderId);
 
             var standard = await TestData.CreateStandard(standardCode: 1234, version: 1, standardName: "Test Standard");
 
-            var apprenticeshipId = (await TestData.CreateApprenticeship(providerId, standard, createdBy: User.ToUserInfo())).Id;
+            var apprenticeshipId = (await TestData.CreateApprenticeship(provider.ProviderId, standard, createdBy: User.ToUserInfo())).Id;
 
             var submissionId = await TestData.CreateApprenticeshipQASubmission(
-                providerId,
+                provider.ProviderId,
                 submittedOn: Clock.UtcNow,
-                submittedByUserId: providerUserId,
+                submittedByUserId: providerUser.UserId,
                 providerMarketingInformation: "The overview",
                 apprenticeshipIds: new[] { apprenticeshipId });
 
@@ -893,7 +818,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ApprenticeshipQA
                 apprenticeshipId,
                 new JourneyModel()
                 {
-                    ProviderId = providerId
+                    ProviderId = provider.ProviderId
                 });
 
             await User.AsHelpdesk();
@@ -916,24 +841,20 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ApprenticeshipQA
         public async Task GetConfirmation_NotGotOutcome_ReturnsBadRequest()
         {
             // Arrange
-            var ukprn = 12345;
-
-            var providerId = await TestData.CreateProvider(
-                ukprn: ukprn,
+            var provider = await TestData.CreateProvider(
                 providerName: "Provider 1",
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.Submitted);
 
-            var providerUserId = $"{ukprn}-user";
-            await TestData.CreateUser(providerUserId, "somebody@provider1.com", "Provider 1", "Person", providerId);
+            var providerUser = await TestData.CreateUser(providerId: provider.ProviderId);
 
             var standard = await TestData.CreateStandard(standardCode: 1234, version: 1, standardName: "Test Standard");
 
-            var apprenticeshipId = (await TestData.CreateApprenticeship(providerId, standard, createdBy: User.ToUserInfo())).Id;
+            var apprenticeshipId = (await TestData.CreateApprenticeship(provider.ProviderId, standard, createdBy: User.ToUserInfo())).Id;
 
             await TestData.CreateApprenticeshipQASubmission(
-                providerId,
+                provider.ProviderId,
                 submittedOn: Clock.UtcNow,
-                submittedByUserId: providerUserId,
+                submittedByUserId: providerUser.UserId,
                 providerMarketingInformation: "The overview",
                 apprenticeshipIds: new[] { apprenticeshipId });
 
@@ -954,24 +875,20 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ApprenticeshipQA
         public async Task GetConfirmation_PassedComplianceAndPassedStyle_RendersExpectedContent()
         {
             // Arrange
-            var ukprn = 12345;
-
-            var providerId = await TestData.CreateProvider(
-                ukprn: ukprn,
+            var provider = await TestData.CreateProvider(
                 providerName: "Provider 1",
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.Submitted);
 
-            var providerUserId = $"{ukprn}-user";
-            await TestData.CreateUser(providerUserId, "somebody@provider1.com", "Provider 1", "Person", providerId);
+            var providerUser = await TestData.CreateUser(providerId: provider.ProviderId);
 
             var standard = await TestData.CreateStandard(standardCode: 1234, version: 1, standardName: "Test Standard");
 
-            var apprenticeshipId = (await TestData.CreateApprenticeship(providerId, standard, createdBy: User.ToUserInfo())).Id;
+            var apprenticeshipId = (await TestData.CreateApprenticeship(provider.ProviderId, standard, createdBy: User.ToUserInfo())).Id;
 
             await TestData.CreateApprenticeshipQASubmission(
-                providerId,
+                provider.ProviderId,
                 submittedOn: Clock.UtcNow,
-                submittedByUserId: providerUserId,
+                submittedByUserId: providerUser.UserId,
                 providerMarketingInformation: "The overview",
                 apprenticeshipIds: new[] { apprenticeshipId });
 
@@ -1005,24 +922,20 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ApprenticeshipQA
         public async Task GetConfirmation_PassedComplianceAndFailedStyle_RendersExpectedContent()
         {
             // Arrange
-            var ukprn = 12345;
-
-            var providerId = await TestData.CreateProvider(
-                ukprn: ukprn,
+            var provider = await TestData.CreateProvider(
                 providerName: "Provider 1",
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.Submitted);
 
-            var providerUserId = $"{ukprn}-user";
-            await TestData.CreateUser(providerUserId, "somebody@provider1.com", "Provider 1", "Person", providerId);
+            var providerUser = await TestData.CreateUser(providerId: provider.ProviderId);
 
             var standard = await TestData.CreateStandard(standardCode: 1234, version: 1, standardName: "Test Standard");
 
-            var apprenticeshipId = (await TestData.CreateApprenticeship(providerId, standard, createdBy: User.ToUserInfo())).Id;
+            var apprenticeshipId = (await TestData.CreateApprenticeship(provider.ProviderId, standard, createdBy: User.ToUserInfo())).Id;
 
             await TestData.CreateApprenticeshipQASubmission(
-                providerId,
+                provider.ProviderId,
                 submittedOn: Clock.UtcNow,
-                submittedByUserId: providerUserId,
+                submittedByUserId: providerUser.UserId,
                 providerMarketingInformation: "The overview",
                 apprenticeshipIds: new[] { apprenticeshipId });
 
@@ -1056,24 +969,20 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ApprenticeshipQA
         public async Task GetConfirmation_FailedComplianceAndPassedStyle_RendersExpectedContent()
         {
             // Arrange
-            var ukprn = 12345;
-
-            var providerId = await TestData.CreateProvider(
-                ukprn: ukprn,
+            var provider = await TestData.CreateProvider(
                 providerName: "Provider 1",
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.Submitted);
 
-            var providerUserId = $"{ukprn}-user";
-            await TestData.CreateUser(providerUserId, "somebody@provider1.com", "Provider 1", "Person", providerId);
+            var providerUser = await TestData.CreateUser(providerId: provider.ProviderId);
 
             var standard = await TestData.CreateStandard(standardCode: 1234, version: 1, standardName: "Test Standard");
 
-            var apprenticeshipId = (await TestData.CreateApprenticeship(providerId, standard, createdBy: User.ToUserInfo())).Id;
+            var apprenticeshipId = (await TestData.CreateApprenticeship(provider.ProviderId, standard, createdBy: User.ToUserInfo())).Id;
 
             await TestData.CreateApprenticeshipQASubmission(
-                providerId,
+                provider.ProviderId,
                 submittedOn: Clock.UtcNow,
-                submittedByUserId: providerUserId,
+                submittedByUserId: providerUser.UserId,
                 providerMarketingInformation: "The overview",
                 apprenticeshipIds: new[] { apprenticeshipId });
 
@@ -1107,24 +1016,20 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ApprenticeshipQA
         public async Task GetConfirmation_FailedComplianceAndFailedStyle_RendersExpectedContent()
         {
             // Arrange
-            var ukprn = 12345;
-
-            var providerId = await TestData.CreateProvider(
-                ukprn: ukprn,
+            var provider = await TestData.CreateProvider(
                 providerName: "Provider 1",
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.Submitted);
 
-            var providerUserId = $"{ukprn}-user";
-            await TestData.CreateUser(providerUserId, "somebody@provider1.com", "Provider 1", "Person", providerId);
+            var providerUser = await TestData.CreateUser(providerId: provider.ProviderId);
 
             var standard = await TestData.CreateStandard(standardCode: 1234, version: 1, standardName: "Test Standard");
 
-            var apprenticeshipId = (await TestData.CreateApprenticeship(providerId, standard, createdBy: User.ToUserInfo())).Id;
+            var apprenticeshipId = (await TestData.CreateApprenticeship(provider.ProviderId, standard, createdBy: User.ToUserInfo())).Id;
 
             await TestData.CreateApprenticeshipQASubmission(
-                providerId,
+                provider.ProviderId,
                 submittedOn: Clock.UtcNow,
-                submittedByUserId: providerUserId,
+                submittedByUserId: providerUser.UserId,
                 providerMarketingInformation: "The overview",
                 apprenticeshipIds: new[] { apprenticeshipId });
 
@@ -1160,24 +1065,20 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ApprenticeshipQA
         public async Task PostConfirmation_ProviderUser_ReturnsForbidden(TestUserType userType)
         {
             // Arrange
-            var ukprn = 12345;
-
-            var providerId = await TestData.CreateProvider(
-                ukprn: ukprn,
+            var provider = await TestData.CreateProvider(
                 providerName: "Provider 1",
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.Submitted);
 
-            var providerUserId = $"{ukprn}-user";
-            await TestData.CreateUser(providerUserId, "somebody@provider1.com", "Provider 1", "Person", providerId);
+            var providerUser = await TestData.CreateUser(providerId: provider.ProviderId);
 
             var standard = await TestData.CreateStandard(standardCode: 1234, version: 1, standardName: "Test Standard");
 
-            var apprenticeshipId = (await TestData.CreateApprenticeship(providerId, standard, createdBy: User.ToUserInfo())).Id;
+            var apprenticeshipId = (await TestData.CreateApprenticeship(provider.ProviderId, standard, createdBy: User.ToUserInfo())).Id;
 
             var submissionId = await TestData.CreateApprenticeshipQASubmission(
-                providerId,
+                provider.ProviderId,
                 submittedOn: Clock.UtcNow,
-                submittedByUserId: providerUserId,
+                submittedByUserId: providerUser.UserId,
                 providerMarketingInformation: "The overview",
                 apprenticeshipIds: new[] { apprenticeshipId });
 
@@ -1190,7 +1091,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ApprenticeshipQA
                 styleFailedReasons: ApprenticeshipQAApprenticeshipStyleFailedReasons.None,
                 styleComments: null));
 
-            await User.AsTestUser(userType, providerId);
+            await User.AsTestUser(userType, provider.ProviderId);
 
             var requestContent = new FormUrlEncodedContentBuilder().ToContent();
 
@@ -1211,24 +1112,20 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ApprenticeshipQA
         public async Task PostConfirmation_InvalidQAStatus_ReturnsBadRequest(ApprenticeshipQAStatus qaStatus)
         {
             // Arrange
-            var ukprn = 12345;
-
-            var providerId = await TestData.CreateProvider(
-                ukprn: ukprn,
+            var provider = await TestData.CreateProvider(
                 providerName: "Provider 1",
                 apprenticeshipQAStatus: qaStatus);
 
-            var providerUserId = $"{ukprn}-user";
-            await TestData.CreateUser(providerUserId, "somebody@provider1.com", "Provider 1", "Person", providerId);
+            var providerUser = await TestData.CreateUser(providerId: provider.ProviderId);
 
             var standard = await TestData.CreateStandard(standardCode: 1234, version: 1, standardName: "Test Standard");
 
-            var apprenticeshipId = (await TestData.CreateApprenticeship(providerId, standard, createdBy: User.ToUserInfo())).Id;
+            var apprenticeshipId = (await TestData.CreateApprenticeship(provider.ProviderId, standard, createdBy: User.ToUserInfo())).Id;
 
             var submissionId = await TestData.CreateApprenticeshipQASubmission(
-                providerId,
+                provider.ProviderId,
                 submittedOn: Clock.UtcNow,
-                submittedByUserId: providerUserId,
+                submittedByUserId: providerUser.UserId,
                 providerMarketingInformation: "The overview",
                 apprenticeshipIds: new[] { apprenticeshipId });
 
@@ -1274,24 +1171,20 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ApprenticeshipQA
             bool? expectedSubmissionPassed)
         {
             // Arrange
-            var ukprn = 12345;
-
-            var providerId = await TestData.CreateProvider(
-                ukprn: ukprn,
+            var provider = await TestData.CreateProvider(
                 providerName: "Provider 1",
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.Submitted);
 
-            var providerUserId = $"{ukprn}-user";
-            await TestData.CreateUser(providerUserId, "somebody@provider1.com", "Provider 1", "Person", providerId);
+            var providerUser = await TestData.CreateUser(providerId: provider.ProviderId);
 
             var standard = await TestData.CreateStandard(standardCode: 1234, version: 1, standardName: "Test Standard");
 
-            var apprenticeshipId = (await TestData.CreateApprenticeship(providerId, standard, createdBy: User.ToUserInfo())).Id;
+            var apprenticeshipId = (await TestData.CreateApprenticeship(provider.ProviderId, standard, createdBy: User.ToUserInfo())).Id;
 
             var submissionId = await TestData.CreateApprenticeshipQASubmission(
-                providerId,
+                provider.ProviderId,
                 submittedOn: Clock.UtcNow,
-                submittedByUserId: providerUserId,
+                submittedByUserId: providerUser.UserId,
                 providerMarketingInformation: "The overview",
                 apprenticeshipIds: new[] { apprenticeshipId });
 
@@ -1327,12 +1220,12 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ApprenticeshipQA
 
             // Assert
             Assert.Equal(HttpStatusCode.Found, response.StatusCode);
-            Assert.Equal($"/apprenticeship-qa/{providerId}", response.Headers.Location.OriginalString);
+            Assert.Equal($"/apprenticeship-qa/{provider.ProviderId}", response.Headers.Location.OriginalString);
 
             var submissionStatus = await WithSqlQueryDispatcher(dispatcher => dispatcher.ExecuteQuery(
                 new GetLatestApprenticeshipQASubmissionForProvider()
                 {
-                    ProviderId = providerId
+                    ProviderId = provider.ProviderId
                 }));
             Assert.Equal(expectedSubmissionPassed, submissionStatus.Passed);
         }

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/ApprenticeshipQA/ListProvidersTest.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/ApprenticeshipQA/ListProvidersTest.cs
@@ -19,9 +19,9 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ApprenticeshipQA
         public async Task Get_ProviderUserCannotAccess(TestUserType userType)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
+            var provider = await TestData.CreateProvider();
 
-            await User.AsTestUser(userType, providerId);
+            await User.AsTestUser(userType, provider.ProviderId);
 
             // Act
             var response = await HttpClient.GetAsync("apprenticeship-qa");
@@ -37,46 +37,37 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ApprenticeshipQA
 
             var standard = await TestData.CreateStandard(standardCode: 1234, version: 1, standardName: "Test Standard");
 
-            var provider1Ukprn = 12345;
-            var provider1UserId = $"user-{provider1Ukprn}";
-            var provider1Id = await TestData.CreateProvider(
-                ukprn: provider1Ukprn,
+            var provider1 = await TestData.CreateProvider(
                 providerName: "Provider 1",
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.Submitted);
-            await TestData.CreateUser(provider1UserId, "guy@provider1.com", "Provider 1", "User", provider1Id);
-            await TestData.CreateUserSignIn(provider1UserId, new DateTime(2018, 4, 1, 10, 4, 3));
-            var provider1ApprenticeshipId = (await TestData.CreateApprenticeship(provider1Id, standard, createdBy: User.ToUserInfo())).Id;
+            var provider1User = await TestData.CreateUser(providerId: provider1.ProviderId);
+            await TestData.CreateUserSignIn(provider1User.UserId, new DateTime(2018, 4, 1, 10, 4, 3));
+            var provider1ApprenticeshipId = (await TestData.CreateApprenticeship(provider1.ProviderId, standard, createdBy: User.ToUserInfo())).Id;
             await TestData.CreateApprenticeshipQASubmission(
-                provider1Id,
+                provider1.ProviderId,
                 submittedOn: new DateTime(2018, 4, 1, 12, 30, 37),
-                submittedByUserId: provider1UserId,
+                submittedByUserId: provider1User.UserId,
                 providerMarketingInformation: "Provider 1 overview",
                 apprenticeshipIds: new[] { provider1ApprenticeshipId });
 
-            var provider2Ukprn = 23456;
-            var provider2UserId = $"user-{provider2Ukprn}";
-            var provider2Id = await TestData.CreateProvider(
-                ukprn: provider2Ukprn,
+            var provider2 = await TestData.CreateProvider(
                 providerName: "Provider 2",
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.Submitted);
-            await TestData.CreateUser(provider2UserId, "guy@provider2.com", "Provider 2", "User", provider2Id);
-            await TestData.CreateUserSignIn(provider2UserId, new DateTime(2019, 5, 3, 14, 55, 17));
-            var provider2ApprenticeshipId = (await TestData.CreateApprenticeship(provider2Id, standard, createdBy: User.ToUserInfo())).Id;
+            var provider2User = await TestData.CreateUser(providerId: provider2.ProviderId);
+            await TestData.CreateUserSignIn(provider2User.UserId, new DateTime(2019, 5, 3, 14, 55, 17));
+            var provider2ApprenticeshipId = (await TestData.CreateApprenticeship(provider2.ProviderId, standard, createdBy: User.ToUserInfo())).Id;
             await TestData.CreateApprenticeshipQASubmission(
-                provider2Id,
+                provider2.ProviderId,
                 submittedOn: new DateTime(2019, 5, 3, 15, 01, 23),
-                submittedByUserId: provider2UserId,
+                submittedByUserId: provider2User.UserId,
                 providerMarketingInformation: "Provider 2 overview",
                 apprenticeshipIds: new[] { provider2ApprenticeshipId });
 
-            var provider3Ukprn = 345678;
-            var provider3UserId = $"user-{provider3Ukprn}";
-            var provider3Id = await TestData.CreateProvider(
-                ukprn: provider3Ukprn,
+            var provider3 = await TestData.CreateProvider(
                 providerName: "Provider 3",
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
-            await TestData.CreateUser(provider3UserId, "guy@provider3.com", "Provider 3", "User", provider3Id);
-            await TestData.CreateUserSignIn(provider3UserId, new DateTime(2019, 2, 6, 7, 22, 9));
+            var provider3User = await TestData.CreateUser(providerId: provider3.ProviderId);
+            await TestData.CreateUserSignIn(provider3User.UserId, new DateTime(2019, 2, 6, 7, 22, 9));
 
             // TODO Add more here once we have a way of modelling other statuses
 
@@ -93,7 +84,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ApprenticeshipQA
 
             var firstNewProviderRow = newProviderRows[0];
             Assert.Equal("Provider 3", firstNewProviderRow.QuerySelector(":nth-child(1)").TextContent);
-            Assert.Equal("345678", firstNewProviderRow.QuerySelector(":nth-child(2)").TextContent);
+            Assert.Equal(provider3.Ukprn.ToString(), firstNewProviderRow.QuerySelector(":nth-child(2)").TextContent);
             Assert.Equal("06 Feb 2019", firstNewProviderRow.QuerySelector(":nth-child(3)").TextContent);
 
             var submitted = doc.QuerySelector("#submitted");
@@ -101,12 +92,12 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ApprenticeshipQA
 
             var firstSubmittedRow = submittedRows[0];
             Assert.Equal("Provider 2", firstSubmittedRow.QuerySelector(":nth-child(1)").TextContent);
-            Assert.Equal("23456", firstSubmittedRow.QuerySelector(":nth-child(2)").TextContent);
+            Assert.Equal(provider2.Ukprn.ToString(), firstSubmittedRow.QuerySelector(":nth-child(2)").TextContent);
             Assert.Equal("03 May 2019", firstSubmittedRow.QuerySelector(":nth-child(3)").TextContent);
 
             var secondSubmittedRow = submittedRows[1];
             Assert.Equal("Provider 1", secondSubmittedRow.QuerySelector(":nth-child(1)").TextContent);
-            Assert.Equal("12345", secondSubmittedRow.QuerySelector(":nth-child(2)").TextContent);
+            Assert.Equal(provider1.Ukprn.ToString(), secondSubmittedRow.QuerySelector(":nth-child(2)").TextContent);
             Assert.Equal("01 Apr 2018", secondSubmittedRow.QuerySelector(":nth-child(3)").TextContent);
         }
 

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/ApprenticeshipQA/ProviderSelectedTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/ApprenticeshipQA/ProviderSelectedTests.cs
@@ -20,31 +20,27 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ApprenticeshipQA
         public async Task Get_ProviderUserCannotAccess(TestUserType testUserType)
         {
             // Arrange
-            var ukprn = 12345;
-
-            var providerId = await TestData.CreateProvider(
-                ukprn: ukprn,
+            var provider = await TestData.CreateProvider(
                 providerName: "Provider 1",
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.Submitted);
 
-            var providerUserId = $"{ukprn}-user";
-            await TestData.CreateUser(providerUserId, "somebody@provider1.com", "Provider 1", "Person", providerId);
+            var providerUser = await TestData.CreateUser(providerId: provider.ProviderId);
 
             var standard = await TestData.CreateStandard(standardCode: 1234, version: 1, standardName: "Test Standard");
 
-            var apprenticeshipId = (await TestData.CreateApprenticeship(providerId, standard, createdBy: User.ToUserInfo())).Id;
+            var apprenticeshipId = (await TestData.CreateApprenticeship(provider.ProviderId, standard, createdBy: User.ToUserInfo())).Id;
 
             await TestData.CreateApprenticeshipQASubmission(
-                providerId,
+                provider.ProviderId,
                 submittedOn: Clock.UtcNow,
-                submittedByUserId: providerUserId,
+                submittedByUserId: providerUser.UserId,
                 providerMarketingInformation: "The overview",
                 apprenticeshipIds: new[] { apprenticeshipId });
 
-            await User.AsTestUser(testUserType, providerId);
+            await User.AsTestUser(testUserType, provider.ProviderId);
 
             // Act
-            var response = await HttpClient.GetAsync($"apprenticeship-qa/{providerId}");
+            var response = await HttpClient.GetAsync($"apprenticeship-qa/{provider.ProviderId}");
 
             // Assert
             Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
@@ -69,31 +65,27 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ApprenticeshipQA
         public async Task Get_RendersExpectedOutput()
         {
             // Arrange
-            var ukprn = 12345;
-
-            var providerId = await TestData.CreateProvider(
-                ukprn: ukprn,
+            var provider = await TestData.CreateProvider(
                 providerName: "Provider 1",
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.Submitted);
 
-            var providerUserId = $"{ukprn}-user";
-            await TestData.CreateUser(providerUserId, "somebody@provider1.com", "Provider 1", "Person", providerId);
+            var providerUser = await TestData.CreateUser(providerId: provider.ProviderId);
 
             var standard = await TestData.CreateStandard(standardCode: 1234, version: 1, standardName: "Test Standard");
 
-            var apprenticeshipId = (await TestData.CreateApprenticeship(providerId, standard, createdBy: User.ToUserInfo())).Id;
+            var apprenticeshipId = (await TestData.CreateApprenticeship(provider.ProviderId, standard, createdBy: User.ToUserInfo())).Id;
 
             await TestData.CreateApprenticeshipQASubmission(
-                providerId,
+                provider.ProviderId,
                 submittedOn: Clock.UtcNow,
-                submittedByUserId: providerUserId,
+                submittedByUserId: providerUser.UserId,
                 providerMarketingInformation: "The overview",
                 apprenticeshipIds: new[] { apprenticeshipId });
 
             await User.AsHelpdesk();
 
             // Act
-            var response = await HttpClient.GetAsync($"apprenticeship-qa/{providerId}");
+            var response = await HttpClient.GetAsync($"apprenticeship-qa/{provider.ProviderId}");
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -112,24 +104,20 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ApprenticeshipQA
         public async Task Get_ProviderAssessmentCompletedRendersBadge(bool passed)
         {
             // Arrange
-            var ukprn = 12345;
-
-            var providerId = await TestData.CreateProvider(
-                ukprn: ukprn,
+            var provider = await TestData.CreateProvider(
                 providerName: "Provider 1",
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.InProgress);
 
-            var providerUserId = $"{ukprn}-user";
-            await TestData.CreateUser(providerUserId, "somebody@provider1.com", "Provider 1", "Person", providerId);
+            var providerUser = await TestData.CreateUser(providerId: provider.ProviderId);
 
             var standard = await TestData.CreateStandard(standardCode: 1234, version: 1, standardName: "Test Standard");
 
-            var apprenticeshipId = (await TestData.CreateApprenticeship(providerId, standard, createdBy: User.ToUserInfo())).Id;
+            var apprenticeshipId = (await TestData.CreateApprenticeship(provider.ProviderId, standard, createdBy: User.ToUserInfo())).Id;
 
             var submissionId = await TestData.CreateApprenticeshipQASubmission(
-                providerId,
+                provider.ProviderId,
                 submittedOn: Clock.UtcNow,
-                submittedByUserId: providerUserId,
+                submittedByUserId: providerUser.UserId,
                 providerMarketingInformation: "The overview",
                 apprenticeshipIds: new[] { apprenticeshipId });
 
@@ -144,7 +132,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ApprenticeshipQA
             await User.AsHelpdesk();
 
             // Act
-            var response = await HttpClient.GetAsync($"apprenticeship-qa/{providerId}");
+            var response = await HttpClient.GetAsync($"apprenticeship-qa/{provider.ProviderId}");
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -159,24 +147,20 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ApprenticeshipQA
         public async Task Get_ProviderAssessmentNotCompletedDoesNotRenderBadge()
         {
             // Arrange
-            var ukprn = 12345;
-
-            var providerId = await TestData.CreateProvider(
-                ukprn: ukprn,
+            var provider = await TestData.CreateProvider(
                 providerName: "Provider 1",
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.InProgress);
 
-            var providerUserId = $"{ukprn}-user";
-            await TestData.CreateUser(providerUserId, "somebody@provider1.com", "Provider 1", "Person", providerId);
+            var providerUser = await TestData.CreateUser(providerId: provider.ProviderId);
 
             var standard = await TestData.CreateStandard(standardCode: 1234, version: 1, standardName: "Test Standard");
 
-            var apprenticeshipId = (await TestData.CreateApprenticeship(providerId, standard, createdBy: User.ToUserInfo())).Id;
+            var apprenticeshipId = (await TestData.CreateApprenticeship(provider.ProviderId, standard, createdBy: User.ToUserInfo())).Id;
 
             var submissionId = await TestData.CreateApprenticeshipQASubmission(
-                providerId,
+                provider.ProviderId,
                 submittedOn: Clock.UtcNow,
-                submittedByUserId: providerUserId,
+                submittedByUserId: providerUser.UserId,
                 providerMarketingInformation: "The overview",
                 apprenticeshipIds: new[] { apprenticeshipId });
 
@@ -191,7 +175,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ApprenticeshipQA
             await User.AsHelpdesk();
 
             // Act
-            var response = await HttpClient.GetAsync($"apprenticeship-qa/{providerId}");
+            var response = await HttpClient.GetAsync($"apprenticeship-qa/{provider.ProviderId}");
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -208,24 +192,20 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ApprenticeshipQA
         public async Task Get_ApprenticeshipAssessmentCompletedRendersBadge(bool passed)
         {
             // Arrange
-            var ukprn = 12345;
-
-            var providerId = await TestData.CreateProvider(
-                ukprn: ukprn,
+            var provider = await TestData.CreateProvider(
                 providerName: "Provider 1",
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.InProgress);
 
-            var providerUserId = $"{ukprn}-user";
-            await TestData.CreateUser(providerUserId, "somebody@provider1.com", "Provider 1", "Person", providerId);
+            var providerUser = await TestData.CreateUser(providerId: provider.ProviderId);
 
             var standard = await TestData.CreateStandard(standardCode: 1234, version: 1, standardName: "Test Standard");
 
-            var apprenticeshipId = (await TestData.CreateApprenticeship(providerId, standard, createdBy: User.ToUserInfo())).Id;
+            var apprenticeshipId = (await TestData.CreateApprenticeship(provider.ProviderId, standard, createdBy: User.ToUserInfo())).Id;
 
             var submissionId = await TestData.CreateApprenticeshipQASubmission(
-                providerId,
+                provider.ProviderId,
                 submittedOn: Clock.UtcNow,
-                submittedByUserId: providerUserId,
+                submittedByUserId: providerUser.UserId,
                 providerMarketingInformation: "The overview",
                 apprenticeshipIds: new[] { apprenticeshipId });
 
@@ -240,7 +220,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ApprenticeshipQA
             await User.AsHelpdesk();
 
             // Act
-            var response = await HttpClient.GetAsync($"apprenticeship-qa/{providerId}");
+            var response = await HttpClient.GetAsync($"apprenticeship-qa/{provider.ProviderId}");
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -255,24 +235,20 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ApprenticeshipQA
         public async Task Get_ApprenticeshipAssessmentNotCompletedDoesNotRenderBadge()
         {
             // Arrange
-            var ukprn = 12345;
-
-            var providerId = await TestData.CreateProvider(
-                ukprn: ukprn,
+            var provider = await TestData.CreateProvider(
                 providerName: "Provider 1",
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.InProgress);
 
-            var providerUserId = $"{ukprn}-user";
-            await TestData.CreateUser(providerUserId, "somebody@provider1.com", "Provider 1", "Person", providerId);
+            var providerUser = await TestData.CreateUser(providerId: provider.ProviderId);
 
             var standard = await TestData.CreateStandard(standardCode: 1234, version: 1, standardName: "Test Standard");
 
-            var apprenticeshipId = (await TestData.CreateApprenticeship(providerId, standard, createdBy: User.ToUserInfo())).Id;
+            var apprenticeshipId = (await TestData.CreateApprenticeship(provider.ProviderId, standard, createdBy: User.ToUserInfo())).Id;
 
             var submissionId = await TestData.CreateApprenticeshipQASubmission(
-                providerId,
+                provider.ProviderId,
                 submittedOn: Clock.UtcNow,
-                submittedByUserId: providerUserId,
+                submittedByUserId: providerUser.UserId,
                 providerMarketingInformation: "The overview",
                 apprenticeshipIds: new[] { apprenticeshipId });
 
@@ -287,7 +263,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ApprenticeshipQA
             await User.AsHelpdesk();
 
             // Act
-            var response = await HttpClient.GetAsync($"apprenticeship-qa/{providerId}");
+            var response = await HttpClient.GetAsync($"apprenticeship-qa/{provider.ProviderId}");
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -304,24 +280,20 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ApprenticeshipQA
         public async Task Get_InProgressStatusAndSubmissionOutcomeIsKnownRendersFinishButton(bool passed)
         {
             // Arrange
-            var ukprn = 12345;
-
-            var providerId = await TestData.CreateProvider(
-                ukprn: ukprn,
+            var provider = await TestData.CreateProvider(
                 providerName: "Provider 1",
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.InProgress);
 
-            var providerUserId = $"{ukprn}-user";
-            await TestData.CreateUser(providerUserId, "somebody@provider1.com", "Provider 1", "Person", providerId);
+            var providerUser = await TestData.CreateUser(providerId: provider.ProviderId);
 
             var standard = await TestData.CreateStandard(standardCode: 1234, version: 1, standardName: "Test Standard");
 
-            var apprenticeshipId = (await TestData.CreateApprenticeship(providerId, standard, createdBy: User.ToUserInfo())).Id;
+            var apprenticeshipId = (await TestData.CreateApprenticeship(provider.ProviderId, standard, createdBy: User.ToUserInfo())).Id;
 
             var submissionId = await TestData.CreateApprenticeshipQASubmission(
-                providerId,
+                provider.ProviderId,
                 submittedOn: Clock.UtcNow,
-                submittedByUserId: providerUserId,
+                submittedByUserId: providerUser.UserId,
                 providerMarketingInformation: "The overview",
                 apprenticeshipIds: new[] { apprenticeshipId });
 
@@ -336,7 +308,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ApprenticeshipQA
             await User.AsHelpdesk();
 
             // Act
-            var response = await HttpClient.GetAsync($"apprenticeship-qa/{providerId}");
+            var response = await HttpClient.GetAsync($"apprenticeship-qa/{provider.ProviderId}");
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -351,31 +323,27 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ApprenticeshipQA
         public async Task Get_InProgressStatusAndSubmissionOutcomeIsNotKnownRendersDisabledFinishButton()
         {
             // Arrange
-            var ukprn = 12345;
-
-            var providerId = await TestData.CreateProvider(
-                ukprn: ukprn,
+            var provider = await TestData.CreateProvider(
                 providerName: "Provider 1",
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.InProgress);
 
-            var providerUserId = $"{ukprn}-user";
-            await TestData.CreateUser(providerUserId, "somebody@provider1.com", "Provider 1", "Person", providerId);
+            var providerUser = await TestData.CreateUser(providerId: provider.ProviderId);
 
             var standard = await TestData.CreateStandard(standardCode: 1234, version: 1, standardName: "Test Standard");
 
-            var apprenticeshipId = (await TestData.CreateApprenticeship(providerId, standard, createdBy: User.ToUserInfo())).Id;
+            var apprenticeshipId = (await TestData.CreateApprenticeship(provider.ProviderId, standard, createdBy: User.ToUserInfo())).Id;
 
             await TestData.CreateApprenticeshipQASubmission(
-                providerId,
+                provider.ProviderId,
                 submittedOn: Clock.UtcNow,
-                submittedByUserId: providerUserId,
+                submittedByUserId: providerUser.UserId,
                 providerMarketingInformation: "The overview",
                 apprenticeshipIds: new[] { apprenticeshipId });
 
             await User.AsHelpdesk();
 
             // Act
-            var response = await HttpClient.GetAsync($"apprenticeship-qa/{providerId}");
+            var response = await HttpClient.GetAsync($"apprenticeship-qa/{provider.ProviderId}");
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -390,24 +358,20 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ApprenticeshipQA
         public async Task Get_FailedStatusRendersText()
         {
             // Arrange
-            var ukprn = 12345;
-
-            var providerId = await TestData.CreateProvider(
-                ukprn: ukprn,
+            var provider = await TestData.CreateProvider(
                 providerName: "Provider 1",
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.Failed);
 
-            var providerUserId = $"{ukprn}-user";
-            await TestData.CreateUser(providerUserId, "somebody@provider1.com", "Provider 1", "Person", providerId);
+            var providerUser = await TestData.CreateUser(providerId: provider.ProviderId);
 
             var standard = await TestData.CreateStandard(standardCode: 1234, version: 1, standardName: "Test Standard");
 
-            var apprenticeshipId = (await TestData.CreateApprenticeship(providerId, standard, createdBy: User.ToUserInfo())).Id;
+            var apprenticeshipId = (await TestData.CreateApprenticeship(provider.ProviderId, standard, createdBy: User.ToUserInfo())).Id;
 
             var submissionId = await TestData.CreateApprenticeshipQASubmission(
-                providerId,
+                provider.ProviderId,
                 submittedOn: Clock.UtcNow,
-                submittedByUserId: providerUserId,
+                submittedByUserId: providerUser.UserId,
                 providerMarketingInformation: "The overview",
                 apprenticeshipIds: new[] { apprenticeshipId });
 
@@ -422,7 +386,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ApprenticeshipQA
             await User.AsHelpdesk();
 
             // Act
-            var response = await HttpClient.GetAsync($"apprenticeship-qa/{providerId}");
+            var response = await HttpClient.GetAsync($"apprenticeship-qa/{provider.ProviderId}");
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -441,24 +405,20 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ApprenticeshipQA
         public async Task Get_PassedStatusRendersText()
         {
             // Arrange
-            var ukprn = 12345;
-
-            var providerId = await TestData.CreateProvider(
-                ukprn: ukprn,
+            var provider = await TestData.CreateProvider(
                 providerName: "Provider 1",
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.Passed);
 
-            var providerUserId = $"{ukprn}-user";
-            await TestData.CreateUser(providerUserId, "somebody@provider1.com", "Provider 1", "Person", providerId);
+            var providerUser = await TestData.CreateUser(providerId: provider.ProviderId);
 
             var standard = await TestData.CreateStandard(standardCode: 1234, version: 1, standardName: "Test Standard");
 
-            var apprenticeshipId = (await TestData.CreateApprenticeship(providerId, standard, createdBy: User.ToUserInfo())).Id;
+            var apprenticeshipId = (await TestData.CreateApprenticeship(provider.ProviderId, standard, createdBy: User.ToUserInfo())).Id;
 
             var submissionId = await TestData.CreateApprenticeshipQASubmission(
-                providerId,
+                provider.ProviderId,
                 submittedOn: Clock.UtcNow,
-                submittedByUserId: providerUserId,
+                submittedByUserId: providerUser.UserId,
                 providerMarketingInformation: "The overview",
                 apprenticeshipIds: new[] { apprenticeshipId });
 
@@ -473,7 +433,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ApprenticeshipQA
             await User.AsHelpdesk();
 
             // Act
-            var response = await HttpClient.GetAsync($"apprenticeship-qa/{providerId}");
+            var response = await HttpClient.GetAsync($"apprenticeship-qa/{provider.ProviderId}");
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -492,20 +452,16 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ApprenticeshipQA
         public async Task Get_NoSubmissionReturnsOk()
         {
             // Arrange
-            var ukprn = 12345;
-
-            var providerId = await TestData.CreateProvider(
-                ukprn: ukprn,
+            var provider = await TestData.CreateProvider(
                 providerName: "Provider 1",
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
 
-            var providerUserId = $"{ukprn}-user";
-            await TestData.CreateUser(providerUserId, "somebody@provider1.com", "Provider 1", "Person", providerId);
+            await TestData.CreateUser(providerId: provider.ProviderId);
 
             await User.AsHelpdesk();
 
             // Act
-            var response = await HttpClient.GetAsync($"apprenticeship-qa/{providerId}");
+            var response = await HttpClient.GetAsync($"apprenticeship-qa/{provider.ProviderId}");
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/Apprenticeships/ClassroomLocationTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/Apprenticeships/ClassroomLocationTests.cs
@@ -21,21 +21,21 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Apprenticeships
         public async Task Get_ValidRequest_RendersExpectedOutput()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(providerType: ProviderType.Apprenticeships);
+            var provider = await TestData.CreateProvider(providerType: ProviderType.Apprenticeships);
 
-            await TestData.CreateVenue(providerId, venueName: "Venue 1");
-            await TestData.CreateVenue(providerId, venueName: "Venue 2");
+            await TestData.CreateVenue(provider.ProviderId, venueName: "Venue 1");
+            await TestData.CreateVenue(provider.ProviderId, venueName: "Venue 2");
 
             var parentMptxInstance = MptxManager.CreateInstance(new ParentFlow());
             var childMptxInstance = MptxManager.CreateInstance<FlowModel, IFlowModelCallback>(
                 parentMptxInstance.InstanceId,
-                FlowModel.Add(providerId, cancelable: true),
+                FlowModel.Add(provider.ProviderId, cancelable: true),
                 new Dictionary<string, object>()
                 {
                     { "ReturnUrl", "callback" }
                 });
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             // Act
             var response = await HttpClient.GetAsync(
@@ -56,18 +56,18 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Apprenticeships
         public async Task Post_MissingVenueId_RendersErrorMessage()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(providerType: ProviderType.Apprenticeships);
+            var provider = await TestData.CreateProvider(providerType: ProviderType.Apprenticeships);
 
             var parentMptxInstance = MptxManager.CreateInstance(new ParentFlow());
             var childMptxInstance = MptxManager.CreateInstance<FlowModel, IFlowModelCallback>(
                 parentMptxInstance.InstanceId,
-                FlowModel.Add(providerId, cancelable: true),
+                FlowModel.Add(provider.ProviderId, cancelable: true),
                 new Dictionary<string, object>()
                 {
                     { "ReturnUrl", "callback" }
                 });
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             var requestContent = new FormUrlEncodedContentBuilder()
                 .Add("Radius", 15)
@@ -91,20 +91,20 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Apprenticeships
         public async Task Post_InvalidVenueId_RendersErrorMessage()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(providerType: ProviderType.Apprenticeships);
+            var provider = await TestData.CreateProvider(providerType: ProviderType.Apprenticeships);
 
             var invalidVenueId = Guid.NewGuid();
 
             var parentMptxInstance = MptxManager.CreateInstance(new ParentFlow());
             var childMptxInstance = MptxManager.CreateInstance<FlowModel, IFlowModelCallback>(
                 parentMptxInstance.InstanceId,
-                FlowModel.Add(providerId, cancelable: true),
+                FlowModel.Add(provider.ProviderId, cancelable: true),
                 new Dictionary<string, object>()
                 {
                     { "ReturnUrl", "callback" }
                 });
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             var requestContent = new FormUrlEncodedContentBuilder()
                 .Add("VenueId", invalidVenueId)
@@ -129,7 +129,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Apprenticeships
         public async Task Post_BlockedVenueId_RendersErrorMessage()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(providerType: ProviderType.Apprenticeships);
+            var provider = await TestData.CreateProvider(providerType: ProviderType.Apprenticeships);
 
             var venueId = Guid.NewGuid();
 
@@ -140,13 +140,13 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Apprenticeships
                 });
             var childMptxInstance = MptxManager.CreateInstance<FlowModel, IFlowModelCallback>(
                 parentMptxInstance.InstanceId,
-                FlowModel.Add(providerId, cancelable: true),
+                FlowModel.Add(provider.ProviderId, cancelable: true),
                 new Dictionary<string, object>()
                 {
                     { "ReturnUrl", "callback" }
                 });
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             var requestContent = new FormUrlEncodedContentBuilder()
                 .Add("VenueId", venueId)
@@ -171,20 +171,20 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Apprenticeships
         public async Task Post_NotNationalMissingRadius_RendersErrorMessage()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(providerType: ProviderType.Apprenticeships);
+            var provider = await TestData.CreateProvider(providerType: ProviderType.Apprenticeships);
 
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
             var parentMptxInstance = MptxManager.CreateInstance(new ParentFlow());
             var childMptxInstance = MptxManager.CreateInstance<FlowModel, IFlowModelCallback>(
                 parentMptxInstance.InstanceId,
-                FlowModel.Add(providerId, cancelable: true),
+                FlowModel.Add(provider.ProviderId, cancelable: true),
                 new Dictionary<string, object>()
                 {
                     { "ReturnUrl", "callback" }
                 });
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             var requestContent = new FormUrlEncodedContentBuilder()
                 .Add("VenueId", venueId)
@@ -208,20 +208,20 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Apprenticeships
         public async Task Post_MissingDeliveryModes_RendersErrorMessage()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(providerType: ProviderType.Apprenticeships);
+            var provider = await TestData.CreateProvider(providerType: ProviderType.Apprenticeships);
 
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
             var parentMptxInstance = MptxManager.CreateInstance(new ParentFlow());
             var childMptxInstance = MptxManager.CreateInstance<FlowModel, IFlowModelCallback>(
                 parentMptxInstance.InstanceId,
-                FlowModel.Add(providerId, cancelable: true),
+                FlowModel.Add(provider.ProviderId, cancelable: true),
                 new Dictionary<string, object>()
                 {
                     { "ReturnUrl", "callback" }
                 });
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             var requestContent = new FormUrlEncodedContentBuilder()
                 .Add("VenueId", venueId)
@@ -244,20 +244,20 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Apprenticeships
         public async Task Post_ValidRequest_UpdatesParentStateAndRedirects()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(providerType: ProviderType.Apprenticeships);
+            var provider = await TestData.CreateProvider(providerType: ProviderType.Apprenticeships);
 
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
             var parentMptxInstance = MptxManager.CreateInstance(new ParentFlow());
             var childMptxInstance = MptxManager.CreateInstance<FlowModel, IFlowModelCallback>(
                 parentMptxInstance.InstanceId,
-                FlowModel.Add(providerId, cancelable: true),
+                FlowModel.Add(provider.ProviderId, cancelable: true),
                 new Dictionary<string, object>()
                 {
                     { "ReturnUrl", "callback" }
                 });
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             var requestContent = new FormUrlEncodedContentBuilder()
                 .Add("VenueId", venueId)
@@ -285,20 +285,20 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Apprenticeships
         public async Task GetRemove_ModeNotEdit_ReturnsBadRequest()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(providerType: ProviderType.Apprenticeships);
+            var provider = await TestData.CreateProvider(providerType: ProviderType.Apprenticeships);
 
-            await TestData.CreateVenue(providerId, venueName: "The Venue");
+            await TestData.CreateVenue(provider.ProviderId, venueName: "The Venue");
 
             var parentMptxInstance = MptxManager.CreateInstance(new ParentFlow());
             var childMptxInstance = MptxManager.CreateInstance<FlowModel, IFlowModelCallback>(
                 parentMptxInstance.InstanceId,
-                FlowModel.Add(providerId, cancelable: true),
+                FlowModel.Add(provider.ProviderId, cancelable: true),
                 new Dictionary<string, object>()
                 {
                     { "ReturnUrl", "callback" }
                 });
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             // Act
             var response = await HttpClient.GetAsync(
@@ -312,15 +312,15 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Apprenticeships
         public async Task GetRemove_ValidRequest_ReturnsExpectedContent()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(providerType: ProviderType.Apprenticeships);
+            var provider = await TestData.CreateProvider(providerType: ProviderType.Apprenticeships);
 
-            var venueId = (await TestData.CreateVenue(providerId, venueName: "The Venue")).Id;
+            var venueId = (await TestData.CreateVenue(provider.ProviderId, venueName: "The Venue")).Id;
 
             var parentMptxInstance = MptxManager.CreateInstance(new ParentFlow());
             var childMptxInstance = MptxManager.CreateInstance<FlowModel, IFlowModelCallback>(
                 parentMptxInstance.InstanceId,
                 FlowModel.Edit(
-                    providerId,
+                    provider.ProviderId,
                     venueId,
                     radius: 5,
                     new[] { ApprenticeshipDeliveryMode.BlockRelease }),
@@ -329,7 +329,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Apprenticeships
                     { "ReturnUrl", "callback" }
                 });
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             // Act
             var response = await HttpClient.GetAsync(
@@ -346,18 +346,18 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Apprenticeships
         public async Task PostRemove_ModeNotEdit_ReturnsBadRequest()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(providerType: ProviderType.Apprenticeships);
+            var provider = await TestData.CreateProvider(providerType: ProviderType.Apprenticeships);
 
             var parentMptxInstance = MptxManager.CreateInstance(new ParentFlow());
             var childMptxInstance = MptxManager.CreateInstance<FlowModel, IFlowModelCallback>(
                 parentMptxInstance.InstanceId,
-                FlowModel.Add(providerId, cancelable: true),
+                FlowModel.Add(provider.ProviderId, cancelable: true),
                 new Dictionary<string, object>()
                 {
                     { "ReturnUrl", "callback" }
                 });
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             var requestContent = new FormUrlEncodedContentBuilder().ToContent();
 
@@ -374,15 +374,15 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Apprenticeships
         public async Task PostRemove_ValidRequest_UpdatesParentStateAndRedirects()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(providerType: ProviderType.Apprenticeships);
+            var provider = await TestData.CreateProvider(providerType: ProviderType.Apprenticeships);
 
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
             var parentMptxInstance = MptxManager.CreateInstance(new ParentFlow());
             var childMptxInstance = MptxManager.CreateInstance<FlowModel, IFlowModelCallback>(
                 parentMptxInstance.InstanceId,
                 FlowModel.Edit(
-                    providerId,
+                    provider.ProviderId,
                     venueId,
                     radius: 5,
                     new[] { ApprenticeshipDeliveryMode.BlockRelease }),
@@ -391,7 +391,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Apprenticeships
                     { "ReturnUrl", "callback" }
                 });
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             var requestContent = new FormUrlEncodedContentBuilder().ToContent();
 

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/Apprenticeships/FindStandardTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/Apprenticeships/FindStandardTests.cs
@@ -17,11 +17,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Apprenticeships
         public async Task Get_ProviderIsFEOnlyReturnsForbidden()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(providerType: ProviderType.FE);
+            var provider = await TestData.CreateProvider(providerType: ProviderType.FE);
 
             // Act
             var response = await HttpClient.GetAsync(
-                $"apprenticeships/find-standard?providerId={providerId}&returnUrl=%2Fcallback");
+                $"apprenticeships/find-standard?providerId={provider.ProviderId}&returnUrl=%2Fcallback");
 
             // Assert
             response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
@@ -31,11 +31,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Apprenticeships
         public async Task GetSearch_NotEnoughCharactersReturnsError()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(providerType: ProviderType.FE | ProviderType.Apprenticeships);
+            var provider = await TestData.CreateProvider(providerType: ProviderType.FE | ProviderType.Apprenticeships);
 
             // Act
             var response = await HttpClient.GetAsync(
-                $"apprenticeships/find-standard/search?providerId={providerId}&returnUrl=%2Fcallback&Search=h");
+                $"apprenticeships/find-standard/search?providerId={provider.ProviderId}&returnUrl=%2Fcallback&Search=h");
 
             // Assert
             response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
@@ -50,7 +50,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Apprenticeships
         public async Task GetSearch_RendersSearchResults()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(providerType: ProviderType.FE | ProviderType.Apprenticeships);
+            var provider = await TestData.CreateProvider(providerType: ProviderType.FE | ProviderType.Apprenticeships);
 
             await TestData.CreateStandard(standardCode: 123, version: 1, standardName: "Hairdressing");
             await TestData.CreateStandard(standardCode: 456, version: 2, standardName: "Hair");
@@ -60,7 +60,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Apprenticeships
 
             // Act
             var response = await HttpClient.GetAsync(
-                $"apprenticeships/find-standard/search?providerId={providerId}&returnUrl=%2Fcallback&Search=hair");
+                $"apprenticeships/find-standard/search?providerId={provider.ProviderId}&returnUrl=%2Fcallback&Search=hair");
 
             // Assert
             response.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -75,13 +75,13 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Apprenticeships
         public async Task GetSelect_ValidRequest_UpdatesParentStateAndRedirects()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(providerType: ProviderType.FE | ProviderType.Apprenticeships);
+            var provider = await TestData.CreateProvider(providerType: ProviderType.FE | ProviderType.Apprenticeships);
 
             await TestData.CreateStandard(standardCode: 456, version: 2, standardName: "Hair");
 
             // Act
             var response = await HttpClient.GetAsync(
-                $"apprenticeships/find-standard/search?providerId={providerId}&returnUrl=%2Fcallback&Search=hair");
+                $"apprenticeships/find-standard/search?providerId={provider.ProviderId}&returnUrl=%2Fcallback&Search=hair");
 
             // Assert
             response.EnsureSuccessStatusCode();

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/BulkUpload/BulkUploadTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/BulkUpload/BulkUploadTests.cs
@@ -2,14 +2,16 @@ using System.Net;
 using System.Threading.Tasks;
 using Dfc.CourseDirectory.Core.Models;
 using FluentAssertions;
-using Microsoft.AspNetCore.Mvc;
 using Xunit;
 
 namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.BulkUpload
 {
-    public class BulkUploadTests :MvcTestBase
+    public class BulkUploadTests : MvcTestBase
     {
-        public BulkUploadTests(CourseDirectoryApplicationFactory factory) : base(factory) { }
+        public BulkUploadTests(CourseDirectoryApplicationFactory factory)
+            : base(factory)
+        {
+        }
 
         [Theory]
         [InlineData(1,"1 course")]
@@ -17,12 +19,12 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.BulkUpload
         public async Task Get_PublishYourFile_RendersPendingCount(int courseCount, string expectedCourseCountText)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
-            await User.AsTestUser(TestUserType.ProviderUser, providerId);
-            var providerUser = await TestData.CreateUser(providerId: providerId);
+            var provider = await TestData.CreateProvider();
+            await User.AsTestUser(TestUserType.ProviderUser, provider.ProviderId);
+            var providerUser = await TestData.CreateUser(providerId: provider.ProviderId);
             for (var i = 0; i < courseCount; i++)
             {
-                await TestData.CreateCourse(providerId, createdBy: providerUser, courseStatus: CourseStatus.BulkUploadReadyToGoLive);
+                await TestData.CreateCourse(provider.ProviderId, createdBy: providerUser, courseStatus: CourseStatus.BulkUploadReadyToGoLive);
             }
 
             // Act

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/Cookies/DetailsTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/Cookies/DetailsTests.cs
@@ -19,8 +19,8 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Cookies
         public async Task Get_AuthenticatedUser_ReturnsOk(TestUserType userType)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
-            await User.AsTestUser(userType, providerId);
+            var provider = await TestData.CreateProvider();
+            await User.AsTestUser(userType, provider.ProviderId);
 
             // Act
             var response = await HttpClient.GetAsync("cookies/details");

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/DeleteCourseRunTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/DeleteCourseRunTests.cs
@@ -29,7 +29,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
         public async Task Get_CourseDoesNotExist_ReturnsNotFound()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
+            var provider = await TestData.CreateProvider();
             var courseId = Guid.NewGuid();
             var courseRunId = Guid.NewGuid();
 
@@ -37,7 +37,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
                 HttpMethod.Get,
                 $"/courses/{courseId}/course-runs/{courseRunId}/delete?returnUrl=%2Fcourses");
 
-            await User.AsProviderUser(providerId, ProviderType.FE);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.FE);
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -50,15 +50,15 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
         public async Task Get_CourseRunDoesNotExist_ReturnsNotFound()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
-            var courseId = await TestData.CreateCourse(providerId, createdBy: User.ToUserInfo());
+            var provider = await TestData.CreateProvider();
+            var courseId = await TestData.CreateCourse(provider.ProviderId, createdBy: User.ToUserInfo());
             var courseRunId = Guid.NewGuid();
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
                 $"/courses/{courseId}/course-runs/{courseRunId}/delete?returnUrl=%2Fcourses");
 
-            await User.AsProviderUser(providerId, ProviderType.FE);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.FE);
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -73,17 +73,17 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
         public async Task Get_UserCannotAccessCourse_ReturnsForbidden(TestUserType userType)
         {
             // Arrange
-            var anotherProviderId = await TestData.CreateProvider(ukprn: 23456);
+            var anotherProvider = await TestData.CreateProvider();
 
-            var providerId = await TestData.CreateProvider(ukprn: 12345);
-            var courseId = await TestData.CreateCourse(providerId, createdBy: User.ToUserInfo());
+            var provider = await TestData.CreateProvider();
+            var courseId = await TestData.CreateCourse(provider.ProviderId, createdBy: User.ToUserInfo());
             var courseRunId = Guid.NewGuid();
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
                 $"/courses/{courseId}/course-runs/{courseRunId}/delete?returnUrl=%2Fcourses");
 
-            await User.AsTestUser(userType, anotherProviderId);
+            await User.AsTestUser(userType, anotherProvider.ProviderId);
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -96,10 +96,10 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
         public async Task Get_ValidRequest_RendersExpectedOutput()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
+            var provider = await TestData.CreateProvider();
 
             var courseId = await TestData.CreateCourse(
-                providerId,
+                provider.ProviderId,
                 qualificationCourseTitle: "Maths",
                 createdBy: User.ToUserInfo());
 
@@ -109,7 +109,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
                 HttpMethod.Get,
                 $"/courses/{courseId}/course-runs/{courseRunId}/delete?returnUrl=%2Fcourses");
 
-            await User.AsProviderUser(providerId, ProviderType.FE);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.FE);
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -125,12 +125,12 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
         public async Task Get_ValidRequestCourseRunWithVenue_RendersLocationRow()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
+            var provider = await TestData.CreateProvider();
 
-            var venueId = (await TestData.CreateVenue(providerId, venueName: "Test Venue")).Id;
+            var venueId = (await TestData.CreateVenue(provider.ProviderId, venueName: "Test Venue")).Id;
 
             var courseId = await TestData.CreateCourse(
-                providerId,
+                provider.ProviderId,
                 qualificationCourseTitle: "Maths",
                 createdBy: User.ToUserInfo(),
                 configureCourseRuns: b => b.WithCourseRun(
@@ -145,7 +145,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
                 HttpMethod.Get,
                 $"/courses/{courseId}/course-runs/{courseRunId}/delete?returnUrl=%2Fcourses");
 
-            await User.AsProviderUser(providerId, ProviderType.FE);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.FE);
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -161,12 +161,12 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
         public async Task Get_ValidRequestCourseRunWithNoVenue_DoesNotRenderLocationRow()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
+            var provider = await TestData.CreateProvider();
 
-            await TestData.CreateVenue(providerId, venueName: "Test Venue");
+            await TestData.CreateVenue(provider.ProviderId, venueName: "Test Venue");
 
             var courseId = await TestData.CreateCourse(
-                providerId,
+                provider.ProviderId,
                 qualificationCourseTitle: "Maths",
                 createdBy: User.ToUserInfo(),
                 configureCourseRuns: b => b.WithCourseRun(
@@ -182,7 +182,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
                 HttpMethod.Get,
                 $"/courses/{courseId}/course-runs/{courseRunId}/delete?returnUrl=%2Fcourses");
 
-            await User.AsProviderUser(providerId, ProviderType.FE);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.FE);
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -198,12 +198,12 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
         public async Task Get_ValidRequestCourseRunWithProviderCourseId_RendersYourReferenceRow()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
+            var provider = await TestData.CreateProvider();
 
-            await TestData.CreateVenue(providerId, venueName: "Test Venue");
+            await TestData.CreateVenue(provider.ProviderId, venueName: "Test Venue");
 
             var courseId = await TestData.CreateCourse(
-                providerId,
+                provider.ProviderId,
                 qualificationCourseTitle: "Maths",
                 createdBy: User.ToUserInfo(),
                 configureCourseRuns: b => b.WithCourseRun(
@@ -219,7 +219,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
                 HttpMethod.Get,
                 $"/courses/{courseId}/course-runs/{courseRunId}/delete?returnUrl=%2Fcourses");
 
-            await User.AsProviderUser(providerId, ProviderType.FE);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.FE);
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -235,12 +235,12 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
         public async Task Get_ValidRequestCourseRunWithNoProviderCourseId_DoesNotRenderYourReferenceRow()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
+            var provider = await TestData.CreateProvider();
 
-            await TestData.CreateVenue(providerId, venueName: "Test Venue");
+            await TestData.CreateVenue(provider.ProviderId, venueName: "Test Venue");
 
             var courseId = await TestData.CreateCourse(
-                providerId,
+                provider.ProviderId,
                 qualificationCourseTitle: "Maths",
                 createdBy: User.ToUserInfo(),
                 configureCourseRuns: b => b.WithCourseRun(
@@ -256,7 +256,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
                 HttpMethod.Get,
                 $"/courses/{courseId}/course-runs/{courseRunId}/delete?returnUrl=%2Fcourses");
 
-            await User.AsProviderUser(providerId, ProviderType.FE);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.FE);
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -272,12 +272,12 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
         public async Task Get_ValidRequestCourseRunWithFlexibleStartDate_RendersFlexibleStartDateRow()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
+            var provider = await TestData.CreateProvider();
 
-            await TestData.CreateVenue(providerId, venueName: "Test Venue");
+            await TestData.CreateVenue(provider.ProviderId, venueName: "Test Venue");
 
             var courseId = await TestData.CreateCourse(
-                providerId,
+                provider.ProviderId,
                 qualificationCourseTitle: "Maths",
                 createdBy: User.ToUserInfo(),
                 configureCourseRuns: b => b.WithCourseRun(
@@ -293,7 +293,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
                 HttpMethod.Get,
                 $"/courses/{courseId}/course-runs/{courseRunId}/delete?returnUrl=%2Fcourses");
 
-            await User.AsProviderUser(providerId, ProviderType.FE);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.FE);
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -309,12 +309,12 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
         public async Task Get_ValidRequestCourseRunWithSpecificStartDate_RendersStartDateRow()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
+            var provider = await TestData.CreateProvider();
 
-            await TestData.CreateVenue(providerId, venueName: "Test Venue");
+            await TestData.CreateVenue(provider.ProviderId, venueName: "Test Venue");
 
             var courseId = await TestData.CreateCourse(
-                providerId,
+                provider.ProviderId,
                 qualificationCourseTitle: "Maths",
                 createdBy: User.ToUserInfo(),
                 configureCourseRuns: b => b.WithCourseRun(
@@ -330,7 +330,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
                 HttpMethod.Get,
                 $"/courses/{courseId}/course-runs/{courseRunId}/delete?returnUrl=%2Fcourses");
 
-            await User.AsProviderUser(providerId, ProviderType.FE);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.FE);
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -346,8 +346,8 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
         public async Task Get_ValidRequest_RendersCancelLinkFromReturnUrlQueryParameter()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
-            var courseId = await TestData.CreateCourse(providerId, createdBy: User.ToUserInfo());
+            var provider = await TestData.CreateProvider();
+            var courseId = await TestData.CreateCourse(provider.ProviderId, createdBy: User.ToUserInfo());
             var courseRunId = await GetCourseRunIdForCourse(courseId);
 
             var returnUrl = "/courses";
@@ -356,7 +356,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
                 HttpMethod.Get,
                 $"/courses/{courseId}/course-runs/{courseRunId}/delete?returnUrl={UrlEncoder.Default.Encode(returnUrl)}");
 
-            await User.AsProviderUser(providerId, ProviderType.FE);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.FE);
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -372,7 +372,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
         public async Task Post_CourseDoesNotExist_ReturnsNotFound()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
+            var provider = await TestData.CreateProvider();
             var courseId = Guid.NewGuid();
             var courseRunId = Guid.NewGuid();
 
@@ -387,7 +387,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
                 Content = requestContent
             };
 
-            await User.AsProviderUser(providerId, ProviderType.FE);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.FE);
 
             CreateJourneyInstance(courseId, courseRunId);
 
@@ -402,8 +402,8 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
         public async Task Post_CourseRunDoesNotExist_ReturnsNotFound()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
-            var courseId = await TestData.CreateCourse(providerId, createdBy: User.ToUserInfo());
+            var provider = await TestData.CreateProvider();
+            var courseId = await TestData.CreateCourse(provider.ProviderId, createdBy: User.ToUserInfo());
             var courseRunId = Guid.NewGuid();
 
             var requestContent = new FormUrlEncodedContentBuilder()
@@ -417,7 +417,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
                 Content = requestContent
             };
 
-            await User.AsProviderUser(providerId, ProviderType.FE);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.FE);
 
             CreateJourneyInstance(courseId, courseRunId);
 
@@ -434,10 +434,10 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
         public async Task Post_UserCannotAccessCourse_ReturnsForbidden(TestUserType userType)
         {
             // Arrange
-            var anotherProviderId = await TestData.CreateProvider(ukprn: 23456);
+            var anotherProvider = await TestData.CreateProvider();
 
-            var providerId = await TestData.CreateProvider(ukprn: 12345);
-            var courseId = await TestData.CreateCourse(providerId, createdBy: User.ToUserInfo());
+            var provider = await TestData.CreateProvider();
+            var courseId = await TestData.CreateCourse(provider.ProviderId, createdBy: User.ToUserInfo());
             var courseRunId = await GetCourseRunIdForCourse(courseId);
 
             var requestContent = new FormUrlEncodedContentBuilder()
@@ -451,7 +451,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
                 Content = requestContent
             };
 
-            await User.AsTestUser(userType, anotherProviderId);
+            await User.AsTestUser(userType, anotherProvider.ProviderId);
 
             CreateJourneyInstance(courseId, courseRunId);
 
@@ -466,8 +466,8 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
         public async Task Post_NotConfirmed_ReturnsError()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
-            var courseId = await TestData.CreateCourse(providerId, createdBy: User.ToUserInfo());
+            var provider = await TestData.CreateProvider();
+            var courseId = await TestData.CreateCourse(provider.ProviderId, createdBy: User.ToUserInfo());
             var courseRunId = await GetCourseRunIdForCourse(courseId);
 
             var requestContent = new FormUrlEncodedContentBuilder()
@@ -480,7 +480,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
                 Content = requestContent
             };
 
-            await User.AsProviderUser(providerId, ProviderType.FE);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.FE);
 
             CreateJourneyInstance(courseId, courseRunId);
 
@@ -496,11 +496,10 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
         public async Task Post_ValidRequest_DeletesCourseRunAndRedirects()
         {
             // Arrange
-            const int ukprn = 12345;
-            var providerId = await TestData.CreateProvider(ukprn: ukprn);
+            var provider = await TestData.CreateProvider();
 
             var courseId = await TestData.CreateCourse(
-                providerId,
+                provider.ProviderId,
                 qualificationCourseTitle: "Maths",
                 createdBy: User.ToUserInfo());
 
@@ -517,7 +516,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
                 Content = requestContent
             };
 
-            await User.AsProviderUser(providerId, ProviderType.FE);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.FE);
 
             CreateJourneyInstance(courseId, courseRunId);
 
@@ -540,7 +539,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
                 capturedDeleteCourseRunQuery.Should().NotBeNull();
                 capturedDeleteCourseRunQuery.CourseId.Should().Be(courseId);
                 capturedDeleteCourseRunQuery.CourseRunId.Should().Be(courseRunId);
-                capturedDeleteCourseRunQuery.ProviderUkprn.Should().Be(ukprn);
+                capturedDeleteCourseRunQuery.ProviderUkprn.Should().Be(provider.Ukprn);
                 capturedDeleteCourseRunQuery.UpdatedBy.Should().Be(TestUserInfo.DefaultUserId);
                 capturedDeleteCourseRunQuery.UpdatedDate.Should().Be(MutableClock.Start);
             }
@@ -550,11 +549,10 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
         public async Task GetConfirmed_RendersExpectedCourseName()
         {
             // Arrange
-            var providerUkprn = 12345;
-            var providerId = await TestData.CreateProvider(ukprn: providerUkprn);
+            var provider = await TestData.CreateProvider();
 
             var courseId = await TestData.CreateCourse(
-                providerId,
+                provider.ProviderId,
                 qualificationCourseTitle: "Maths",
                 createdBy: User.ToUserInfo());
 
@@ -564,14 +562,14 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
             {
                 CourseId = courseId,
                 CourseRunId = courseRunId,
-                ProviderUkprn = providerUkprn
+                ProviderUkprn = provider.Ukprn
             });
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
                 $"/courses/{courseId}/course-runs/{courseRunId}/delete/confirmed");
 
-            await User.AsProviderUser(providerId, ProviderType.FE);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.FE);
 
             CreateJourneyInstance(
                 courseId,
@@ -579,8 +577,8 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
                 new JourneyModel()
                 {
                     CourseName = "Maths",
-                    ProviderId = providerId,
-                    ProviderUkprn = providerUkprn
+                    ProviderId = provider.ProviderId,
+                    ProviderUkprn = provider.Ukprn
                 });
 
             // Act
@@ -597,11 +595,10 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
         public async Task GetConfirmed_NoOtherLiveCourseRuns_DoesNotRenderViewEditCopyLink()
         {
             // Arrange
-            var providerUkprn = 12345;
-            var providerId = await TestData.CreateProvider(ukprn: providerUkprn);
+            var provider = await TestData.CreateProvider();
 
             var courseId = await TestData.CreateCourse(
-                providerId,
+                provider.ProviderId,
                 qualificationCourseTitle: "Maths",
                 createdBy: User.ToUserInfo());
 
@@ -611,14 +608,14 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
             {
                 CourseId = courseId,
                 CourseRunId = courseRunId,
-                ProviderUkprn = providerUkprn
+                ProviderUkprn = provider.Ukprn
             });
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
                 $"/courses/{courseId}/course-runs/{courseRunId}/delete/confirmed");
 
-            await User.AsProviderUser(providerId, ProviderType.FE);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.FE);
 
             CreateJourneyInstance(
                 courseId,
@@ -626,8 +623,8 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
                 new JourneyModel()
                 {
                     CourseName = "Maths",
-                    ProviderId = providerId,
-                    ProviderUkprn = providerUkprn
+                    ProviderId = provider.ProviderId,
+                    ProviderUkprn = provider.Ukprn
                 });
 
             // Act
@@ -644,31 +641,30 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
         public async Task GetConfirmed_HasOtherLiveCourseRuns_DoesRenderViewEditCopyLink()
         {
             // Arrange
-            var providerUkprn = 12345;
-            var providerId = await TestData.CreateProvider(ukprn: providerUkprn);
+            var provider = await TestData.CreateProvider();
 
             var courseId = await TestData.CreateCourse(
-                providerId,
+                provider.ProviderId,
                 qualificationCourseTitle: "Maths",
                 createdBy: User.ToUserInfo());
 
             var courseRunId = await GetCourseRunIdForCourse(courseId);
 
             // Create another live course
-            await TestData.CreateCourse(providerId, createdBy: User.ToUserInfo());
+            await TestData.CreateCourse(provider.ProviderId, createdBy: User.ToUserInfo());
 
             await CosmosDbQueryDispatcher.Object.ExecuteQuery(new DeleteCourseRunQuery()
             {
                 CourseId = courseId,
                 CourseRunId = courseRunId,
-                ProviderUkprn = providerUkprn
+                ProviderUkprn = provider.Ukprn
             });
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
                 $"/courses/{courseId}/course-runs/{courseRunId}/delete/confirmed");
 
-            await User.AsProviderUser(providerId, ProviderType.FE);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.FE);
 
             CreateJourneyInstance(
                 courseId,
@@ -676,8 +672,8 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
                 new JourneyModel()
                 {
                     CourseName = "Maths",
-                    ProviderId = providerId,
-                    ProviderUkprn = providerUkprn
+                    ProviderId = provider.ProviderId,
+                    ProviderUkprn = provider.Ukprn
                 });
 
             // Act

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/HelpdeskDashboard/DashboardTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/HelpdeskDashboard/DashboardTests.cs
@@ -18,8 +18,8 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.HelpdeskDashboard
         public async Task Get_ProviderUserCannotAccess(TestUserType userType)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
-            await User.AsTestUser(userType, providerId);
+            var provider = await TestData.CreateProvider();
+            await User.AsTestUser(userType, provider.ProviderId);
 
             // Act
             var response = await HttpClient.GetAsync("helpdesk-dashboard");

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/Home/IndexTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/Home/IndexTests.cs
@@ -56,9 +56,9 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Home
         public async Task ProviderUser_RedirectsToProviderDashboard(TestUserType userType)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
+            var provider = await TestData.CreateProvider();
 
-            await User.AsTestUser(userType, providerId);
+            await User.AsTestUser(userType, provider.ProviderId);
 
             var request = new HttpRequestMessage(HttpMethod.Get, "/");
 

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/NewApprenticeshipProvider/ApprenticeshipDetailsTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/NewApprenticeshipProvider/ApprenticeshipDetailsTests.cs
@@ -18,7 +18,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Get_HelpdeskUserCannotAccess()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
 
             var standard = await TestData.CreateStandard(standardCode: 123, version: 1, standardName: "My standard");
 
@@ -30,7 +30,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.GetAsync(
-                $"new-apprenticeship-provider/apprenticeship-details?providerId={providerId}&ffiid={mptxInstance.InstanceId}");
+                $"new-apprenticeship-provider/apprenticeship-details?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}");
 
             // Act
             Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
@@ -44,11 +44,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Get_QAStatusNotValidReturnsBadRequest(ApprenticeshipQAStatus qaStatus)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: qaStatus);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: qaStatus);
 
             var standard = await TestData.CreateStandard(standardCode: 123, version: 1, standardName: "My standard");
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             var flowModel = new FlowModel();
             flowModel.SetApprenticeshipStandardOrFramework(standard);
@@ -56,7 +56,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.GetAsync(
-                $"new-apprenticeship-provider/apprenticeship-details?providerId={providerId}&ffiid={mptxInstance.InstanceId}");
+                $"new-apprenticeship-provider/apprenticeship-details?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}");
 
             // Act
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -66,13 +66,13 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Get_NotApprenticeshipProviderReturnsForbidden()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.FE,
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
 
             var standard = await TestData.CreateStandard(standardCode: 123, version: 1, standardName: "My standard");
 
-            await User.AsProviderUser(providerId, ProviderType.FE);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.FE);
 
             var flowModel = new FlowModel();
             flowModel.SetApprenticeshipStandardOrFramework(standard);
@@ -80,7 +80,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.GetAsync(
-                $"new-apprenticeship-provider/apprenticeship-details?providerId={providerId}&ffiid={mptxInstance.InstanceId}");
+                $"new-apprenticeship-provider/apprenticeship-details?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}");
 
             // Act
             Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
@@ -90,11 +90,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Get_RendersExpectedOutput()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
 
             var standard = await TestData.CreateStandard(standardCode: 123, version: 1, standardName: "My standard");
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             var flowModel = new FlowModel();
             flowModel.SetApprenticeshipStandardOrFramework(standard);
@@ -102,7 +102,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.GetAsync(
-                $"new-apprenticeship-provider/apprenticeship-details?providerId={providerId}&ffiid={mptxInstance.InstanceId}");
+                $"new-apprenticeship-provider/apprenticeship-details?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}");
 
             // Act
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -117,7 +117,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Post_HelpdeskUserCannotAccess()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
 
             var standard = await TestData.CreateStandard(standardCode: 123, version: 1, standardName: "My standard");
 
@@ -135,7 +135,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.PostAsync(
-                $"new-apprenticeship-provider/apprenticeship-details?providerId={providerId}&ffiid={mptxInstance.InstanceId}",
+                $"new-apprenticeship-provider/apprenticeship-details?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}",
                 requestContent);
 
             // Act
@@ -150,11 +150,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Post_QAStatusNotValidReturnsBadRequest(ApprenticeshipQAStatus qaStatus)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: qaStatus);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: qaStatus);
 
             var standard = await TestData.CreateStandard(standardCode: 123, version: 1, standardName: "My standard");
 
-            await User.AsProviderUser(providerId, ProviderType.FE);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.FE);
 
             var flowModel = new FlowModel();
             flowModel.SetApprenticeshipStandardOrFramework(standard);
@@ -168,7 +168,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.PostAsync(
-                $"new-apprenticeship-provider/apprenticeship-details?providerId={providerId}&ffiid={mptxInstance.InstanceId}",
+                $"new-apprenticeship-provider/apprenticeship-details?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}",
                 requestContent);
 
             // Act
@@ -179,13 +179,13 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Post_NotApprenticeshipProviderReturnsForbidden()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.FE,
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
 
             var standard = await TestData.CreateStandard(standardCode: 123, version: 1, standardName: "My standard");
 
-            await User.AsProviderUser(providerId, ProviderType.FE);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.FE);
 
             var flowModel = new FlowModel();
             flowModel.SetApprenticeshipStandardOrFramework(standard);
@@ -199,7 +199,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.PostAsync(
-                $"new-apprenticeship-provider/apprenticeship-details?providerId={providerId}&ffiid={mptxInstance.InstanceId}",
+                $"new-apprenticeship-provider/apprenticeship-details?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}",
                 requestContent);
 
             // Act
@@ -211,11 +211,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Post_InvalidMarketingInformationRendersError(string marketingInfo)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
 
             var standard = await TestData.CreateStandard(standardCode: 123, version: 1, standardName: "My standard");
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             var flowModel = new FlowModel();
             flowModel.SetApprenticeshipStandardOrFramework(standard);
@@ -229,7 +229,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.PostAsync(
-                $"new-apprenticeship-provider/apprenticeship-details?providerId={providerId}&ffiid={mptxInstance.InstanceId}",
+                $"new-apprenticeship-provider/apprenticeship-details?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}",
                 requestContent);
 
             // Act
@@ -246,11 +246,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Post_InvalidWebsiteRendersError(string website)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
 
             var standard = await TestData.CreateStandard(standardCode: 123, version: 1, standardName: "My standard");
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             var flowModel = new FlowModel();
             flowModel.SetApprenticeshipStandardOrFramework(standard);
@@ -265,7 +265,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.PostAsync(
-                $"new-apprenticeship-provider/apprenticeship-details?providerId={providerId}&ffiid={mptxInstance.InstanceId}",
+                $"new-apprenticeship-provider/apprenticeship-details?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}",
                 requestContent);
 
             // Act
@@ -285,11 +285,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
             string expectedErrorMessage)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
 
             var standard = await TestData.CreateStandard(standardCode: 123, version: 1, standardName: "My standard");
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             var flowModel = new FlowModel();
             flowModel.SetApprenticeshipStandardOrFramework(standard);
@@ -303,7 +303,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.PostAsync(
-                $"new-apprenticeship-provider/apprenticeship-details?providerId={providerId}&ffiid={mptxInstance.InstanceId}",
+                $"new-apprenticeship-provider/apprenticeship-details?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}",
                 requestContent);
 
             // Act
@@ -321,11 +321,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
             string expectedErrorMessage)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
 
             var standard = await TestData.CreateStandard(standardCode: 123, version: 1, standardName: "My standard");
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             var flowModel = new FlowModel();
             flowModel.SetApprenticeshipStandardOrFramework(standard);
@@ -339,7 +339,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.PostAsync(
-                $"new-apprenticeship-provider/apprenticeship-details?providerId={providerId}&ffiid={mptxInstance.InstanceId}",
+                $"new-apprenticeship-provider/apprenticeship-details?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}",
                 requestContent);
 
             // Act
@@ -354,11 +354,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Post_InvalidContactWebsiteRendersError(string contactWebsite)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
 
             var standard = await TestData.CreateStandard(standardCode: 123, version: 1, standardName: "My standard");
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             var flowModel = new FlowModel();
             flowModel.SetApprenticeshipStandardOrFramework(standard);
@@ -373,7 +373,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.PostAsync(
-                $"new-apprenticeship-provider/apprenticeship-details?providerId={providerId}&ffiid={mptxInstance.InstanceId}",
+                $"new-apprenticeship-provider/apprenticeship-details?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}",
                 requestContent);
 
             // Act
@@ -389,11 +389,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Post_ValidRequestRedirects()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
 
             var standard = await TestData.CreateStandard(standardCode: 123, version: 1, standardName: "My standard");
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             var flowModel = new FlowModel();
             flowModel.SetApprenticeshipStandardOrFramework(standard);
@@ -407,7 +407,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.PostAsync(
-                $"new-apprenticeship-provider/apprenticeship-details?providerId={providerId}&ffiid={mptxInstance.InstanceId}",
+                $"new-apprenticeship-provider/apprenticeship-details?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}",
                 requestContent);
 
             // Act

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/NewApprenticeshipProvider/ApprenticeshipEmployerLocationsRegionsTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/NewApprenticeshipProvider/ApprenticeshipEmployerLocationsRegionsTests.cs
@@ -20,7 +20,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Get_HelpdeskUserCannotAccess()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
 
             await User.AsHelpdesk();
 
@@ -31,7 +31,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.GetAsync(
-                $"new-apprenticeship-provider/apprenticeship-employer-locations-regions?providerId={providerId}&ffiid={mptxInstance.InstanceId}");
+                $"new-apprenticeship-provider/apprenticeship-employer-locations-regions?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}");
 
             // Assert
             Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
@@ -45,9 +45,9 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Get_QAStatusNotValidReturnsBadRequest(ApprenticeshipQAStatus qaStatus)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: qaStatus);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: qaStatus);
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             var flowModel = new FlowModel();
             flowModel.SetApprenticeshipLocationType(ApprenticeshipLocationType.EmployerBased);
@@ -56,7 +56,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.GetAsync(
-                $"new-apprenticeship-provider/apprenticeship-employer-locations-regions?providerId={providerId}&ffiid={mptxInstance.InstanceId}");
+                $"new-apprenticeship-provider/apprenticeship-employer-locations-regions?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}");
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -66,11 +66,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Get_NotApprenticeshipProviderReturnsForbidden()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted,
                 providerType: ProviderType.FE);
 
-            await User.AsProviderUser(providerId, ProviderType.FE);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.FE);
 
             var flowModel = new FlowModel();
             flowModel.SetApprenticeshipLocationType(ApprenticeshipLocationType.EmployerBased);
@@ -79,7 +79,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.GetAsync(
-                $"new-apprenticeship-provider/apprenticeship-employer-locations-regions?providerId={providerId}&ffiid={mptxInstance.InstanceId}");
+                $"new-apprenticeship-provider/apprenticeship-employer-locations-regions?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}");
 
             // Assert
             Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
@@ -89,9 +89,9 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Get_NoPersistedStateRendersExpectedOutput()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             var flowModel = new FlowModel();
             flowModel.SetApprenticeshipLocationType(ApprenticeshipLocationType.EmployerBased);
@@ -100,7 +100,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.GetAsync(
-                $"new-apprenticeship-provider/apprenticeship-employer-locations-regions?providerId={providerId}&ffiid={mptxInstance.InstanceId}");
+                $"new-apprenticeship-provider/apprenticeship-employer-locations-regions?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}");
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -114,9 +114,9 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Get_PersistedStateRendersExpectedOutput()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             var flowModel = new FlowModel();
             flowModel.SetApprenticeshipLocationType(ApprenticeshipLocationType.EmployerBased);
@@ -126,7 +126,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.GetAsync(
-                $"new-apprenticeship-provider/apprenticeship-employer-locations-regions?providerId={providerId}&ffiid={mptxInstance.InstanceId}");
+                $"new-apprenticeship-provider/apprenticeship-employer-locations-regions?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}");
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -146,7 +146,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Post_HelpdeskUserCannotAccess()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
 
             await User.AsHelpdesk();
 
@@ -166,7 +166,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.PostAsync(
-                $"new-apprenticeship-provider/apprenticeship-employer-locations-regions?providerId={providerId}&ffiid={mptxInstance.InstanceId}",
+                $"new-apprenticeship-provider/apprenticeship-employer-locations-regions?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}",
                 requestContent);
 
             // Assert
@@ -181,9 +181,9 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Post_QAStatusNotValidReturnsBadRequest(ApprenticeshipQAStatus qaStatus)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: qaStatus);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: qaStatus);
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             var flowModel = new FlowModel();
             flowModel.SetApprenticeshipLocationType(ApprenticeshipLocationType.EmployerBased);
@@ -201,7 +201,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.PostAsync(
-                $"new-apprenticeship-provider/apprenticeship-employer-locations-regions?providerId={providerId}&ffiid={mptxInstance.InstanceId}",
+                $"new-apprenticeship-provider/apprenticeship-employer-locations-regions?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}",
                 requestContent);
 
             // Assert
@@ -212,11 +212,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Post_NotApprenticeshipProviderReturnsForbidden()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted,
                 providerType: ProviderType.FE);
 
-            await User.AsProviderUser(providerId, ProviderType.FE);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.FE);
 
             var flowModel = new FlowModel();
             flowModel.SetApprenticeshipLocationType(ApprenticeshipLocationType.EmployerBased);
@@ -234,7 +234,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.PostAsync(
-                $"new-apprenticeship-provider/apprenticeship-employer-locations-regions?providerId={providerId}&ffiid={mptxInstance.InstanceId}",
+                $"new-apprenticeship-provider/apprenticeship-employer-locations-regions?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}",
                 requestContent);
 
             // Assert
@@ -245,9 +245,9 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Post_NoRegionSelectedRendersError()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             var flowModel = new FlowModel();
             flowModel.SetApprenticeshipLocationType(ApprenticeshipLocationType.EmployerBased);
@@ -259,7 +259,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.PostAsync(
-                $"new-apprenticeship-provider/apprenticeship-employer-locations-regions?providerId={providerId}&ffiid={mptxInstance.InstanceId}",
+                $"new-apprenticeship-provider/apprenticeship-employer-locations-regions?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}",
                 requestContent);
 
             // Assert
@@ -276,9 +276,9 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Post_InvalidRegionIdRendersError()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             var flowModel = new FlowModel();
             flowModel.SetApprenticeshipLocationType(ApprenticeshipLocationType.EmployerBased);
@@ -291,7 +291,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.PostAsync(
-                $"new-apprenticeship-provider/apprenticeship-employer-locations-regions?providerId={providerId}&ffiid={mptxInstance.InstanceId}",
+                $"new-apprenticeship-provider/apprenticeship-employer-locations-regions?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}",
                 requestContent);
 
             // Assert
@@ -314,9 +314,9 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
             string expectedRedirectLocation)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             var flowModel = new FlowModel();
             flowModel.SetApprenticeshipLocationType(locationType);
@@ -325,7 +325,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             if (gotClassroomLocation)
             {
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
                 mptxInstance.Update(s => s.SetClassroomLocationForVenue(
                     venueId,
@@ -344,7 +344,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.PostAsync(
-                $"new-apprenticeship-provider/apprenticeship-employer-locations-regions?providerId={providerId}&ffiid={mptxInstance.InstanceId}",
+                $"new-apprenticeship-provider/apprenticeship-employer-locations-regions?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}",
                 requestContent);
 
             // Assert
@@ -361,9 +361,9 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Post_RegionIdSpecifiedStoresExpandedSubRegionsInState()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             var flowModel = new FlowModel();
             flowModel.SetApprenticeshipLocationType(ApprenticeshipLocationType.EmployerBased);
@@ -376,7 +376,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.PostAsync(
-                $"new-apprenticeship-provider/apprenticeship-employer-locations-regions?providerId={providerId}&ffiid={mptxInstance.InstanceId}",
+                $"new-apprenticeship-provider/apprenticeship-employer-locations-regions?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}",
                 requestContent);
 
             // Assert

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/NewApprenticeshipProvider/ApprenticeshipEmployerLocationsTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/NewApprenticeshipProvider/ApprenticeshipEmployerLocationsTests.cs
@@ -18,7 +18,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Get_HelpdeskUserCannotAccess()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
 
             await User.AsHelpdesk();
 
@@ -28,7 +28,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.GetAsync(
-                $"new-apprenticeship-provider/apprenticeship-employer-locations?providerId={providerId}&ffiid={mptxInstance.InstanceId}");
+                $"new-apprenticeship-provider/apprenticeship-employer-locations?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}");
 
             // Assert
             Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
@@ -42,9 +42,9 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Get_QAStatusNotValidReturnsBadRequest(ApprenticeshipQAStatus qaStatus)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: qaStatus);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: qaStatus);
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             var flowModel = new FlowModel();
             flowModel.SetApprenticeshipLocationType(ApprenticeshipLocationType.EmployerBased);
@@ -52,7 +52,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.GetAsync(
-                $"new-apprenticeship-provider/apprenticeship-employer-locations?providerId={providerId}&ffiid={mptxInstance.InstanceId}");
+                $"new-apprenticeship-provider/apprenticeship-employer-locations?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}");
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -62,11 +62,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Get_NotApprenticeshipProviderReturnsForbidden()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted,
                 providerType: ProviderType.FE);
 
-            await User.AsProviderUser(providerId, ProviderType.FE);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.FE);
 
             var flowModel = new FlowModel();
             flowModel.SetApprenticeshipLocationType(ApprenticeshipLocationType.EmployerBased);
@@ -74,7 +74,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.GetAsync(
-                $"new-apprenticeship-provider/apprenticeship-employer-locations?providerId={providerId}&ffiid={mptxInstance.InstanceId}");
+                $"new-apprenticeship-provider/apprenticeship-employer-locations?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}");
 
             // Assert
             Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
@@ -84,9 +84,9 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Get_NoPersistedStateRendersExpectedOutput()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             var flowModel = new FlowModel();
             flowModel.SetApprenticeshipLocationType(ApprenticeshipLocationType.EmployerBased);
@@ -94,7 +94,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.GetAsync(
-                $"new-apprenticeship-provider/apprenticeship-employer-locations?providerId={providerId}&ffiid={mptxInstance.InstanceId}");
+                $"new-apprenticeship-provider/apprenticeship-employer-locations?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}");
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -108,9 +108,9 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Get_PersistedStateRendersExpectedOutput()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             var flowModel = new FlowModel();
             flowModel.SetApprenticeshipLocationType(ApprenticeshipLocationType.EmployerBased);
@@ -119,7 +119,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.GetAsync(
-                $"new-apprenticeship-provider/apprenticeship-employer-locations?providerId={providerId}&ffiid={mptxInstance.InstanceId}");
+                $"new-apprenticeship-provider/apprenticeship-employer-locations?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}");
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -133,7 +133,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Post_HelpdeskUserCannotAccess()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
 
             await User.AsHelpdesk();
 
@@ -146,7 +146,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.PostAsync(
-                $"new-apprenticeship-provider/apprenticeship-employer-locations?providerId={providerId}&ffiid={mptxInstance.InstanceId}",
+                $"new-apprenticeship-provider/apprenticeship-employer-locations?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}",
                 requestContent);
 
             // Assert
@@ -162,9 +162,9 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Post_QAStatusNotValidReturnsBadRequest(ApprenticeshipQAStatus qaStatus)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: qaStatus);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: qaStatus);
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             var flowModel = new FlowModel();
             flowModel.SetApprenticeshipLocationType(ApprenticeshipLocationType.EmployerBased);
@@ -175,7 +175,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.PostAsync(
-                $"new-apprenticeship-provider/apprenticeship-employer-locations?providerId={providerId}&ffiid={mptxInstance.InstanceId}",
+                $"new-apprenticeship-provider/apprenticeship-employer-locations?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}",
                 requestContent);
 
             // Assert
@@ -186,11 +186,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Post_NotApprenticeshipProviderReturnsForbidden()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted,
                 providerType: ProviderType.FE);
 
-            await User.AsProviderUser(providerId, ProviderType.FE);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.FE);
 
             var flowModel = new FlowModel();
             flowModel.SetApprenticeshipLocationType(ApprenticeshipLocationType.EmployerBased);
@@ -202,7 +202,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.PostAsync(
-                $"new-apprenticeship-provider/apprenticeship-employer-locations?providerId={providerId}&ffiid={mptxInstance.InstanceId}",
+                $"new-apprenticeship-provider/apprenticeship-employer-locations?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}",
                 requestContent);
 
             // Assert
@@ -213,9 +213,9 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Post_NoOptionSelectedRendersValidationError()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             var flowModel = new FlowModel();
             flowModel.SetApprenticeshipLocationType(ApprenticeshipLocationType.EmployerBased);
@@ -226,7 +226,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.PostAsync(
-                $"new-apprenticeship-provider/apprenticeship-employer-locations?providerId={providerId}&ffiid={mptxInstance.InstanceId}",
+                $"new-apprenticeship-provider/apprenticeship-employer-locations?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}",
                 requestContent);
 
             // Assert
@@ -246,9 +246,9 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
             string expectedRedirectLocation)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             var flowModel = new FlowModel();
             flowModel.SetApprenticeshipLocationType(locationType);
@@ -256,7 +256,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             if (gotClassroomLocation)
             {
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
                 mptxInstance.Update(s => s.SetClassroomLocationForVenue(
                     venueId,
@@ -271,7 +271,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.PostAsync(
-                $"new-apprenticeship-provider/apprenticeship-employer-locations?providerId={providerId}&ffiid={mptxInstance.InstanceId}",
+                $"new-apprenticeship-provider/apprenticeship-employer-locations?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}",
                 requestContent);
 
             // Assert
@@ -291,9 +291,9 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
             ApprenticeshipLocationType locationType)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             var flowModel = new FlowModel();
             flowModel.SetApprenticeshipLocationType(locationType);
@@ -305,7 +305,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.PostAsync(
-                $"new-apprenticeship-provider/apprenticeship-employer-locations?providerId={providerId}&ffiid={mptxInstance.InstanceId}",
+                $"new-apprenticeship-provider/apprenticeship-employer-locations?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}",
                 requestContent);
 
             // Assert

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/NewApprenticeshipProvider/ApprenticeshipLocationsTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/NewApprenticeshipProvider/ApprenticeshipLocationsTests.cs
@@ -18,7 +18,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Get_HelpdeskUserCannotAccess()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
 
             await User.AsHelpdesk();
 
@@ -26,7 +26,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.GetAsync(
-                $"new-apprenticeship-provider/apprenticeship-locations?providerId={providerId}&ffiid={mptxInstance.InstanceId}");
+                $"new-apprenticeship-provider/apprenticeship-locations?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}");
 
             // Assert
             Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
@@ -40,15 +40,15 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Get_QAStatusNotValidReturnsBadRequest(ApprenticeshipQAStatus qaStatus)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: qaStatus);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: qaStatus);
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             var mptxInstance = CreateMptxInstance(new FlowModel());
 
             // Act
             var response = await HttpClient.GetAsync(
-                $"new-apprenticeship-provider/apprenticeship-locations?providerId={providerId}&ffiid={mptxInstance.InstanceId}");
+                $"new-apprenticeship-provider/apprenticeship-locations?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}");
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -58,17 +58,17 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Get_NotApprenticeshipProviderReturnsForbidden()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted,
                 providerType: ProviderType.FE);
 
-            await User.AsProviderUser(providerId, ProviderType.FE);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.FE);
 
             var mptxInstance = CreateMptxInstance(new FlowModel());
 
             // Act
             var response = await HttpClient.GetAsync(
-                $"new-apprenticeship-provider/apprenticeship-locations?providerId={providerId}&ffiid={mptxInstance.InstanceId}");
+                $"new-apprenticeship-provider/apprenticeship-locations?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}");
 
             // Assert
             Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
@@ -78,15 +78,15 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Get_NoPersistedStateRendersExpectedOutput()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             var mptxInstance = CreateMptxInstance(new FlowModel());
 
             // Act
             var response = await HttpClient.GetAsync(
-                $"new-apprenticeship-provider/apprenticeship-locations?providerId={providerId}&ffiid={mptxInstance.InstanceId}");
+                $"new-apprenticeship-provider/apprenticeship-locations?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}");
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -101,9 +101,9 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Get_PersistedStateRendersExpectedOutput()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             var flowModel = new FlowModel();
             flowModel.SetApprenticeshipLocationType(ApprenticeshipLocationType.EmployerBased);
@@ -111,7 +111,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.GetAsync(
-                $"new-apprenticeship-provider/apprenticeship-locations?providerId={providerId}&ffiid={mptxInstance.InstanceId}");
+                $"new-apprenticeship-provider/apprenticeship-locations?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}");
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -126,7 +126,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Post_HelpdeskUserCannotAccess()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
 
             await User.AsHelpdesk();
 
@@ -138,7 +138,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.PostAsync(
-                $"new-apprenticeship-provider/apprenticeship-locations?providerId={providerId}&ffiid={mptxInstance.InstanceId}",
+                $"new-apprenticeship-provider/apprenticeship-locations?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}",
                 requestContent);
 
             // Assert
@@ -153,9 +153,9 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Post_QAStatusNotValidReturnsBadRequest(ApprenticeshipQAStatus qaStatus)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: qaStatus);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: qaStatus);
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             var mptxInstance = CreateMptxInstance(new FlowModel());
 
@@ -165,7 +165,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.PostAsync(
-                $"new-apprenticeship-provider/apprenticeship-locations?providerId={providerId}&ffiid={mptxInstance.InstanceId}",
+                $"new-apprenticeship-provider/apprenticeship-locations?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}",
                 requestContent);
 
             // Assert
@@ -176,11 +176,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Post_NotApprenticeshipProviderReturnsForbidden()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted,
                 providerType: ProviderType.FE);
 
-            await User.AsProviderUser(providerId, ProviderType.FE);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.FE);
 
             var mptxInstance = CreateMptxInstance(new FlowModel());
 
@@ -190,7 +190,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.PostAsync(
-                $"new-apprenticeship-provider/apprenticeship-locations?providerId={providerId}&ffiid={mptxInstance.InstanceId}",
+                $"new-apprenticeship-provider/apprenticeship-locations?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}",
                 requestContent);
 
             // Assert
@@ -201,9 +201,9 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Post_NoOptionSelectedRendersValidationError()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             var mptxInstance = CreateMptxInstance(new FlowModel());
 
@@ -212,7 +212,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.PostAsync(
-                $"new-apprenticeship-provider/apprenticeship-locations?providerId={providerId}&ffiid={mptxInstance.InstanceId}",
+                $"new-apprenticeship-provider/apprenticeship-locations?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}",
                 requestContent);
 
             // Assert
@@ -231,9 +231,9 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
             string expectedRedirect)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             var mptxInstance = CreateMptxInstance(new FlowModel());
 
@@ -243,7 +243,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.PostAsync(
-                $"new-apprenticeship-provider/apprenticeship-locations?providerId={providerId}&ffiid={mptxInstance.InstanceId}",
+                $"new-apprenticeship-provider/apprenticeship-locations?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}",
                 requestContent);
 
             // Assert

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/NewApprenticeshipProvider/ApprenticeshipSummaryTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/NewApprenticeshipProvider/ApprenticeshipSummaryTests.cs
@@ -25,7 +25,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Get_HelpdeskUser_ReturnsForbidden()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
 
             var standardCode = 123;
             var standardVersion = 1;
@@ -48,7 +48,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.GetAsync(
-                $"new-apprenticeship-provider/apprenticeship-confirmation?providerId={providerId}&ffiid={mptxInstance.InstanceId}");
+                $"new-apprenticeship-provider/apprenticeship-confirmation?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}");
 
             // Assert
             Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
@@ -62,13 +62,13 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Get_QAStatusNotValid_ReturnsBadRequest(ApprenticeshipQAStatus qaStatus)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: qaStatus);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: qaStatus);
 
             var standardCode = 123;
             var standardVersion = 1;
             var standard = await TestData.CreateStandard(standardCode, standardVersion, standardName: "My standard");
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             var flowModel = new FlowModel();
             flowModel.SetProviderDetails("Provider 1 rocks");
@@ -85,7 +85,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.GetAsync(
-                $"new-apprenticeship-provider/apprenticeship-confirmation?providerId={providerId}&ffiid={mptxInstance.InstanceId}");
+                $"new-apprenticeship-provider/apprenticeship-confirmation?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}");
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -95,7 +95,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Get_NotApprenticeshipProvider_ReturnsForbidden()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted,
                 providerType: ProviderType.FE);
 
@@ -103,7 +103,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
             var standardVersion = 1;
             var standard = await TestData.CreateStandard(standardCode, standardVersion, standardName: "My standard");
 
-            await User.AsProviderUser(providerId, ProviderType.FE);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.FE);
 
             var flowModel = new FlowModel();
             flowModel.SetProviderDetails("Provider 1 rocks");
@@ -120,7 +120,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.GetAsync(
-                $"new-apprenticeship-provider/apprenticeship-confirmation?providerId={providerId}&ffiid={mptxInstance.InstanceId}");
+                $"new-apprenticeship-provider/apprenticeship-confirmation?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}");
 
             // Assert
             Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
@@ -130,16 +130,16 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Get_IncompleteFlow_ReturnsBadRequest()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             var flowModel = new FlowModel();
             var mptxInstance = CreateMptxInstance(flowModel);
 
             // Act
             var response = await HttpClient.GetAsync(
-                $"new-apprenticeship-provider/apprenticeship-confirmation?providerId={providerId}&ffiid={mptxInstance.InstanceId}");
+                $"new-apprenticeship-provider/apprenticeship-confirmation?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}");
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -149,13 +149,13 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Get_MissingClassroomLocations_RendersExpectedOutput()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
 
             var standardCode = 123;
             var standardVersion = 1;
             var standard = await TestData.CreateStandard(standardCode, standardVersion, standardName: "My standard");
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             var flowModel = new FlowModel();
             flowModel.SetProviderDetails("Provider 1 rocks");
@@ -171,7 +171,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.GetAsync(
-                $"new-apprenticeship-provider/apprenticeship-confirmation?providerId={providerId}&ffiid={mptxInstance.InstanceId}");
+                $"new-apprenticeship-provider/apprenticeship-confirmation?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}");
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -184,13 +184,13 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Get_ValidRequest_RendersExpectedOutput()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
 
             var standardCode = 123;
             var standardVersion = 1;
             var standard = await TestData.CreateStandard(standardCode, standardVersion, standardName: "My standard");
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             var flowModel = new FlowModel();
             flowModel.SetProviderDetails("Provider 1 rocks");
@@ -207,7 +207,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.GetAsync(
-                $"new-apprenticeship-provider/apprenticeship-confirmation?providerId={providerId}&ffiid={mptxInstance.InstanceId}");
+                $"new-apprenticeship-provider/apprenticeship-confirmation?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}");
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -223,7 +223,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Post_HelpdeskUser_ReturnsForbidden()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
 
             var standardCode = 123;
             var standardVersion = 1;
@@ -248,7 +248,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.PostAsync(
-                $"new-apprenticeship-provider/apprenticeship-confirmation?providerId={providerId}&ffiid={mptxInstance.InstanceId}",
+                $"new-apprenticeship-provider/apprenticeship-confirmation?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}",
                 requestContent);
 
             // Assert
@@ -263,13 +263,13 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Post_QAStatusNotValid_ReturnsBadRequest(ApprenticeshipQAStatus qaStatus)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: qaStatus);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: qaStatus);
 
             var standardCode = 123;
             var standardVersion = 1;
             var standard = await TestData.CreateStandard(standardCode, standardVersion, standardName: "My standard");
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             var flowModel = new FlowModel();
             flowModel.SetProviderDetails("Provider 1 rocks");
@@ -288,7 +288,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.PostAsync(
-                $"new-apprenticeship-provider/apprenticeship-confirmation?providerId={providerId}&ffiid={mptxInstance.InstanceId}",
+                $"new-apprenticeship-provider/apprenticeship-confirmation?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}",
                 requestContent);
 
             // Assert
@@ -299,7 +299,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Post_NotApprenticeshipProvider_ReturnsForbidden()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted,
                 providerType: ProviderType.FE);
 
@@ -307,7 +307,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
             var standardVersion = 1;
             var standard = await TestData.CreateStandard(standardCode, standardVersion, standardName: "My standard");
 
-            await User.AsProviderUser(providerId, ProviderType.FE);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.FE);
 
             var flowModel = new FlowModel();
             flowModel.SetProviderDetails("Provider 1 rocks");
@@ -326,7 +326,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.PostAsync(
-                $"new-apprenticeship-provider/apprenticeship-confirmation?providerId={providerId}&ffiid={mptxInstance.InstanceId}",
+                $"new-apprenticeship-provider/apprenticeship-confirmation?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}",
                 requestContent);
 
             // Assert
@@ -337,9 +337,9 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Post_IncompleteFlow_ReturnsBadRequest()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             var flowModel = new FlowModel();
             var mptxInstance = CreateMptxInstance(flowModel);
@@ -348,7 +348,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.PostAsync(
-                $"new-apprenticeship-provider/apprenticeship-confirmation?providerId={providerId}&ffiid={mptxInstance.InstanceId}",
+                $"new-apprenticeship-provider/apprenticeship-confirmation?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}",
                 requestContent);
 
             // Assert
@@ -359,13 +359,13 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Post_MissingClassroomLocations_RendersErrorMessage()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
 
             var standardCode = 123;
             var standardVersion = 1;
             var standard = await TestData.CreateStandard(standardCode, standardVersion, standardName: "My standard");
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             var flowModel = new FlowModel();
             flowModel.SetProviderDetails("Provider 1 rocks");
@@ -386,7 +386,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.PostAsync(
-                $"new-apprenticeship-provider/apprenticeship-confirmation?providerId={providerId}&ffiid={mptxInstance.InstanceId}",
+                $"new-apprenticeship-provider/apprenticeship-confirmation?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}",
                 requestContent);
 
             // Assert
@@ -400,13 +400,13 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task PostConfirmation_ValidRequestWithNationalLocations_CreatesApprenticeshipQASubmissionUpdatesQAStatusAndReturnsConfirmation()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
 
             var standardCode = 123;
             var standardVersion = 1;
             var standard = await TestData.CreateStandard(standardCode, standardVersion, standardName: "My standard");
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             var flowModel = new FlowModel();
             flowModel.SetProviderDetails("Provider 1 rocks");
@@ -428,7 +428,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.PostAsync(
-                $"new-apprenticeship-provider/apprenticeship-confirmation?providerId={providerId}&ffiid={mptxInstance.InstanceId}",
+                $"new-apprenticeship-provider/apprenticeship-confirmation?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}",
                 requestContent);
 
             // Assert
@@ -443,7 +443,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
                 q.CreatedByUser.UserId == User.UserId &&
                 q.CreatedDate == Clock.UtcNow &&
                 q.MarketingInformation == "My apprenticeship" &&
-                q.ProviderId == providerId &&
+                q.ProviderId == provider.ProviderId &&
                 q.StandardOrFramework.Standard.StandardCode == standardCode &&
                 q.StandardOrFramework.Standard.Version == standardVersion &&
                 q.Url == "http://provider.com/apprenticeship" &&
@@ -453,13 +453,13 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
                 q.Apprenticeships.Single().ApprenticeshipId == apprenticeshipId &&
                 q.Apprenticeships.Single().ApprenticeshipMarketingInformation == "My apprenticeship" &&
                 q.Apprenticeships.Single().ApprenticeshipTitle == "My standard" &&
-                q.ProviderId == providerId &&
+                q.ProviderId == provider.ProviderId &&
                 q.ProviderMarketingInformation == "Provider 1 rocks" &&
                 q.SubmittedByUserId == User.UserId &&
                 q.SubmittedOn == Clock.UtcNow);
 
             SqlQuerySpy.VerifyQuery<SetProviderApprenticeshipQAStatus, None>(q =>
-                q.ProviderId == providerId && q.ApprenticeshipQAStatus == ApprenticeshipQAStatus.Submitted);
+                q.ProviderId == provider.ProviderId && q.ApprenticeshipQAStatus == ApprenticeshipQAStatus.Submitted);
 
             var doc = await response.GetDocument();
 
@@ -472,13 +472,13 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task PostConfirmation_ValidRequestWithNationalLocations_CreatesValidApprenticeship()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
 
             var standardCode = 123;
             var standardVersion = 1;
             var standard = await TestData.CreateStandard(standardCode, standardVersion, standardName: "My standard");
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             var flowModel = new FlowModel();
             flowModel.SetProviderDetails("Provider 1 rocks");
@@ -500,7 +500,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.PostAsync(
-                $"new-apprenticeship-provider/apprenticeship-confirmation?providerId={providerId}&ffiid={mptxInstance.InstanceId}",
+                $"new-apprenticeship-provider/apprenticeship-confirmation?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}",
                 requestContent);
 
             // Assert
@@ -516,13 +516,13 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task PostConfirmation_ValidRequestWithRegions_CreatesValidApprenticeship()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
 
             var standardCode = 123;
             var standardVersion = 1;
             var standard = await TestData.CreateStandard(standardCode, standardVersion, standardName: "My standard");
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             var flowModel = new FlowModel();
             flowModel.SetProviderDetails("Provider 1 rocks");
@@ -548,7 +548,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.PostAsync(
-                $"new-apprenticeship-provider/apprenticeship-confirmation?providerId={providerId}&ffiid={mptxInstance.InstanceId}",
+                $"new-apprenticeship-provider/apprenticeship-confirmation?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}",
                 requestContent);
 
             // Assert
@@ -567,15 +567,15 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task PostConfirmation_ValidRequestWithVenue_CreatesValidApprenticeship()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
 
             var standardCode = 123;
             var standardVersion = 1;
             var standard = await TestData.CreateStandard(standardCode, standardVersion, standardName: "My standard");
 
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             var flowModel = new FlowModel();
             flowModel.SetProviderDetails("Provider 1 rocks");
@@ -601,7 +601,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.PostAsync(
-                $"new-apprenticeship-provider/apprenticeship-confirmation?providerId={providerId}&ffiid={mptxInstance.InstanceId}",
+                $"new-apprenticeship-provider/apprenticeship-confirmation?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}",
                 requestContent);
 
             // Assert
@@ -618,15 +618,15 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task PostConfirmation_ValidRequestWithRegionsAndVenue_CreatesValidApprenticeship()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
 
             var standardCode = 123;
             var standardVersion = 1;
             var standard = await TestData.CreateStandard(standardCode, standardVersion, standardName: "My standard");
 
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             var flowModel = new FlowModel();
             flowModel.SetProviderDetails("Provider 1 rocks");
@@ -657,7 +657,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.PostAsync(
-                $"new-apprenticeship-provider/apprenticeship-confirmation?providerId={providerId}&ffiid={mptxInstance.InstanceId}",
+                $"new-apprenticeship-provider/apprenticeship-confirmation?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}",
                 requestContent);
 
             // Assert
@@ -691,11 +691,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
             var regions = new List<string> { "123" };
             var standardCode = 123;
             var standardVersion = 1;
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
-            var user = await TestData.CreateUser(providerUserId, "somebody@provider1.com", "Provider 1", "Person", providerId);
-            var adminUser = await TestData.CreateUser(adminUserId, "admin@provider.com", "admin", "admin", null);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
+            var user = await TestData.CreateUser(providerId: provider.ProviderId);
+            var adminUser = await TestData.CreateUser();
             var standard = await TestData.CreateStandard(standardCode, standardVersion, standardName: "My standard");
-            var apprenticeshipId = (await TestData.CreateApprenticeship(providerId,
+            var apprenticeshipId = (await TestData.CreateApprenticeship(provider.ProviderId,
                 standard,
                 createdBy: user,
                 contactEmail: adminUser.Email,
@@ -706,9 +706,9 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
                 {
                     CreateApprenticeshipLocation.CreateRegions(regions)
                 })).Id;
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             var flowModel = new FlowModel();
             flowModel.SetProviderDetails("Provider 1 rocks");
@@ -737,7 +737,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.PostAsync(
-                $"new-apprenticeship-provider/apprenticeship-confirmation?providerId={providerId}&ffiid={mptxInstance.InstanceId}",
+                $"new-apprenticeship-provider/apprenticeship-confirmation?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}",
                 requestContent);
 
             // Assert

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/NewApprenticeshipProvider/FlowModelInitializerTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/NewApprenticeshipProvider/FlowModelInitializerTests.cs
@@ -19,8 +19,6 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Initialize_ApprenticeshipWithStandard_PopulatesModelCorrectly()
         {
             // Arrange
-            var ukprn = 12347;
-            var adminUserId = $"admin-user";
             var contactTelephone = "1111 111 1111";
             var website = "https://somerandomprovider.com/apprenticeship";
             var contactWebsite = "https://somerandomprovider.com";
@@ -28,19 +26,17 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
             var regions = new List<string> { "123" };
             var contactEmail = "somecontact@nonexistentprovider.com";
 
-            var providerId = await TestData.CreateProvider(
-                ukprn: ukprn,
+            var provider = await TestData.CreateProvider(
                 providerName: "Provider 1",
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.Submitted);
 
-            var providerUserId = $"{ukprn}-user";
-            var user = await TestData.CreateUser(providerUserId, "somebody@provider1.com", "Provider 1", "Person", providerId);
-            var adminUser = await TestData.CreateUser(adminUserId, "admin@provider.com", "admin", "admin", null);
+            var providerUser = await TestData.CreateUser(providerId: provider.ProviderId);
+            var adminUser = await TestData.CreateUser();
             var standard = await TestData.CreateStandard(standardCode: 1234, version: 1, standardName: "Test Standard");
 
-            var apprenticeshipId = (await TestData.CreateApprenticeship(providerId,
+            var apprenticeshipId = (await TestData.CreateApprenticeship(provider.ProviderId,
                 standard,
-                createdBy: user,
+                createdBy: providerUser,
                 contactEmail: contactEmail,
                 contactTelephone: contactTelephone,
                 contactWebsite: contactWebsite,
@@ -54,9 +50,9 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
             var standardsAndFrameworksCache = new StandardsAndFrameworksCache(CosmosDbQueryDispatcher.Object);
 
             var submissionId = await TestData.CreateApprenticeshipQASubmission(
-                providerId,
+                provider.ProviderId,
                 submittedOn: Clock.UtcNow,
-                submittedByUserId: providerUserId,
+                submittedByUserId: providerUser.UserId,
                 providerMarketingInformation: "The overview",
                 apprenticeshipIds: new[] { apprenticeshipId });
 
@@ -65,7 +61,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
                 var initializer = new FlowModelInitializer(CosmosDbQueryDispatcher.Object, dispatcher, standardsAndFrameworksCache);
 
                 // Act
-                var model = await initializer.Initialize(providerId);
+                var model = await initializer.Initialize(provider.ProviderId);
 
                 // Assert
                 Assert.True(model.GotApprenticeshipDetails);
@@ -92,8 +88,6 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Initialize_ApprenticeshipWithFramework_PopulatesModelSuccessfully()
         {
             // Arrange
-            var ukprn = 12346;
-            var adminUserId = $"admin-user";
             var contactTelephone = "1111 111 1111";
             var website = "https://somerandomprovider.com/apprenticeship";
             var contactWebsite = "https://somerandomprovider.com";
@@ -101,19 +95,17 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
             var regions = new List<string> { "123" };
             var contactEmail = "somecontact@nonexistentprovider.com";
 
-            var providerId = await TestData.CreateProvider(
-                ukprn: ukprn,
+            var provider = await TestData.CreateProvider(
                 providerName: "Provider 1",
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.Submitted);
 
-            var providerUserId = $"{ukprn}-user";
-            var user = await TestData.CreateUser(providerUserId, "somebody@provider1.com", "Provider 1", "Person", providerId);
-            var adminUser = await TestData.CreateUser(adminUserId, "admin@provider.com", "admin", "admin", null);
+            var providerUser = await TestData.CreateUser(providerId: provider.ProviderId);
+            var adminUser = await TestData.CreateUser(null);
             var framework = await TestData.CreateFramework(1, 1, 1, "Test Framework");
 
-            var apprenticeshipId = (await TestData.CreateApprenticeship(providerId,
+            var apprenticeshipId = (await TestData.CreateApprenticeship(provider.ProviderId,
                 framework,
-                createdBy: user,
+                createdBy: providerUser,
                 contactEmail: contactEmail,
                 contactTelephone: contactTelephone,
                 contactWebsite: contactWebsite,
@@ -127,9 +119,9 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
             var standardsAndFrameworksCache = new StandardsAndFrameworksCache(CosmosDbQueryDispatcher.Object);
 
             var submissionId = await TestData.CreateApprenticeshipQASubmission(
-                providerId,
+                provider.ProviderId,
                 submittedOn: Clock.UtcNow,
-                submittedByUserId: providerUserId,
+                submittedByUserId: providerUser.UserId,
                 providerMarketingInformation: "The overview",
                 apprenticeshipIds: new[] { apprenticeshipId });
 
@@ -138,7 +130,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
                 var initializer = new FlowModelInitializer(CosmosDbQueryDispatcher.Object, dispatcher, standardsAndFrameworksCache);
 
                 // Act
-                var model = await initializer.Initialize(providerId);
+                var model = await initializer.Initialize(provider.ProviderId);
 
                 // Assert
                 Assert.True(model.GotApprenticeshipDetails);
@@ -165,8 +157,6 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Initialize_NationalApprenticeship_PopulatesModelCorrectly()
         {
             // Arrange
-            var ukprn = 12346;
-            var adminUserId = $"admin-user";
             var contactTelephone = "1111 111 1111";
             var website = "https://somerandomprovider.com/apprenticeship";
             var contactWebsite = "https://somerandomprovider.com";
@@ -174,19 +164,17 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
             var regions = new List<string> { "123" };
             var contactEmail = "somecontact@nonexistentprovider.com";
 
-            var providerId = await TestData.CreateProvider(
-                ukprn: ukprn,
+            var provider = await TestData.CreateProvider(
                 providerName: "Provider 1",
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.Submitted);
 
-            var providerUserId = $"{ukprn}-user";
-            var user = await TestData.CreateUser(providerUserId, "somebody@provider1.com", "Provider 1", "Person", providerId);
-            var adminUser = await TestData.CreateUser(adminUserId, "admin@provider.com", "admin", "admin", null);
+            var providerUser = await TestData.CreateUser(providerId: provider.ProviderId);
+            var adminUser = await TestData.CreateUser();
             var framework = await TestData.CreateFramework(1, 1, 1, "Test Framework");
 
-            var apprenticeshipId = (await TestData.CreateApprenticeship(providerId,
+            var apprenticeshipId = (await TestData.CreateApprenticeship(provider.ProviderId,
                 framework,
-                createdBy: user,
+                createdBy: providerUser,
                 contactEmail: contactEmail,
                 contactTelephone: contactTelephone,
                 contactWebsite: contactWebsite,
@@ -200,9 +188,9 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
             var standardsAndFrameworksCache = new StandardsAndFrameworksCache(CosmosDbQueryDispatcher.Object);
 
             var submissionId = await TestData.CreateApprenticeshipQASubmission(
-                providerId,
+                provider.ProviderId,
                 submittedOn: Clock.UtcNow,
-                submittedByUserId: providerUserId,
+                submittedByUserId: providerUser.UserId,
                 providerMarketingInformation: "The overview",
                 apprenticeshipIds: new[] { apprenticeshipId });
 
@@ -211,7 +199,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
                 var initializer = new FlowModelInitializer(CosmosDbQueryDispatcher.Object, dispatcher, standardsAndFrameworksCache);
 
                 // Act
-                var model = await initializer.Initialize(providerId);
+                var model = await initializer.Initialize(provider.ProviderId);
 
                 // Assert
                 Assert.True(model.GotApprenticeshipDetails);
@@ -233,11 +221,9 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Initialize_NoSubmission_DoesNotPopulateApprenticeshipFields()
         {
             // Arrange
-            var ukprn = 12345;
             var marketingInfo = "example marketing information";
 
-            var providerId = await TestData.CreateProvider(
-                ukprn: ukprn,
+            var provider = await TestData.CreateProvider(
                 providerName: "Provider 1",
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.Submitted,
                 marketingInformation: marketingInfo);
@@ -249,7 +235,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
                 var initializer = new FlowModelInitializer(CosmosDbQueryDispatcher.Object, dispatcher, standardsAndFrameworksCache);
 
                 // Act
-                var model = await initializer.Initialize(providerId);
+                var model = await initializer.Initialize(provider.ProviderId);
 
                 // Assert
                 Assert.False(model.GotApprenticeshipDetails);
@@ -270,8 +256,6 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Initialize_BothLocationType_InitializesModelCorrectly()
         {
             // Arrange
-            var ukprn = 12346;
-            var adminUserId = $"admin-user";
             var contactTelephone = "1111 111 1111";
             var website = "https://somerandomprovider.com/apprenticeship";
             var contactWebsite = "https://somerandomprovider.com";
@@ -280,22 +264,20 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
             var contactEmail = "somecontact@nonexistentprovider.com";
             var radius = 30;
             var deliveryMode = ApprenticeshipDeliveryMode.BlockRelease;
-            var providerId = await TestData.CreateProvider(
-                ukprn: ukprn,
+            var provider = await TestData.CreateProvider(
                 providerName: "Provider 1",
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.Submitted);
 
-            var providerUserId = $"{ukprn}-user";
-            var user = await TestData.CreateUser(providerUserId, "somebody@provider1.com", "Provider 1", "Person", providerId);
-            var adminUser = await TestData.CreateUser(adminUserId, "admin@provider.com", "admin", "admin", null);
+            var providerUser = await TestData.CreateUser(providerId: provider.ProviderId);
+            var adminUser = await TestData.CreateUser();
             var framework = await TestData.CreateFramework(1, 1, 1, "Test Framework");
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
             var venue = await CosmosDbQueryDispatcher.Object.ExecuteQuery(new GetVenueById() { VenueId = venueId });
 
-            var apprenticeshipId = (await TestData.CreateApprenticeship(providerId,
+            var apprenticeshipId = (await TestData.CreateApprenticeship(provider.ProviderId,
                 framework,
-                createdBy: user,
+                createdBy: providerUser,
                 contactEmail: contactEmail,
                 contactTelephone: contactTelephone,
                 contactWebsite: contactWebsite,
@@ -313,9 +295,9 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
             var standardsAndFrameworksCache = new StandardsAndFrameworksCache(CosmosDbQueryDispatcher.Object);
 
             var submissionId = await TestData.CreateApprenticeshipQASubmission(
-                providerId,
+                provider.ProviderId,
                 submittedOn: Clock.UtcNow,
-                submittedByUserId: providerUserId,
+                submittedByUserId: providerUser.UserId,
                 providerMarketingInformation: "The overview",
                 apprenticeshipIds: new[] { apprenticeshipId });
 
@@ -324,7 +306,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
                 var initializer = new FlowModelInitializer(CosmosDbQueryDispatcher.Object, dispatcher, standardsAndFrameworksCache);
 
                 // Act
-                var model = await initializer.Initialize(providerId);
+                var model = await initializer.Initialize(provider.ProviderId);
 
                 // Assert
                 Assert.True(model.GotApprenticeshipDetails);
@@ -353,27 +335,23 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Initialize_EmployerBasedLocationType_PopulatesModelCorrectly()
         {
             // Arrange
-            var ukprn = 12346;
-            var adminUserId = $"admin-user";
             var contactTelephone = "1111 111 1111";
             var website = "https://somerandomprovider.com/apprenticeship";
             var contactWebsite = "https://somerandomprovider.com";
             var marketingInfo = "Providing Online training";
             var contactEmail = "somecontact@nonexistentprovider.com";
 
-            var providerId = await TestData.CreateProvider(
-                ukprn: ukprn,
+            var provider = await TestData.CreateProvider(
                 providerName: "Provider 1",
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.Submitted);
 
-            var providerUserId = $"{ukprn}-user";
-            var user = await TestData.CreateUser(providerUserId, "somebody@provider1.com", "Provider 1", "Person", providerId);
-            var adminUser = await TestData.CreateUser(adminUserId, "admin@provider.com", "admin", "admin", null);
+            var providerUser = await TestData.CreateUser(providerId: provider.ProviderId);
+            var adminUser = await TestData.CreateUser();
             var framework = await TestData.CreateFramework(1, 1, 1, "Test Framework");
 
-            var apprenticeshipId = (await TestData.CreateApprenticeship(providerId,
+            var apprenticeshipId = (await TestData.CreateApprenticeship(provider.ProviderId,
                 framework,
-                createdBy: user,
+                createdBy: providerUser,
                 contactEmail: contactEmail,
                 contactTelephone: contactTelephone,
                 contactWebsite: contactWebsite,
@@ -387,9 +365,9 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
             var standardsAndFrameworksCache = new StandardsAndFrameworksCache(CosmosDbQueryDispatcher.Object);
 
             var submissionId = await TestData.CreateApprenticeshipQASubmission(
-                providerId,
+                provider.ProviderId,
                 submittedOn: Clock.UtcNow,
-                submittedByUserId: providerUserId,
+                submittedByUserId: providerUser.UserId,
                 providerMarketingInformation: "The overview",
                 apprenticeshipIds: new[] { apprenticeshipId });
 
@@ -398,7 +376,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
                 var initializer = new FlowModelInitializer(CosmosDbQueryDispatcher.Object, dispatcher, standardsAndFrameworksCache);
 
                 // Act
-                var model = await initializer.Initialize(providerId);
+                var model = await initializer.Initialize(provider.ProviderId);
 
                 // Assert
                 Assert.True(model.GotApprenticeshipDetails);

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/NewApprenticeshipProvider/ProviderDetailTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/NewApprenticeshipProvider/ProviderDetailTests.cs
@@ -20,7 +20,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Get_HelpdeskUserCannotAccess()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
 
             await User.AsHelpdesk();
@@ -29,7 +29,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.GetAsync(
-                $"new-apprenticeship-provider/provider-detail?providerId={providerId}&ffiid={mptxInstance.InstanceId}");
+                $"new-apprenticeship-provider/provider-detail?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}");
 
             // Assert
             Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
@@ -43,15 +43,15 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Get_QAStatusNotValidReturnsBadRequest(ApprenticeshipQAStatus qaStatus)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: qaStatus);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: qaStatus);
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             var mptxInstance = CreateMptxInstance(new FlowModel());
 
             // Act
             var response = await HttpClient.GetAsync(
-                $"new-apprenticeship-provider/provider-detail?providerId={providerId}&ffiid={mptxInstance.InstanceId}");
+                $"new-apprenticeship-provider/provider-detail?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}");
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -61,17 +61,17 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Get_NotApprenticeshipProviderReturnsForbidden()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted,
                 providerType: ProviderType.FE);
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             var mptxInstance = CreateMptxInstance(new FlowModel());
 
             // Act
             var response = await HttpClient.GetAsync(
-                $"new-apprenticeship-provider/provider-detail?providerId={providerId}&ffiid={mptxInstance.InstanceId}");
+                $"new-apprenticeship-provider/provider-detail?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}");
 
             // Assert
             Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
@@ -81,12 +81,12 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Get_RendersExpectedOutput()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerName: "Provider name",
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted,
                 marketingInformation: "<p>Existing marketing info</p>");
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             var flowModel = new FlowModel();
             flowModel.SetProviderDetails("<p>Existing marketing info</p>");
@@ -94,7 +94,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.GetAsync(
-                $"new-apprenticeship-provider/provider-detail?providerId={providerId}&ffiid={mptxInstance.InstanceId}");
+                $"new-apprenticeship-provider/provider-detail?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}");
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -107,7 +107,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Post_HelpdeskUserCannotAccess()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerName: "Provider name",
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted,
                 courseDirectoryName: "Alias");
@@ -122,7 +122,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.PostAsync(
-                $"new-apprenticeship-provider/provider-detail?providerId={providerId}&ffiid={mptxInstance.InstanceId}",
+                $"new-apprenticeship-provider/provider-detail?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}",
                 requestContent);
 
             // Assert
@@ -137,12 +137,12 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Post_QAStatusNotValidReturnsBadRequest(ApprenticeshipQAStatus qaStatus)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerName: "Provider name",
                 apprenticeshipQAStatus: qaStatus,
                 courseDirectoryName: "Alias");
 
-            await User.AsProviderUser(providerId, ProviderType.FE);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.FE);
 
             var mptxInstance = CreateMptxInstance(new FlowModel());
 
@@ -152,7 +152,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.PostAsync(
-                $"new-apprenticeship-provider/provider-detail?providerId={providerId}&ffiid={mptxInstance.InstanceId}",
+                $"new-apprenticeship-provider/provider-detail?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}",
                 requestContent);
 
             // Assert
@@ -163,11 +163,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Post_NotApprenticeshipProviderReturnsForbidden()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.FE,
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
 
-            await User.AsProviderUser(providerId, ProviderType.FE);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.FE);
 
             var mptxInstance = CreateMptxInstance(new FlowModel());
 
@@ -177,7 +177,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.PostAsync(
-                $"new-apprenticeship-provider/provider-detail?providerId={providerId}&ffiid={mptxInstance.InstanceId}",
+                $"new-apprenticeship-provider/provider-detail?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}",
                 requestContent);
 
             // Assert
@@ -188,12 +188,12 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Post_InvalidMarketingInfoRendersErrorMessage()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerName: "Provider name",
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted,
                 courseDirectoryName: "Alias");
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             var mptxInstance = CreateMptxInstance(new FlowModel());
 
@@ -203,7 +203,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.PostAsync(
-                $"new-apprenticeship-provider/provider-detail?providerId={providerId}&ffiid={mptxInstance.InstanceId}",
+                $"new-apprenticeship-provider/provider-detail?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}",
                 requestContent);
 
             // Assert
@@ -217,12 +217,12 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Post_ValidRequestUpdatesStateAndRedirects()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerName: "Provider name",
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted,
                 courseDirectoryName: "Alias");
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             var mptxInstance = CreateMptxInstance(new FlowModel());
 
@@ -232,7 +232,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.PostAsync(
-                $"new-apprenticeship-provider/provider-detail?providerId={providerId}&ffiid={mptxInstance.InstanceId}",
+                $"new-apprenticeship-provider/provider-detail?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}",
                 requestContent);
 
             // Assert
@@ -250,7 +250,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task GetConfirmation_HelpdeskUserCannotAccess()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted,
                 providerName: "Test Provider",
                 courseDirectoryName: "CD Name");
@@ -263,7 +263,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.GetAsync(
-                $"new-apprenticeship-provider/provider-detail-confirmation?providerId={providerId}&ffiid={mptxInstance.InstanceId}");
+                $"new-apprenticeship-provider/provider-detail-confirmation?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}");
 
             // Assert
             Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
@@ -277,9 +277,9 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task GetConfirmation_QAStatusNotValidReturnsBadRequest(ApprenticeshipQAStatus qaStatus)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: qaStatus);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: qaStatus);
 
-            await User.AsProviderUser(providerId, ProviderType.FE);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.FE);
 
             var flowModel = new FlowModel();
             flowModel.SetProviderDetails("<p>New marketing info</p>");
@@ -287,7 +287,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.GetAsync(
-                $"new-apprenticeship-provider/provider-detail-confirmation?providerId={providerId}&ffiid={mptxInstance.InstanceId}");
+                $"new-apprenticeship-provider/provider-detail-confirmation?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}");
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -297,11 +297,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task GetConfirmation_NotApprenticeshipProviderReturnsForbidden()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted,
                 providerType: ProviderType.FE);
 
-            await User.AsProviderUser(providerId, ProviderType.FE);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.FE);
 
             var flowModel = new FlowModel();
             flowModel.SetProviderDetails("<p>New marketing info</p>");
@@ -309,7 +309,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.GetAsync(
-                $"new-apprenticeship-provider/provider-detail-confirmation?providerId={providerId}&ffiid={mptxInstance.InstanceId}");
+                $"new-apprenticeship-provider/provider-detail-confirmation?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}");
 
             // Assert
             Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
@@ -319,15 +319,15 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task GetConfirmation_NoProviderDetailSetReturnsBadRequest()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             var mptxInstance = CreateMptxInstance(new FlowModel());
 
             // Act
             var response = await HttpClient.GetAsync(
-                $"new-apprenticeship-provider/provider-detail-confirmation?providerId={providerId}&ffiid={mptxInstance.InstanceId}");
+                $"new-apprenticeship-provider/provider-detail-confirmation?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}");
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -337,12 +337,12 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task GetConfirmation_RendersExpectedOutput()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted,
                 providerName: "Test Provider",
                 courseDirectoryName: "CD Name");
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             var flowModel = new FlowModel();
             flowModel.SetProviderDetails("<p>New marketing info</p>");
@@ -350,7 +350,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.GetAsync(
-                $"new-apprenticeship-provider/provider-detail-confirmation?providerId={providerId}&ffiid={mptxInstance.InstanceId}");
+                $"new-apprenticeship-provider/provider-detail-confirmation?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}");
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -360,7 +360,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task PostConfirmation_HelpdeskUserCannotAccess()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
 
             await User.AsHelpdesk();
 
@@ -372,7 +372,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.PostAsync(
-                $"new-apprenticeship-provider/provider-detail-confirmation?providerId={providerId}&ffiid={mptxInstance.InstanceId}",
+                $"new-apprenticeship-provider/provider-detail-confirmation?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}",
                 requestContent);
 
             // Assert
@@ -387,9 +387,9 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task PostConfirmation_QAStatusNotValidReturnsBadRequest(ApprenticeshipQAStatus qaStatus)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: qaStatus);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: qaStatus);
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             var flowModel = new FlowModel();
             flowModel.SetProviderDetails("<p>New marketing info</p>");
@@ -399,7 +399,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.PostAsync(
-                $"new-apprenticeship-provider/provider-detail-confirmation?providerId={providerId}&ffiid={mptxInstance.InstanceId}",
+                $"new-apprenticeship-provider/provider-detail-confirmation?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}",
                 requestContent);
 
             // Assert
@@ -410,11 +410,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task PostConfirmation_NotApprenticeshipProviderReturnsForbidden()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted,
                 providerType: ProviderType.FE);
 
-            await User.AsProviderUser(providerId, ProviderType.FE);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.FE);
 
             var flowModel = new FlowModel();
             flowModel.SetProviderDetails("<p>New marketing info</p>");
@@ -424,7 +424,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.PostAsync(
-                $"new-apprenticeship-provider/provider-detail-confirmation?providerId={providerId}&ffiid={mptxInstance.InstanceId}",
+                $"new-apprenticeship-provider/provider-detail-confirmation?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}",
                 requestContent);
 
             // Assert
@@ -435,9 +435,9 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task PostConfirmation_NoProviderDetailSetReturnsBadRequest()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             var mptxInstance = CreateMptxInstance(new FlowModel());
 
@@ -445,7 +445,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.PostAsync(
-                $"new-apprenticeship-provider/provider-detail-confirmation?providerId={providerId}&ffiid={mptxInstance.InstanceId}",
+                $"new-apprenticeship-provider/provider-detail-confirmation?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}",
                 requestContent);
 
             // Assert
@@ -456,9 +456,9 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task PostConfirmation_ValidRequestUpdatesDbAndRedirects()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             var flowModel = new FlowModel();
             flowModel.SetProviderDetails("<p>New marketing info</p>");
@@ -468,12 +468,12 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             // Act
             var response = await HttpClient.PostAsync(
-                $"new-apprenticeship-provider/provider-detail-confirmation?providerId={providerId}&ffiid={mptxInstance.InstanceId}",
+                $"new-apprenticeship-provider/provider-detail-confirmation?providerId={provider.ProviderId}&ffiid={mptxInstance.InstanceId}",
                 requestContent);
 
             // Assert
             CosmosDbQueryDispatcher.Verify(mock => mock.ExecuteQuery(It.Is<UpdateProviderInfo>(c =>
-                c.ProviderId == providerId &&
+                c.ProviderId == provider.ProviderId &&
                 c.MarketingInformation == "<p>New marketing info</p>" &&
                 c.UpdatedBy.UserId == User.UserId &&
                 c.UpdatedOn == Clock.UtcNow)));

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/NewApprenticeshipProvider/QANotificationsTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/NewApprenticeshipProvider/QANotificationsTests.cs
@@ -22,9 +22,9 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task RendersCorrectMessage(ApprenticeshipQAStatus qaStatus, string expectedNotificationId)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(apprenticeshipQAStatus: qaStatus);
+            var provider = await TestData.CreateProvider(apprenticeshipQAStatus: qaStatus);
 
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             // Act
             var response = await HttpClient.GetAsync("QANotificationsTests");
@@ -58,11 +58,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task FEOnlyProviderRendersNoMessage(ApprenticeshipQAStatus qaStatus, string notificationId)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 apprenticeshipQAStatus: qaStatus,
                 providerType: ProviderType.FE);
 
-            await User.AsProviderUser(providerId, ProviderType.FE);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.FE);
 
             // Act
             var response = await HttpClient.GetAsync("QANotificationsTests");
@@ -79,32 +79,27 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task PassedQANotification_Is_Not_Visible_Once_Notification_Is_Closed()
         {
             // Arrange
-            var ukprn = 12345;
-            var adminUserId = $"admin-user";
-
-            var providerId = await TestData.CreateProvider(
-                ukprn: ukprn,
+            var provider = await TestData.CreateProvider(
                 providerName: "Provider 1",
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.Submitted);
 
-            var providerUserId = $"{ukprn}-user";
-            await TestData.CreateUser(providerUserId, "somebody@provider1.com", "Provider 1", "Person", providerId);
-            await TestData.CreateUser(adminUserId, "admin", "admin", "admin", null);
+            var providerUser = await TestData.CreateUser(providerId: provider.ProviderId);
+            var adminUser = await TestData.CreateUser();
 
             var standard = await TestData.CreateStandard(standardCode: 1234, version: 1, standardName: "Test Standard");
-            var apprenticeshipId = (await TestData.CreateApprenticeship(providerId, standard, createdBy: User.ToUserInfo())).Id;
+            var apprenticeshipId = (await TestData.CreateApprenticeship(provider.ProviderId, standard, createdBy: User.ToUserInfo())).Id;
 
             var submissionId = await TestData.CreateApprenticeshipQASubmission(
-                providerId,
+                provider.ProviderId,
                 submittedOn: Clock.UtcNow,
-                submittedByUserId: providerUserId,
+                submittedByUserId: providerUser.UserId,
                 providerMarketingInformation: "The overview",
                 apprenticeshipIds: new[] { apprenticeshipId });
 
             var passedProviderAssessmentOn = Clock.UtcNow;
             await TestData.CreateApprenticeshipQAProviderAssessment(
                 submissionId,
-                assessedByUserId: adminUserId,
+                assessedByUserId: adminUser.UserId,
                 assessedOn: passedProviderAssessmentOn,
                 compliancePassed: true,
                 complianceComments: null,
@@ -122,9 +117,9 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
                 lastAssessedByUserId: User.UserId.ToString(),
                 lastAssessedOn: Clock.UtcNow);
 
-            await TestData.SetProviderApprenticeshipQAStatus(providerId, ApprenticeshipQAStatus.Passed);
+            await TestData.SetProviderApprenticeshipQAStatus(provider.ProviderId, ApprenticeshipQAStatus.Passed);
             await TestData.UpdateHidePassedNotification(submissionId, true);
-            await User.AsProviderSuperUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderSuperUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             // Act
             var response = await HttpClient.GetAsync("QANotificationsTests");
@@ -140,39 +135,31 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
             Assert.Empty(notificationElements);
         }
 
-
-
         [Fact]
-
         public async Task PassedQANotification_Is_Visible_For_PassedQAProviders()
         {
             // Arrange
-            var ukprn = 12345;
-            var adminUserId = $"admin-user";
-
-            var providerId = await TestData.CreateProvider(
-                ukprn: ukprn,
+            var provider = await TestData.CreateProvider(
                 providerName: "Provider 1",
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.Submitted);
 
-            var providerUserId = $"{ukprn}-user";
-            await TestData.CreateUser(providerUserId, "somebody@provider1.com", "Provider 1", "Person", providerId);
-            await TestData.CreateUser(adminUserId, "admin", "admin", "admin", null);
+            var providerUser = await TestData.CreateUser(providerId: provider.ProviderId);
+            var adminUser = await TestData.CreateUser();
 
             var standard = await TestData.CreateStandard(standardCode: 1234, version: 1, standardName: "Test Standard");
-            var apprenticeshipId = (await TestData.CreateApprenticeship(providerId, standard, createdBy: User.ToUserInfo())).Id;
+            var apprenticeshipId = (await TestData.CreateApprenticeship(provider.ProviderId, standard, createdBy: User.ToUserInfo())).Id;
 
             var submissionId = await TestData.CreateApprenticeshipQASubmission(
-                providerId,
+                provider.ProviderId,
                 submittedOn: Clock.UtcNow,
-                submittedByUserId: providerUserId,
+                submittedByUserId: providerUser.UserId,
                 providerMarketingInformation: "The overview",
                 apprenticeshipIds: new[] { apprenticeshipId });
 
             var passedProviderAssessmentOn = Clock.UtcNow;
             await TestData.CreateApprenticeshipQAProviderAssessment(
                 submissionId,
-                assessedByUserId: adminUserId,
+                assessedByUserId: adminUser.UserId,
                 assessedOn: passedProviderAssessmentOn,
                 compliancePassed: true,
                 complianceComments: null,
@@ -190,8 +177,8 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
                 lastAssessedByUserId: User.UserId.ToString(),
                 lastAssessedOn: Clock.UtcNow);
 
-            await TestData.SetProviderApprenticeshipQAStatus(providerId, ApprenticeshipQAStatus.Passed);
-            await User.AsProviderSuperUser(providerId, ProviderType.Apprenticeships);
+            await TestData.SetProviderApprenticeshipQAStatus(provider.ProviderId, ApprenticeshipQAStatus.Passed);
+            await User.AsProviderSuperUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             // Act
             var response = await HttpClient.GetAsync("QANotificationsTests");
@@ -212,15 +199,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task PassedQANotification_Is_Not_Visible_For_MigratedPassedQAProviders()
         {
             // Arrange
-            var ukprn = 12345;
-            var adminUserId = $"admin-user";
-
-            var providerId = await TestData.CreateProvider(
-                ukprn: ukprn,
+            var provider = await TestData.CreateProvider(
                 providerName: "Provider 1",
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.Passed);
 
-            await User.AsProviderSuperUser(providerId, ProviderType.Apprenticeships);
+            await User.AsProviderSuperUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             // Act
             var response = await HttpClient.GetAsync("QANotificationsTests");
@@ -235,7 +218,6 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
 
             Assert.Empty(notificationElements);
         }
-
     }
 
     public class QANotificationsTestsController : Controller

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/NewApprenticeshipProvider/StandardSelectedTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/NewApprenticeshipProvider/StandardSelectedTests.cs
@@ -20,7 +20,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
         public async Task Get_StoresPassedStandardInState()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
 
             var standard = await TestData.CreateStandard(standardCode: 123, version: 1, standardName: "My standard");
@@ -32,7 +32,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
                 $"new-apprenticeship-provider/standard-selected?" +
-                $"providerId={providerId}&" +
+                $"providerId={provider.ProviderId}&" +
                 $"ffiid={mptxInstance.InstanceId}&" +
                 $"standardCode=123&version=1");
 
@@ -44,7 +44,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.NewApprenticeshipProvider
             // Assert
             response.StatusCode.Should().Be(HttpStatusCode.Found);
             response.Headers.Location.OriginalString.Should().Be(
-                $"/new-apprenticeship-provider/apprenticeship-details?ffiid={mptxInstance.InstanceId}&providerId={providerId}");
+                $"/new-apprenticeship-provider/apprenticeship-details?ffiid={mptxInstance.InstanceId}&providerId={provider.ProviderId}");
 
             using (new AssertionScope())
             {

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/ProviderDashboard/DashboardTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/ProviderDashboard/DashboardTests.cs
@@ -36,23 +36,21 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ProviderDashboard
         public async Task ValidRequest_RendersExpectedOutput()
         {
             // Arrange
-            var ukprn = 12345;
             var providerName = "Test provider";
 
-            var providerId = await TestData.CreateProvider(
-                ukprn,
+            var provider = await TestData.CreateProvider(
                 providerName,
                 providerType: ProviderType.Apprenticeships | ProviderType.FE | ProviderType.TLevels,
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.Passed);
 
             var tLevelDefinitions = await TestData.CreateInitialTLevelDefinitions();
-            var venues = await CreateVenues(providerId, count: 2);
+            var venues = await CreateVenues(provider.ProviderId, count: 2);
 
-            await CreateCourses(providerId, count: 5);
-            await CreateApprenticeships(providerId, count: 3);
-            await CreateTLevels(providerId, tLevelDefinitions, venues, 4);
+            await CreateCourses(provider.ProviderId, count: 5);
+            await CreateApprenticeships(provider.ProviderId, count: 3);
+            await CreateTLevels(provider.ProviderId, tLevelDefinitions, venues, 4);
 
-            var request = new HttpRequestMessage(HttpMethod.Get, $"/dashboard?providerId={providerId}");
+            var request = new HttpRequestMessage(HttpMethod.Get, $"/dashboard?providerId={provider.ProviderId}");
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -61,7 +59,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ProviderDashboard
             response.StatusCode.Should().Be(HttpStatusCode.OK);
 
             var doc = await response.GetDocument();
-            doc.GetElementByTestId("ukprn").TextContent.Should().Be(ukprn.ToString());
+            doc.GetElementByTestId("ukprn").TextContent.Should().Be(provider.Ukprn.ToString());
             doc.GetElementByTestId("provider-name").TextContent.Should().Be(providerName);
 
             doc.GetElementByTestId("courses-row").TextContent.Should().NotBeNull();
@@ -82,11 +80,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ProviderDashboard
         public async Task HasNotPassedQA_DoesNotRenderApprenticeshipsRow(ApprenticeshipQAStatus qaStatus)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.Apprenticeships,
                 apprenticeshipQAStatus: qaStatus);
 
-            var request = new HttpRequestMessage(HttpMethod.Get, $"/dashboard?providerId={providerId}");
+            var request = new HttpRequestMessage(HttpMethod.Get, $"/dashboard?providerId={provider.ProviderId}");
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -102,9 +100,9 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ProviderDashboard
         public async Task ProviderHasNoVenues_DoesNotRenderViewAndEditLink()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(providerType: ProviderType.FE);
+            var provider = await TestData.CreateProvider(providerType: ProviderType.FE);
 
-            var request = new HttpRequestMessage(HttpMethod.Get, $"/dashboard?providerId={providerId}");
+            var request = new HttpRequestMessage(HttpMethod.Get, $"/dashboard?providerId={provider.ProviderId}");
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -120,11 +118,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ProviderDashboard
         public async Task ProviderHasVenues_DoesRenderViewAndEditLink()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(providerType: ProviderType.FE);
+            var provider = await TestData.CreateProvider(providerType: ProviderType.FE);
 
-            await CreateVenues(providerId, count: 1);
+            await CreateVenues(provider.ProviderId, count: 1);
 
-            var request = new HttpRequestMessage(HttpMethod.Get, $"/dashboard?providerId={providerId}");
+            var request = new HttpRequestMessage(HttpMethod.Get, $"/dashboard?providerId={provider.ProviderId}");
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -140,9 +138,9 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ProviderDashboard
         public async Task FEProviderHasNoCourses_DoesNotRenderViewAndEditLink()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(providerType: ProviderType.FE);
+            var provider = await TestData.CreateProvider(providerType: ProviderType.FE);
 
-            var request = new HttpRequestMessage(HttpMethod.Get, $"/dashboard?providerId={providerId}");
+            var request = new HttpRequestMessage(HttpMethod.Get, $"/dashboard?providerId={provider.ProviderId}");
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -158,11 +156,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ProviderDashboard
         public async Task FEProviderHasCourses_DoesRenderViewAndEditLink()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(providerType: ProviderType.FE);
+            var provider = await TestData.CreateProvider(providerType: ProviderType.FE);
 
-            await CreateCourses(providerId, count: 1);
+            await CreateCourses(provider.ProviderId, count: 1);
 
-            var request = new HttpRequestMessage(HttpMethod.Get, $"/dashboard?providerId={providerId}");
+            var request = new HttpRequestMessage(HttpMethod.Get, $"/dashboard?providerId={provider.ProviderId}");
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -178,11 +176,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ProviderDashboard
         public async Task ApprenticeshipProviderHasNoApprenticeships_DoesNotRenderViewAndEditLink()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.Apprenticeships,
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.Passed);
 
-            var request = new HttpRequestMessage(HttpMethod.Get, $"/dashboard?providerId={providerId}");
+            var request = new HttpRequestMessage(HttpMethod.Get, $"/dashboard?providerId={provider.ProviderId}");
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -198,13 +196,13 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ProviderDashboard
         public async Task ApprenticeshipProviderHasApprenticeships_DoesRenderViewAndEditLink()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.Apprenticeships,
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.Passed);
 
-            await CreateApprenticeships(providerId, count: 1);
+            await CreateApprenticeships(provider.ProviderId, count: 1);
 
-            var request = new HttpRequestMessage(HttpMethod.Get, $"/dashboard?providerId={providerId}");
+            var request = new HttpRequestMessage(HttpMethod.Get, $"/dashboard?providerId={provider.ProviderId}");
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -220,10 +218,10 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ProviderDashboard
         public async Task TLevelsProviderHasNoTLevels_DoesNotRenderViewAndEditLink()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels);
 
-            var request = new HttpRequestMessage(HttpMethod.Get, $"/dashboard?providerId={providerId}");
+            var request = new HttpRequestMessage(HttpMethod.Get, $"/dashboard?providerId={provider.ProviderId}");
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -239,14 +237,14 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ProviderDashboard
         public async Task TLevelsProviderHasTLevels_DoesRenderViewAndEditLink()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels);
 
             var tLevelDefinitions = await TestData.CreateInitialTLevelDefinitions();
-            var venues = await CreateVenues(providerId, count: 2);
-            await CreateTLevels(providerId, tLevelDefinitions, venues, 3);
+            var venues = await CreateVenues(provider.ProviderId, count: 2);
+            await CreateTLevels(provider.ProviderId, tLevelDefinitions, venues, 3);
 
-            var request = new HttpRequestMessage(HttpMethod.Get, $"/dashboard?providerId={providerId}");
+            var request = new HttpRequestMessage(HttpMethod.Get, $"/dashboard?providerId={provider.ProviderId}");
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -262,20 +260,20 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ProviderDashboard
         public async Task Notifications_WithPastStartDateRunCountGreaterThanZero_DisplaysCourseStartDatesNotification()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.FE);
 
             await TestData.CreateCourse(
-                    providerId,
-                    createdBy: User.ToUserInfo(),
-                    configureCourseRuns: courseRunBuilder =>
-                        courseRunBuilder.WithCourseRun(
-                            CourseDeliveryMode.ClassroomBased,
-                            CourseStudyMode.FullTime,
-                            CourseAttendancePattern.Daytime,
-                            startDate: Clock.UtcNow.AddMonths(-1).Date));
+                provider.ProviderId,
+                createdBy: User.ToUserInfo(),
+                configureCourseRuns: courseRunBuilder =>
+                    courseRunBuilder.WithCourseRun(
+                        CourseDeliveryMode.ClassroomBased,
+                        CourseStudyMode.FullTime,
+                        CourseAttendancePattern.Daytime,
+                        startDate: Clock.UtcNow.AddMonths(-1).Date));
 
-            var request = new HttpRequestMessage(HttpMethod.Get, $"/dashboard?providerId={providerId}");
+            var request = new HttpRequestMessage(HttpMethod.Get, $"/dashboard?providerId={provider.ProviderId}");
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -293,20 +291,20 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ProviderDashboard
         public async Task Notifications_WithMigrationCourseStatusCourseRunCountGreaterThanZero_DisplaysMigrationNotification(CourseStatus courseStatus)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.FE);
 
             await TestData.CreateCourse(
-                    providerId,
-                    createdBy: User.ToUserInfo(),
-                    courseStatus: courseStatus,
-                    configureCourseRuns: courseRunBuilder =>
-                        courseRunBuilder.WithCourseRun(
-                            CourseDeliveryMode.ClassroomBased,
-                            CourseStudyMode.FullTime,
-                            CourseAttendancePattern.Daytime));
+                provider.ProviderId,
+                createdBy: User.ToUserInfo(),
+                courseStatus: courseStatus,
+                configureCourseRuns: courseRunBuilder =>
+                    courseRunBuilder.WithCourseRun(
+                        CourseDeliveryMode.ClassroomBased,
+                        CourseStudyMode.FullTime,
+                        CourseAttendancePattern.Daytime));
 
-            var request = new HttpRequestMessage(HttpMethod.Get, $"/dashboard?providerId={providerId}");
+            var request = new HttpRequestMessage(HttpMethod.Get, $"/dashboard?providerId={provider.ProviderId}");
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -322,11 +320,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ProviderDashboard
         public async Task Notifications_WithBulkUploadInProgress_DisplaysProcessingCoursesBulkUploadNotification()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.FE,
                 bulkUploadInProgress: true);
 
-            var request = new HttpRequestMessage(HttpMethod.Get, $"/dashboard?providerId={providerId}");
+            var request = new HttpRequestMessage(HttpMethod.Get, $"/dashboard?providerId={provider.ProviderId}");
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -342,20 +340,20 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ProviderDashboard
         public async Task Notifications_WithBulkUploadErrorOrPendingCountGreaterThanZero_DisplaysCoursesBulkUploadErrorNotification()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.FE);
 
             await TestData.CreateCourse(
-                    providerId,
-                    createdBy: User.ToUserInfo(),
-                    courseStatus: CourseStatus.BulkUploadPending,
-                    configureCourseRuns: courseRunBuilder =>
-                        courseRunBuilder.WithCourseRun(
-                            CourseDeliveryMode.ClassroomBased,
-                            CourseStudyMode.FullTime,
-                            CourseAttendancePattern.Daytime));
+                provider.ProviderId,
+                createdBy: User.ToUserInfo(),
+                courseStatus: CourseStatus.BulkUploadPending,
+                configureCourseRuns: courseRunBuilder =>
+                    courseRunBuilder.WithCourseRun(
+                        CourseDeliveryMode.ClassroomBased,
+                        CourseStudyMode.FullTime,
+                        CourseAttendancePattern.Daytime));
 
-            var request = new HttpRequestMessage(HttpMethod.Get, $"/dashboard?providerId={providerId}");
+            var request = new HttpRequestMessage(HttpMethod.Get, $"/dashboard?providerId={provider.ProviderId}");
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -371,20 +369,20 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ProviderDashboard
         public async Task Notification_WithBulkUploadReadyToGoLiveCourseRunCountGreaterThanZero_DisplaysCoursesBulkUploadSuccessfulNotification()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.FE);
 
             await TestData.CreateCourse(
-                    providerId,
-                    createdBy: User.ToUserInfo(),
-                    courseStatus: CourseStatus.BulkUploadReadyToGoLive,
-                    configureCourseRuns: courseRunBuilder =>
-                        courseRunBuilder.WithCourseRun(
-                            CourseDeliveryMode.ClassroomBased,
-                            CourseStudyMode.FullTime,
-                            CourseAttendancePattern.Daytime));
+                provider.ProviderId,
+                createdBy: User.ToUserInfo(),
+                courseStatus: CourseStatus.BulkUploadReadyToGoLive,
+                configureCourseRuns: courseRunBuilder =>
+                    courseRunBuilder.WithCourseRun(
+                        CourseDeliveryMode.ClassroomBased,
+                        CourseStudyMode.FullTime,
+                        CourseAttendancePattern.Daytime));
 
-            var request = new HttpRequestMessage(HttpMethod.Get, $"/dashboard?providerId={providerId}");
+            var request = new HttpRequestMessage(HttpMethod.Get, $"/dashboard?providerId={provider.ProviderId}");
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -400,18 +398,18 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ProviderDashboard
         public async Task Notification_WithBulkUploadReadyToGoLiveApprenticeshipsCountGreaterThanZero_DisplaysApprenticeshipsBulkUploadSuccessfulNotification()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.Apprenticeships);
 
             var standard = await TestData.CreateStandard(123, 456, "TestStandard");
 
             await TestData.CreateApprenticeship(
-                providerId,
+                provider.ProviderId,
                 standard,
                 User.ToUserInfo(),
                 ApprenticeshipStatus.BulkUploadReadyToGoLive);
 
-            var request = new HttpRequestMessage(HttpMethod.Get, $"/dashboard?providerId={providerId}");
+            var request = new HttpRequestMessage(HttpMethod.Get, $"/dashboard?providerId={provider.ProviderId}");
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -427,9 +425,9 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ProviderDashboard
         public async Task ProviderTypeNone_RendersNewProviderMessage()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(providerType: ProviderType.None);
+            var provider = await TestData.CreateProvider(providerType: ProviderType.None);
 
-            var request = new HttpRequestMessage(HttpMethod.Get, $"/dashboard?providerId={providerId}");
+            var request = new HttpRequestMessage(HttpMethod.Get, $"/dashboard?providerId={provider.ProviderId}");
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -448,9 +446,9 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ProviderDashboard
         public async Task ProviderTypeNotNone_DoesNotRenderNewProviderMessage(ProviderType providerType)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(providerType: providerType);
+            var provider = await TestData.CreateProvider(providerType: providerType);
 
-            var request = new HttpRequestMessage(HttpMethod.Get, $"/dashboard?providerId={providerId}");
+            var request = new HttpRequestMessage(HttpMethod.Get, $"/dashboard?providerId={provider.ProviderId}");
 
             // Act
             var response = await HttpClient.SendAsync(request);

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/ProviderSearch/ProviderSearchTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/ProviderSearch/ProviderSearchTests.cs
@@ -29,11 +29,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ProviderSearch
         public async Task ProviderSearch_Get_WithNonAdminUser_ReturnsForbidden(TestUserType testUserType)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
+            var provider = await TestData.CreateProvider();
 
             var request = new HttpRequestMessage(HttpMethod.Get, $"/provider-search");
 
-            await User.AsTestUser(testUserType, providerId);
+            await User.AsTestUser(testUserType, provider.ProviderId);
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -48,11 +48,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ProviderSearch
         public async Task ProviderSearch_Get_WithAdminUser_ReturnsExpectedContent(TestUserType testUserType)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
+            var provider = await TestData.CreateProvider();
 
             var request = new HttpRequestMessage(HttpMethod.Get, $"/provider-search");
 
-            await User.AsTestUser(testUserType, providerId);
+            await User.AsTestUser(testUserType, provider.ProviderId);
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -154,10 +154,10 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ProviderSearch
         public async Task OnboardProvider_Post_WithNonAdminUser_ReturnsForbidden(TestUserType testUserType)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
+            var provider = await TestData.CreateProvider();
 
             var requestContent = new FormUrlEncodedContentBuilder()
-                .Add(nameof(OnboardProviderCommand.ProviderId), providerId)
+                .Add(nameof(OnboardProviderCommand.ProviderId), provider.ProviderId)
                 .ToContent();
 
             var request = new HttpRequestMessage(HttpMethod.Post, $"/provider-search/onboard")
@@ -165,7 +165,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ProviderSearch
                 Content = requestContent
             };
 
-            await User.AsTestUser(testUserType, providerId);
+            await User.AsTestUser(testUserType, provider.ProviderId);
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -180,10 +180,10 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ProviderSearch
         public async Task OnboardProvider_Post_WithAdminUser_OnboardsProviderAndRedirects(TestUserType testUserType)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(status: ProviderStatus.Registered);
+            var provider = await TestData.CreateProvider(status: ProviderStatus.Registered);
 
             var requestContent = new FormUrlEncodedContentBuilder()
-                .Add(nameof(OnboardProviderCommand.ProviderId), providerId)
+                .Add(nameof(OnboardProviderCommand.ProviderId), provider.ProviderId)
                 .ToContent();
 
             var request = new HttpRequestMessage(HttpMethod.Post, $"/provider-search/onboard")
@@ -191,14 +191,14 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ProviderSearch
                 Content = requestContent
             };
 
-            await User.AsTestUser(testUserType, providerId);
+            await User.AsTestUser(testUserType, provider.ProviderId);
 
             // Act
             var response = await HttpClient.SendAsync(request);
 
             //Assert
             response.StatusCode.Should().Be(StatusCodes.Status302Found);
-            response.Headers.Location.OriginalString.Should().Be($"/dashboard?providerId={providerId}");
+            response.Headers.Location.OriginalString.Should().Be($"/dashboard?providerId={provider.ProviderId}");
         }
 
         [Fact]

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/Providers/DisplayNameTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/Providers/DisplayNameTests.cs
@@ -22,16 +22,16 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
         public async Task Get_ProviderUser_ReturnsForbidden()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.FE | ProviderType.Apprenticeships,
                 providerName: "Provider name",
                 alias: "Trading name");
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"providers/display-name?providerId={providerId}");
+                $"providers/display-name?providerId={provider.ProviderId}");
 
-            await User.AsProviderUser(providerId, ProviderType.FE | ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.FE | ProviderType.Apprenticeships);
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -61,13 +61,13 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
         public async Task Get_ProviderHasNoTradingName_ReturnsBadRequest()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerName: "Provider name",
                 alias: null);
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"providers/display-name?providerId={providerId}");
+                $"providers/display-name?providerId={provider.ProviderId}");
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -84,14 +84,14 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
             string expectedCheckedElementId)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerName: "Provider name",
                 alias: "Trading name",
                 displayNameSource: displayNameSource);
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"providers/display-name?providerId={providerId}");
+                $"providers/display-name?providerId={provider.ProviderId}");
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -107,7 +107,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
         public async Task Post_ProviderUser_ReturnsForbidden()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.FE | ProviderType.Apprenticeships,
                 providerName: "Provider name",
                 alias: "Trading name");
@@ -118,12 +118,12 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
 
             var request = new HttpRequestMessage(
                 HttpMethod.Post,
-                $"providers/display-name?providerId={providerId}")
+                $"providers/display-name?providerId={provider.ProviderId}")
             {
                 Content = content
             };
 
-            await User.AsProviderUser(providerId, ProviderType.FE | ProviderType.Apprenticeships);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.FE | ProviderType.Apprenticeships);
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -160,7 +160,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
         public async Task Post_ProviderHasNoTradingName_ReturnsBadRequest()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerName: "Provider name",
                 alias: null);
 
@@ -170,7 +170,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
 
             var request = new HttpRequestMessage(
                 HttpMethod.Post,
-                $"providers/display-name?providerId={providerId}")
+                $"providers/display-name?providerId={provider.ProviderId}")
             {
                 Content = content
             };
@@ -186,7 +186,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
         public async Task Post_ValidRequest_UpdatesDisplayNameSourceAndRedirects()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerName: "Provider name",
                 alias: "Trading name");
 
@@ -196,7 +196,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
 
             var request = new HttpRequestMessage(
                 HttpMethod.Post,
-                $"providers/display-name?providerId={providerId}")
+                $"providers/display-name?providerId={provider.ProviderId}")
             {
                 Content = content
             };
@@ -206,10 +206,10 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
 
             // Assert
             Assert.Equal(HttpStatusCode.Found, response.StatusCode);
-            Assert.Equal($"/providers?providerId={providerId}", response.Headers.Location.OriginalString);
+            Assert.Equal($"/providers?providerId={provider.ProviderId}", response.Headers.Location.OriginalString);
 
             SqlQuerySpy.VerifyQuery<SetProviderDisplayNameSource, OneOf<NotFound, Success>>(q =>
-                q.ProviderId == providerId && q.DisplayNameSource == Core.Models.ProviderDisplayNameSource.TradingName);
+                q.ProviderId == provider.ProviderId && q.DisplayNameSource == ProviderDisplayNameSource.TradingName);
         }
     }
 }

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/Providers/EditProviderInfoTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/Providers/EditProviderInfoTests.cs
@@ -21,14 +21,14 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
         public async Task Get_ProviderUser_ReturnsForbidden(TestUserType userType)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.Apprenticeships,
                 marketingInformation: "Current overview");
 
-            await User.AsTestUser(userType, providerId);
+            await User.AsTestUser(userType, provider.ProviderId);
 
             // Act
-            var response = await HttpClient.GetAsync($"/providers/info?providerId={providerId}");
+            var response = await HttpClient.GetAsync($"/providers/info?providerId={provider.ProviderId}");
 
             // Assert
             Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
@@ -39,14 +39,14 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
         public async Task Get_NotApprenticeshipProvider_ReturnsForbidden(ProviderType providerType)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: providerType,
                 marketingInformation: "Current overview");
 
             await User.AsHelpdesk();
 
             // Act
-            var response = await HttpClient.GetAsync($"/providers/info?providerId={providerId}");
+            var response = await HttpClient.GetAsync($"/providers/info?providerId={provider.ProviderId}");
 
             // Assert
             Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
@@ -58,14 +58,14 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
         public async Task Get_ValidRequest_RendersExpectedOutput(ProviderType providerType)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: providerType,
                 marketingInformation: "Current overview");
 
             await User.AsHelpdesk();
 
             // Act
-            var response = await HttpClient.GetAsync($"/providers/info?providerId={providerId}");
+            var response = await HttpClient.GetAsync($"/providers/info?providerId={provider.ProviderId}");
 
             // Assert
             response.EnsureSuccessStatusCode();
@@ -79,7 +79,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
         public async Task Post_NotApprenticeshipProvider_ReturnsForbidden(ProviderType providerType)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(providerType: providerType);
+            var provider = await TestData.CreateProvider(providerType: providerType);
 
             var requestContent = new FormUrlEncodedContentBuilder()
                 .Add("MarketingInformation", "Overview")
@@ -88,7 +88,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
             await User.AsHelpdesk();
 
             // Act
-            var response = await HttpClient.PostAsync($"/providers/info?providerId={providerId}", requestContent);
+            var response = await HttpClient.PostAsync($"/providers/info?providerId={provider.ProviderId}", requestContent);
 
             // Assert
             Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
@@ -100,16 +100,16 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
         public async Task Post_ProviderUser_ReturnsForbidden(TestUserType userType)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(providerType: ProviderType.Apprenticeships);
+            var provider = await TestData.CreateProvider(providerType: ProviderType.Apprenticeships);
 
             var requestContent = new FormUrlEncodedContentBuilder()
                 .Add("MarketingInformation", "Overview")
                 .ToContent();
 
-            await User.AsTestUser(userType, providerId);
+            await User.AsTestUser(userType, provider.ProviderId);
 
             // Act
-            var response = await HttpClient.PostAsync($"/providers/info?providerId={providerId}", requestContent);
+            var response = await HttpClient.PostAsync($"/providers/info?providerId={provider.ProviderId}", requestContent);
 
             // Assert
             Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
@@ -119,7 +119,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
         public async Task Post_InvalidMarketingInformation_RendersError()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(providerType: ProviderType.Apprenticeships);
+            var provider = await TestData.CreateProvider(providerType: ProviderType.Apprenticeships);
 
             var requestContent = new FormUrlEncodedContentBuilder()
                 .Add("MarketingInformation", new string('z', 751))  // Limit is 750 characters
@@ -128,7 +128,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
             await User.AsHelpdesk();
 
             // Act
-            var response = await HttpClient.PostAsync($"/providers/info?providerId={providerId}", requestContent);
+            var response = await HttpClient.PostAsync($"/providers/info?providerId={provider.ProviderId}", requestContent);
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -143,7 +143,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
         public async Task Post_ValidRequest_ReturnsRedirect()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(providerType: ProviderType.Apprenticeships);
+            var provider = await TestData.CreateProvider(providerType: ProviderType.Apprenticeships);
 
             var requestContent = new FormUrlEncodedContentBuilder()
                 .Add("MarketingInformation", "Overview")
@@ -152,11 +152,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
             await User.AsHelpdesk();
 
             // Act
-            var response = await HttpClient.PostAsync($"/providers/info?providerId={providerId}", requestContent);
+            var response = await HttpClient.PostAsync($"/providers/info?providerId={provider.ProviderId}", requestContent);
 
             // Assert
             Assert.Equal(HttpStatusCode.Found, response.StatusCode);
-            Assert.Equal($"/providers?providerId={providerId}", response.Headers.Location.OriginalString);
+            Assert.Equal($"/providers?providerId={provider.ProviderId}", response.Headers.Location.OriginalString);
         }
     }
 }

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/Providers/EditProviderTypeTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/Providers/EditProviderTypeTests.cs
@@ -32,11 +32,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
         public async Task Get_UserCannotEditProviderType_ReturnsForbidden(TestUserType userType)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
+            var provider = await TestData.CreateProvider();
 
-            var request = new HttpRequestMessage(HttpMethod.Get, $"providers/provider-type?providerId={providerId}");
+            var request = new HttpRequestMessage(HttpMethod.Get, $"providers/provider-type?providerId={provider.ProviderId}");
 
-            await User.AsTestUser(userType, providerId);
+            await User.AsTestUser(userType, provider.ProviderId);
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -64,9 +64,9 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
         public async Task Get_ValidRequestNoneProviderType_RendersExpectedOutput()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(providerType: ProviderType.None);
+            var provider = await TestData.CreateProvider(providerType: ProviderType.None);
 
-            var request = new HttpRequestMessage(HttpMethod.Get, $"providers/provider-type?providerId={providerId}");
+            var request = new HttpRequestMessage(HttpMethod.Get, $"providers/provider-type?providerId={provider.ProviderId}");
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -93,11 +93,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
             IEnumerable<string> expectedCheckedTestIds)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(providerType: providerType);
+            var provider = await TestData.CreateProvider(providerType: providerType);
 
             var tLevelDefinitionIds = await Task.WhenAll(Enumerable.Range(0, 3).Select(_ => TestData.CreateTLevelDefinition()));
 
-            var request = new HttpRequestMessage(HttpMethod.Get, $"providers/provider-type?providerId={providerId}");
+            var request = new HttpRequestMessage(HttpMethod.Get, $"providers/provider-type?providerId={provider.ProviderId}");
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -144,16 +144,16 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
             IEnumerable<int> expectedSelectedTLevelDefinitionIds)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(providerType: providerType);
+            var provider = await TestData.CreateProvider(providerType: providerType);
 
             var parsedTLevelDefinitionIds = tLevelDefinitionIds.Select(ToGuid).ToArray();
             var parsedSelectedTLevelDefinitionIds = selectedTLevelDefinitionIds.Select(ToGuid).ToArray();
             var parsedExpectedSelectedTLevelDefinitionIds = expectedSelectedTLevelDefinitionIds.Select(ToGuid).ToArray();
 
             await Task.WhenAll(parsedTLevelDefinitionIds.Select(id => TestData.CreateTLevelDefinition(tLevelDefinitionId: id)));
-            await TestData.SetProviderTLevelDefinitions(providerId, parsedSelectedTLevelDefinitionIds);
+            await TestData.SetProviderTLevelDefinitions(provider.ProviderId, parsedSelectedTLevelDefinitionIds);
 
-            var request = new HttpRequestMessage(HttpMethod.Get, $"providers/provider-type?providerId={providerId}");
+            var request = new HttpRequestMessage(HttpMethod.Get, $"providers/provider-type?providerId={provider.ProviderId}");
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -186,18 +186,18 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
         public async Task Post_UserCannotEditProviderType_ReturnsForbidden(TestUserType userType)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
+            var provider = await TestData.CreateProvider();
 
             var content = new FormUrlEncodedContentBuilder()
                 .Add(nameof(Command.ProviderType), (int)ProviderType.FE)
                 .ToContent();
 
-            var request = new HttpRequestMessage(HttpMethod.Post, $"providers/provider-type?providerId={providerId}")
+            var request = new HttpRequestMessage(HttpMethod.Post, $"providers/provider-type?providerId={provider.ProviderId}")
             {
                 Content = content
             };
 
-            await User.AsTestUser(userType, providerId);
+            await User.AsTestUser(userType, provider.ProviderId);
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -232,14 +232,14 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
         public async Task Post_ProviderIdAndProviderContextProviderIdDoNotMatch_ReturnsBadRequest()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(providerType: ProviderType.None);
+            var provider = await TestData.CreateProvider(providerType: ProviderType.None);
 
             var content = new FormUrlEncodedContentBuilder()
                 .Add(nameof(Command.ProviderType), (int)ProviderType.FE)
                 .Add("ProviderId", Guid.NewGuid())
                 .ToContent();
 
-            var request = new HttpRequestMessage(HttpMethod.Post, $"providers/provider-type?providerId={providerId}")
+            var request = new HttpRequestMessage(HttpMethod.Post, $"providers/provider-type?providerId={provider.ProviderId}")
             {
                 Content = content
             };
@@ -258,13 +258,13 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
         public async Task Post_ValidRequest_UpdatesProviderTypeAndRedirects(ProviderType providerType)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(providerType: ProviderType.None);
+            var provider = await TestData.CreateProvider(providerType: ProviderType.None);
 
             var content = new FormUrlEncodedContentBuilder()
                 .Add(nameof(Command.ProviderType), (int)providerType)
                 .ToContent();
 
-            var request = new HttpRequestMessage(HttpMethod.Post, $"providers/provider-type?providerId={providerId}")
+            var request = new HttpRequestMessage(HttpMethod.Post, $"providers/provider-type?providerId={provider.ProviderId}")
             {
                 Content = content
             };
@@ -274,10 +274,10 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
 
             // Assert
             response.StatusCode.Should().Be(HttpStatusCode.Found);
-            response.Headers.Location.OriginalString.Should().Be($"/providers?providerId={providerId}");
+            response.Headers.Location.OriginalString.Should().Be($"/providers?providerId={provider.ProviderId}");
 
             CosmosDbQueryDispatcher.VerifyExecuteQuery<UpdateProviderType, OneOf<NotFound, Success>>(q =>
-                q.ProviderId == providerId && q.ProviderType == providerType);
+                q.ProviderId == provider.ProviderId && q.ProviderType == providerType);
         }
 
         [Theory]
@@ -288,7 +288,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
         public async Task Post_WithTLevelsAndSelectedTLevelDefinitions_UpdatesProviderTypeAndSelectedTLevelDefinitionsAndRedirects(ProviderType providerType)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(providerType: ProviderType.None);
+            var provider = await TestData.CreateProvider(providerType: ProviderType.None);
 
             var tLevelDefinitionIds = (await Task.WhenAll(Enumerable.Range(0, 3).Select(_ => TestData.CreateTLevelDefinition())))
                 .OrderBy(_ => Guid.NewGuid())
@@ -303,7 +303,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
                 contentBuilder.Add(nameof(Command.SelectedProviderTLevelDefinitionIds), tLevelDefinitionId);
             }
 
-            var request = new HttpRequestMessage(HttpMethod.Post, $"providers/provider-type?providerId={providerId}")
+            var request = new HttpRequestMessage(HttpMethod.Post, $"providers/provider-type?providerId={provider.ProviderId}")
             {
                 Content = contentBuilder.ToContent()
             };
@@ -313,13 +313,13 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
 
             // Assert
             response.StatusCode.Should().Be(HttpStatusCode.Found);
-            response.Headers.Location.OriginalString.Should().Be($"/providers?providerId={providerId}");
+            response.Headers.Location.OriginalString.Should().Be($"/providers?providerId={provider.ProviderId}");
 
             CosmosDbQueryDispatcher.VerifyExecuteQuery<UpdateProviderType, OneOf<NotFound, Success>>(q =>
-                q.ProviderId == providerId && q.ProviderType == providerType);
+                q.ProviderId == provider.ProviderId && q.ProviderType == providerType);
 
             SqlQuerySpy.VerifyQuery<SetProviderTLevelDefinitions, (IReadOnlyCollection<Guid>, IReadOnlyCollection<Guid>)>(query =>
-                query.ProviderId == providerId
+                query.ProviderId == provider.ProviderId
                 && query.TLevelDefinitionIds.SequenceEqual(tLevelDefinitionIds));
         }
 
@@ -331,14 +331,14 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
         public async Task Post_WithTLevelsAndNoSelectedTLevelDefinitions_DoesNotUpdateProviderTypeOrSelectedTLevelDefinitionsAndReturnsViewWithErrorMessage(ProviderType providerType)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(providerType: ProviderType.None);
+            var provider = await TestData.CreateProvider(providerType: ProviderType.None);
 
             await Task.WhenAll(Enumerable.Range(0, 3).Select(_ => TestData.CreateTLevelDefinition()));
 
             var contentBuilder = new FormUrlEncodedContentBuilder()
                 .Add(nameof(Command.ProviderType), (int)providerType);
 
-            var request = new HttpRequestMessage(HttpMethod.Post, $"providers/provider-type?providerId={providerId}")
+            var request = new HttpRequestMessage(HttpMethod.Post, $"providers/provider-type?providerId={provider.ProviderId}")
             {
                 Content = contentBuilder.ToContent()
             };
@@ -353,14 +353,14 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
             doc.AssertHasError(nameof(Command.SelectedProviderTLevelDefinitionIds), "Select the T Levels this provider can offer");
 
             CosmosDbQueryDispatcher.VerifyExecuteQuery<UpdateProviderType, OneOf<NotFound, Success>>(q =>
-                q.ProviderId == providerId && q.ProviderType == providerType, Times.Never());
+                q.ProviderId == provider.ProviderId && q.ProviderType == providerType, Times.Never());
         }
 
         [Fact]
         public async Task Post_WithTLevelsProviderAndInvalidTLevelDefinitionId_DoesNotUpdateProviderTypeOrSelectedTLevelDefinitionsAndReturnsViewWithErrorMessage()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(providerType: ProviderType.None);
+            var provider = await TestData.CreateProvider(providerType: ProviderType.None);
 
             var tLevelDefinitionIds = await Task.WhenAll(Enumerable.Range(0, 3).Select(_ => TestData.CreateTLevelDefinition()));
             var selectedTLevelDefinitionIds = tLevelDefinitionIds.OrderBy(_ => Guid.NewGuid()).Take(2).ToArray();
@@ -375,7 +375,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
 
             contentBuilder.Add(nameof(Command.SelectedProviderTLevelDefinitionIds), Guid.NewGuid());
 
-            var request = new HttpRequestMessage(HttpMethod.Post, $"providers/provider-type?providerId={providerId}")
+            var request = new HttpRequestMessage(HttpMethod.Post, $"providers/provider-type?providerId={provider.ProviderId}")
             {
                 Content = contentBuilder.ToContent()
             };
@@ -390,7 +390,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
             doc.AssertHasError(nameof(Command.SelectedProviderTLevelDefinitionIds), "Select a valid T Level");
 
             CosmosDbQueryDispatcher.VerifyExecuteQuery<UpdateProviderType, OneOf<NotFound, Success>>(q =>
-                q.ProviderId == providerId && q.ProviderType == ProviderType.TLevels, Times.Never());
+                q.ProviderId == provider.ProviderId && q.ProviderType == ProviderType.TLevels, Times.Never());
         }
 
         [Theory]
@@ -401,14 +401,14 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
         public async Task Post_WithTLevelsProviderWithSelectedTLevelDefinitions_UpdatesProviderTypeAndRemovesSelectedTLevelDefinitionsAndRedirects(ProviderType newProviderType)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(providerType: ProviderType.TLevels);
+            var provider = await TestData.CreateProvider(providerType: ProviderType.TLevels);
 
             var tLevelDefinitionIds = (await Task.WhenAll(Enumerable.Range(0, 3).Select(_ => TestData.CreateTLevelDefinition())))
                 .OrderBy(_ => Guid.NewGuid())
                 .Take(2)
                 .ToArray();
 
-            await TestData.SetProviderTLevelDefinitions(providerId, tLevelDefinitionIds);
+            await TestData.SetProviderTLevelDefinitions(provider.ProviderId, tLevelDefinitionIds);
 
             var contentBuilder = new FormUrlEncodedContentBuilder()
                 .Add(nameof(Command.ProviderType), (int)newProviderType);
@@ -418,7 +418,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
                 contentBuilder.Add(nameof(Command.SelectedProviderTLevelDefinitionIds), tLevelDefinitionId);
             }
 
-            var request = new HttpRequestMessage(HttpMethod.Post, $"providers/provider-type?providerId={providerId}")
+            var request = new HttpRequestMessage(HttpMethod.Post, $"providers/provider-type?providerId={provider.ProviderId}")
             {
                 Content = contentBuilder.ToContent()
             };
@@ -428,13 +428,13 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
 
             // Assert
             response.StatusCode.Should().Be(HttpStatusCode.Found);
-            response.Headers.Location.OriginalString.Should().Be($"/providers?providerId={providerId}");
+            response.Headers.Location.OriginalString.Should().Be($"/providers?providerId={provider.ProviderId}");
 
             CosmosDbQueryDispatcher.VerifyExecuteQuery<UpdateProviderType, OneOf<NotFound, Success>>(q =>
-                q.ProviderId == providerId && q.ProviderType == newProviderType);
+                q.ProviderId == provider.ProviderId && q.ProviderType == newProviderType);
 
             SqlQuerySpy.VerifyQuery<SetProviderTLevelDefinitions, (IReadOnlyCollection<Guid>, IReadOnlyCollection<Guid>)>(query =>
-                query.ProviderId == providerId
+                query.ProviderId == provider.ProviderId
                 && query.TLevelDefinitionIds.SequenceEqual(Enumerable.Empty<Guid>()));
         }
 
@@ -448,26 +448,26 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
             // Arrange
             var tLevelDefinitions = await TestData.CreateInitialTLevelDefinitions();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray());
 
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
             var tLevels = await Task.WhenAll(
                 TestData.CreateTLevel(
-                    providerId,
+                    provider.ProviderId,
                     tLevelDefinitions.First().TLevelDefinitionId,
                     locationVenueIds: new[] { venueId },
                     createdBy: User.ToUserInfo()),
                 TestData.CreateTLevel(
-                    providerId,
+                    provider.ProviderId,
                     tLevelDefinitions.First().TLevelDefinitionId,
                     locationVenueIds: new[] { venueId },
                     createdBy: User.ToUserInfo(),
                     startDate: new DateTime(2022, 01, 01)),
                 TestData.CreateTLevel(
-                    providerId,
+                    provider.ProviderId,
                     tLevelDefinitions.Skip(1).First().TLevelDefinitionId,
                     locationVenueIds: new[] { venueId },
                     createdBy: User.ToUserInfo())
@@ -477,7 +477,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
                 .Add(nameof(Command.ProviderType), (int)newProviderType)
                 .ToContent();
 
-            var request = new HttpRequestMessage(HttpMethod.Post, $"providers/provider-type?providerId={providerId}")
+            var request = new HttpRequestMessage(HttpMethod.Post, $"providers/provider-type?providerId={provider.ProviderId}")
             {
                 Content = content
             };
@@ -490,7 +490,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
 
             var doc = await response.GetDocument();
 
-            doc.GetElementByTestId("provider-id").GetAttribute("value").Should().Be(providerId.ToString());
+            doc.GetElementByTestId("provider-id").GetAttribute("value").Should().Be(provider.ProviderId.ToString());
             doc.GetElementByTestId("provider-type").GetAttribute("value").Should().Be(((int)newProviderType).ToString());
             doc.GetElementByTestId("affected-tLevel-ids-checksum").GetAttribute("value").Should().Be(Convert.ToBase64String(tLevels.OrderBy(t => t.TLevelId).SelectMany(t => t.TLevelId.ToByteArray()).ToArray()));
             doc.GetAllElementsByTestId("affected-item").Select(i => i.TextContent).Should().Equal(
@@ -513,26 +513,26 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
             // Arrange
             var tLevelDefinitions = await TestData.CreateInitialTLevelDefinitions();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray());
 
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
             var tLevels = await Task.WhenAll(
                 TestData.CreateTLevel(
-                    providerId,
+                    provider.ProviderId,
                     tLevelDefinitions.First().TLevelDefinitionId,
                     locationVenueIds: new[] { venueId },
                     createdBy: User.ToUserInfo()),
                 TestData.CreateTLevel(
-                    providerId,
+                    provider.ProviderId,
                     tLevelDefinitions.First().TLevelDefinitionId,
                     locationVenueIds: new[] { venueId },
                     createdBy: User.ToUserInfo(),
                     startDate: new DateTime(2022, 01, 01)),
                 TestData.CreateTLevel(
-                    providerId,
+                    provider.ProviderId,
                     tLevelDefinitions.Skip(1).First().TLevelDefinitionId,
                     locationVenueIds: new[] { venueId },
                     createdBy: User.ToUserInfo())
@@ -544,7 +544,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
                 .Add(nameof(Command.Confirm), null)
                 .ToContent();
 
-            var request = new HttpRequestMessage(HttpMethod.Post, $"providers/provider-type?providerId={providerId}")
+            var request = new HttpRequestMessage(HttpMethod.Post, $"providers/provider-type?providerId={provider.ProviderId}")
             {
                 Content = content
             };
@@ -558,7 +558,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
             var doc = await response.GetDocument();
 
             doc.GetElementByTestId("confirm-error").TextContent.Should().Be("Select yes to permanently delete");
-            doc.GetElementByTestId("provider-id").GetAttribute("value").Should().Be(providerId.ToString());
+            doc.GetElementByTestId("provider-id").GetAttribute("value").Should().Be(provider.ProviderId.ToString());
             doc.GetElementByTestId("provider-type").GetAttribute("value").Should().Be(((int)newProviderType).ToString());
             doc.GetElementByTestId("affected-tLevel-ids-checksum").GetAttribute("value").Should().Be(Convert.ToBase64String(tLevels.OrderBy(t => t.TLevelId).SelectMany(t => t.TLevelId.ToByteArray()).ToArray()));
             doc.GetAllElementsByTestId("affected-item").Select(i => i.TextContent).Should().Equal(
@@ -581,26 +581,26 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
             // Arrange
             var tLevelDefinitions = await TestData.CreateInitialTLevelDefinitions();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray());
 
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
             var tLevels = await Task.WhenAll(
                 TestData.CreateTLevel(
-                    providerId,
+                    provider.ProviderId,
                     tLevelDefinitions.First().TLevelDefinitionId,
                     locationVenueIds: new[] { venueId },
                     createdBy: User.ToUserInfo()),
                 TestData.CreateTLevel(
-                    providerId,
+                    provider.ProviderId,
                     tLevelDefinitions.First().TLevelDefinitionId,
                     locationVenueIds: new[] { venueId },
                     createdBy: User.ToUserInfo(),
                     startDate: new DateTime(2022, 01, 01)),
                 TestData.CreateTLevel(
-                    providerId,
+                    provider.ProviderId,
                     tLevelDefinitions.Skip(1).First().TLevelDefinitionId,
                     locationVenueIds: new[] { venueId },
                     createdBy: User.ToUserInfo())
@@ -612,7 +612,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
                 .Add(nameof(Command.Confirm), false)
                 .ToContent();
 
-            var request = new HttpRequestMessage(HttpMethod.Post, $"providers/provider-type?providerId={providerId}")
+            var request = new HttpRequestMessage(HttpMethod.Post, $"providers/provider-type?providerId={provider.ProviderId}")
             {
                 Content = content
             };
@@ -622,7 +622,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
 
             // Assert
             response.StatusCode.Should().Be(StatusCodes.Status302Found);
-            response.Headers.Location.OriginalString.Should().Be($"/providers/provider-type?providerId={providerId}");
+            response.Headers.Location.OriginalString.Should().Be($"/providers/provider-type?providerId={provider.ProviderId}");
 
             foreach (var tLevel in tLevels)
             {
@@ -641,26 +641,26 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
             // Arrange
             var tLevelDefinitions = await TestData.CreateInitialTLevelDefinitions();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray());
 
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
             var tLevels = await Task.WhenAll(
                 TestData.CreateTLevel(
-                    providerId,
+                    provider.ProviderId,
                     tLevelDefinitions.First().TLevelDefinitionId,
                     locationVenueIds: new[] { venueId },
                     createdBy: User.ToUserInfo()),
                 TestData.CreateTLevel(
-                    providerId,
+                    provider.ProviderId,
                     tLevelDefinitions.First().TLevelDefinitionId,
                     locationVenueIds: new[] { venueId },
                     createdBy: User.ToUserInfo(),
                     startDate: new DateTime(2022, 01, 01)),
                 TestData.CreateTLevel(
-                    providerId,
+                    provider.ProviderId,
                     tLevelDefinitions.Skip(1).First().TLevelDefinitionId,
                     locationVenueIds: new[] { venueId },
                     createdBy: User.ToUserInfo())
@@ -672,7 +672,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
                 .Add(nameof(Command.Confirm), true)
                 .ToContent();
 
-            var request = new HttpRequestMessage(HttpMethod.Post, $"providers/provider-type?providerId={providerId}")
+            var request = new HttpRequestMessage(HttpMethod.Post, $"providers/provider-type?providerId={provider.ProviderId}")
             {
                 Content = content
             };
@@ -686,7 +686,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
             var doc = await response.GetDocument();
 
             doc.GetElementByTestId("affected-item-counts-error").TextContent.Should().Be("The affected T Levels have changed");
-            doc.GetElementByTestId("provider-id").GetAttribute("value").Should().Be(providerId.ToString());
+            doc.GetElementByTestId("provider-id").GetAttribute("value").Should().Be(provider.ProviderId.ToString());
             doc.GetElementByTestId("provider-type").GetAttribute("value").Should().Be(((int)newProviderType).ToString());
             doc.GetElementByTestId("affected-tLevel-ids-checksum").GetAttribute("value").Should().Be(Convert.ToBase64String(tLevels.OrderBy(t => t.TLevelId).SelectMany(t => t.TLevelId.ToByteArray()).ToArray()));
             doc.GetAllElementsByTestId("affected-item").Select(i => i.TextContent).Should().Equal(
@@ -709,26 +709,26 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
             // Arrange
             var tLevelDefinitions = await TestData.CreateInitialTLevelDefinitions();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray());
 
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
             var tLevels = await Task.WhenAll(
                 TestData.CreateTLevel(
-                    providerId,
+                    provider.ProviderId,
                     tLevelDefinitions.First().TLevelDefinitionId,
                     locationVenueIds: new[] { venueId },
                     createdBy: User.ToUserInfo()),
                 TestData.CreateTLevel(
-                    providerId,
+                    provider.ProviderId,
                     tLevelDefinitions.First().TLevelDefinitionId,
                     locationVenueIds: new[] { venueId },
                     createdBy: User.ToUserInfo(),
                     startDate: new DateTime(2022, 01, 01)),
                 TestData.CreateTLevel(
-                    providerId,
+                    provider.ProviderId,
                     tLevelDefinitions.Skip(1).First().TLevelDefinitionId,
                     locationVenueIds: new[] { venueId },
                     createdBy: User.ToUserInfo())
@@ -740,7 +740,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
                 .Add(nameof(Command.Confirm), true)
                 .ToContent();
 
-            var request = new HttpRequestMessage(HttpMethod.Post, $"providers/provider-type?providerId={providerId}")
+            var request = new HttpRequestMessage(HttpMethod.Post, $"providers/provider-type?providerId={provider.ProviderId}")
             {
                 Content = content
             };
@@ -750,7 +750,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
 
             // Assert
             response.StatusCode.Should().Be(StatusCodes.Status302Found);
-            response.Headers.Location.OriginalString.Should().Be($"/providers?providerId={providerId}");
+            response.Headers.Location.OriginalString.Should().Be($"/providers?providerId={provider.ProviderId}");
 
             foreach (var tLevel in tLevels)
             {
@@ -771,14 +771,14 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
 
             var providerTLevelDefinitionIds = tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: providerTLevelDefinitionIds);
 
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
             var tLevel = await TestData.CreateTLevel(
-                providerId,
+                provider.ProviderId,
                 tLevelDefinitions.First().TLevelDefinitionId,
                 locationVenueIds: new[] { venueId },
                 createdBy: User.ToUserInfo());
@@ -788,7 +788,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
                 .Add(nameof(Command.SelectedProviderTLevelDefinitionIds), providerTLevelDefinitionIds)
                 .ToContent();
 
-            var request = new HttpRequestMessage(HttpMethod.Post, $"providers/provider-type?providerId={providerId}")
+            var request = new HttpRequestMessage(HttpMethod.Post, $"providers/provider-type?providerId={provider.ProviderId}")
             {
                 Content = content
             };
@@ -798,7 +798,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
 
             // Assert
             response.StatusCode.Should().Be(StatusCodes.Status302Found);
-            response.Headers.Location.OriginalString.Should().Be($"/providers?providerId={providerId}");
+            response.Headers.Location.OriginalString.Should().Be($"/providers?providerId={provider.ProviderId}");
 
             tLevel = await WithSqlQueryDispatcher(dispatcher => dispatcher.ExecuteQuery(
                 new GetTLevel() { TLevelId = tLevel.TLevelId }));
@@ -812,18 +812,18 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
             // Arrange
             var tLevelDefinitions = await TestData.CreateInitialTLevelDefinitions();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray());
 
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
             var keepingTLevelDefinitionId = tLevelDefinitions.First().TLevelDefinitionId;
             var removingTLevelDefinitionId = tLevelDefinitions.Last().TLevelDefinitionId;
             keepingTLevelDefinitionId.Should().NotBe(removingTLevelDefinitionId);
 
             var tLevel1 = await TestData.CreateTLevel(
-                providerId,
+                provider.ProviderId,
                 keepingTLevelDefinitionId,
                 locationVenueIds: new[] { venueId },
                 createdBy: User.ToUserInfo());
@@ -833,7 +833,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
                 .Add(nameof(Command.SelectedProviderTLevelDefinitionIds), keepingTLevelDefinitionId)
                 .ToContent();
 
-            var request = new HttpRequestMessage(HttpMethod.Post, $"providers/provider-type?providerId={providerId}")
+            var request = new HttpRequestMessage(HttpMethod.Post, $"providers/provider-type?providerId={provider.ProviderId}")
             {
                 Content = content
             };
@@ -843,7 +843,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
 
             // Assert
             response.StatusCode.Should().Be(StatusCodes.Status302Found);
-            response.Headers.Location.OriginalString.Should().Be($"/providers?providerId={providerId}");
+            response.Headers.Location.OriginalString.Should().Be($"/providers?providerId={provider.ProviderId}");
 
             tLevel1 = await WithSqlQueryDispatcher(dispatcher => dispatcher.ExecuteQuery(
                 new GetTLevel() { TLevelId = tLevel1.TLevelId }));
@@ -856,24 +856,24 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
             // Arrange
             var tLevelDefinitions = await TestData.CreateInitialTLevelDefinitions();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray());
 
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
             var keepingTLevelDefinitionId = tLevelDefinitions.First().TLevelDefinitionId;
             var removingTLevelDefinitionId = tLevelDefinitions.Last().TLevelDefinitionId;
             keepingTLevelDefinitionId.Should().NotBe(removingTLevelDefinitionId);
 
             var tLevel1 = await TestData.CreateTLevel(
-                providerId,
+                provider.ProviderId,
                 keepingTLevelDefinitionId,
                 locationVenueIds: new[] { venueId },
                 createdBy: User.ToUserInfo());
 
             var tLevel2 = await TestData.CreateTLevel(
-                providerId,
+                provider.ProviderId,
                 removingTLevelDefinitionId,
                 locationVenueIds: new[] { venueId },
                 createdBy: User.ToUserInfo());
@@ -883,7 +883,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
                 .Add(nameof(Command.SelectedProviderTLevelDefinitionIds), keepingTLevelDefinitionId)
                 .ToContent();
 
-            var request = new HttpRequestMessage(HttpMethod.Post, $"providers/provider-type?providerId={providerId}")
+            var request = new HttpRequestMessage(HttpMethod.Post, $"providers/provider-type?providerId={provider.ProviderId}")
             {
                 Content = content
             };
@@ -896,7 +896,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
 
             var doc = await response.GetDocument();
 
-            doc.GetElementByTestId("provider-id").GetAttribute("value").Should().Be(providerId.ToString());
+            doc.GetElementByTestId("provider-id").GetAttribute("value").Should().Be(provider.ProviderId.ToString());
             doc.GetElementByTestId("provider-type").GetAttribute("value").Should().Be(((int)ProviderType.TLevels).ToString());
             doc.GetElementByTestId("affected-tLevel-ids-checksum").GetAttribute("value").Should().Be(Convert.ToBase64String(new[] { tLevel2.TLevelId }.SelectMany(t => t.ToByteArray()).ToArray()));
             doc.GetAllElementsByTestId("selected-provider-tlevel-definition-id").Select(e => e.GetAttribute("value")).Should().BeEquivalentTo(
@@ -922,24 +922,24 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
             // Arrange
             var tLevelDefinitions = await TestData.CreateInitialTLevelDefinitions();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray());
 
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
             var keepingTLevelDefinitionId = tLevelDefinitions.First().TLevelDefinitionId;
             var removingTLevelDefinitionId = tLevelDefinitions.Last().TLevelDefinitionId;
             keepingTLevelDefinitionId.Should().NotBe(removingTLevelDefinitionId);
 
             var tLevel1 = await TestData.CreateTLevel(
-                providerId,
+                provider.ProviderId,
                 keepingTLevelDefinitionId,
                 locationVenueIds: new[] { venueId },
                 createdBy: User.ToUserInfo());
 
             var tLevel2 = await TestData.CreateTLevel(
-                providerId,
+                provider.ProviderId,
                 removingTLevelDefinitionId,
                 locationVenueIds: new[] { venueId },
                 createdBy: User.ToUserInfo());
@@ -951,7 +951,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
                 .Add(nameof(Command.Confirm), null)
                 .ToContent();
 
-            var request = new HttpRequestMessage(HttpMethod.Post, $"providers/provider-type?providerId={providerId}")
+            var request = new HttpRequestMessage(HttpMethod.Post, $"providers/provider-type?providerId={provider.ProviderId}")
             {
                 Content = content
             };
@@ -965,7 +965,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
             var doc = await response.GetDocument();
 
             doc.GetElementByTestId("confirm-error").TextContent.Should().Be("Select yes to permanently delete");
-            doc.GetElementByTestId("provider-id").GetAttribute("value").Should().Be(providerId.ToString());
+            doc.GetElementByTestId("provider-id").GetAttribute("value").Should().Be(provider.ProviderId.ToString());
             doc.GetElementByTestId("provider-type").GetAttribute("value").Should().Be(((int)ProviderType.TLevels).ToString());
             doc.GetElementByTestId("affected-tLevel-ids-checksum").GetAttribute("value").Should().Be(Convert.ToBase64String(new[] { tLevel2.TLevelId }.SelectMany(t => t.ToByteArray()).ToArray()));
             doc.GetAllElementsByTestId("selected-provider-tlevel-definition-id").Select(e => e.GetAttribute("value")).Should().BeEquivalentTo(
@@ -991,24 +991,24 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
             // Arrange
             var tLevelDefinitions = await TestData.CreateInitialTLevelDefinitions();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray());
 
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
             var keepingTLevelDefinitionId = tLevelDefinitions.First().TLevelDefinitionId;
             var removingTLevelDefinitionId = tLevelDefinitions.Last().TLevelDefinitionId;
             keepingTLevelDefinitionId.Should().NotBe(removingTLevelDefinitionId);
 
             var tLevel1 = await TestData.CreateTLevel(
-                providerId,
+                provider.ProviderId,
                 keepingTLevelDefinitionId,
                 locationVenueIds: new[] { venueId },
                 createdBy: User.ToUserInfo());
 
             var tLevel2 = await TestData.CreateTLevel(
-                providerId,
+                provider.ProviderId,
                 removingTLevelDefinitionId,
                 locationVenueIds: new[] { venueId },
                 createdBy: User.ToUserInfo());
@@ -1020,7 +1020,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
                 .Add(nameof(Command.Confirm), false)
                 .ToContent();
 
-            var request = new HttpRequestMessage(HttpMethod.Post, $"providers/provider-type?providerId={providerId}")
+            var request = new HttpRequestMessage(HttpMethod.Post, $"providers/provider-type?providerId={provider.ProviderId}")
             {
                 Content = content
             };
@@ -1030,7 +1030,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
 
             // Assert
             response.StatusCode.Should().Be(StatusCodes.Status302Found);
-            response.Headers.Location.OriginalString.Should().Be($"/providers/provider-type?providerId={providerId}");
+            response.Headers.Location.OriginalString.Should().Be($"/providers/provider-type?providerId={provider.ProviderId}");
 
             tLevel1 = await WithSqlQueryDispatcher(dispatcher => dispatcher.ExecuteQuery(
                 new GetTLevel() { TLevelId = tLevel1.TLevelId }));
@@ -1050,24 +1050,24 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
             // Arrange
             var tLevelDefinitions = await TestData.CreateInitialTLevelDefinitions();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray());
 
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
             var keepingTLevelDefinitionId = tLevelDefinitions.First().TLevelDefinitionId;
             var removingTLevelDefinitionId = tLevelDefinitions.Last().TLevelDefinitionId;
             keepingTLevelDefinitionId.Should().NotBe(removingTLevelDefinitionId);
 
             var tLevel1 = await TestData.CreateTLevel(
-                providerId,
+                provider.ProviderId,
                 keepingTLevelDefinitionId,
                 locationVenueIds: new[] { venueId },
                 createdBy: User.ToUserInfo());
 
             var tLevel2 = await TestData.CreateTLevel(
-                providerId,
+                provider.ProviderId,
                 removingTLevelDefinitionId,
                 locationVenueIds: new[] { venueId },
                 createdBy: User.ToUserInfo());
@@ -1079,7 +1079,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
                 .Add(nameof(Command.Confirm), true)
                 .ToContent();
 
-            var request = new HttpRequestMessage(HttpMethod.Post, $"providers/provider-type?providerId={providerId}")
+            var request = new HttpRequestMessage(HttpMethod.Post, $"providers/provider-type?providerId={provider.ProviderId}")
             {
                 Content = content
             };
@@ -1093,7 +1093,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
             var doc = await response.GetDocument();
 
             doc.GetElementByTestId("affected-item-counts-error").TextContent.Should().Be("The affected T Levels have changed");
-            doc.GetElementByTestId("provider-id").GetAttribute("value").Should().Be(providerId.ToString());
+            doc.GetElementByTestId("provider-id").GetAttribute("value").Should().Be(provider.ProviderId.ToString());
             doc.GetElementByTestId("provider-type").GetAttribute("value").Should().Be(((int)ProviderType.TLevels).ToString());
             doc.GetElementByTestId("affected-tLevel-ids-checksum").GetAttribute("value").Should().Be(Convert.ToBase64String(new[] { tLevel2.TLevelId }.SelectMany(t => t.ToByteArray()).ToArray()));
             doc.GetAllElementsByTestId("selected-provider-tlevel-definition-id").Select(e => e.GetAttribute("value")).Should().BeEquivalentTo(
@@ -1119,24 +1119,24 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
             // Arrange
             var tLevelDefinitions = await TestData.CreateInitialTLevelDefinitions();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray());
 
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
             var keepingTLevelDefinitionId = tLevelDefinitions.First().TLevelDefinitionId;
             var removingTLevelDefinitionId = tLevelDefinitions.Last().TLevelDefinitionId;
             keepingTLevelDefinitionId.Should().NotBe(removingTLevelDefinitionId);
 
             var tLevel1 = await TestData.CreateTLevel(
-                providerId,
+                provider.ProviderId,
                 keepingTLevelDefinitionId,
                 locationVenueIds: new[] { venueId },
                 createdBy: User.ToUserInfo());
 
             var tLevel2 = await TestData.CreateTLevel(
-                providerId,
+                provider.ProviderId,
                 removingTLevelDefinitionId,
                 locationVenueIds: new[] { venueId },
                 createdBy: User.ToUserInfo());
@@ -1148,7 +1148,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
                 .Add(nameof(Command.Confirm), true)
                 .ToContent();
 
-            var request = new HttpRequestMessage(HttpMethod.Post, $"providers/provider-type?providerId={providerId}")
+            var request = new HttpRequestMessage(HttpMethod.Post, $"providers/provider-type?providerId={provider.ProviderId}")
             {
                 Content = content
             };
@@ -1158,7 +1158,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers
 
             // Assert
             response.StatusCode.Should().Be(StatusCodes.Status302Found);
-            response.Headers.Location.OriginalString.Should().Be($"/providers?providerId={providerId}");
+            response.Headers.Location.OriginalString.Should().Be($"/providers?providerId={provider.ProviderId}");
 
             tLevel1 = await WithSqlQueryDispatcher(dispatcher => dispatcher.ExecuteQuery(
                 new GetTLevel() { TLevelId = tLevel1.TLevelId }));

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/Providers/Reporting/ProviderTypeReportTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/Providers/Reporting/ProviderTypeReportTests.cs
@@ -26,8 +26,8 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers.Reporting
         public async Task ProviderTypeReport_Get_WithProviderUser_ReturnsForbidden(TestUserType userType)
         {
             //Arange
-            var providerId = await TestData.CreateProvider();
-            await User.AsTestUser(userType, providerId);
+            var provider = await TestData.CreateProvider();
+            await User.AsTestUser(userType, provider.ProviderId);
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
@@ -178,15 +178,15 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers.Reporting
         }
 
         private async Task<(Guid ProviderId, int Ukprn, string Name, ProviderType ProviderType, ProviderStatus ProviderStatus, string UkrlpProviderStatusDescription)> CreateProvider(
-            int ukprn,
+            int index,
             ProviderType providerType,
             ProviderStatus providerStatus,
             string ukrlpProviderStatusDescription)
         {
-            var providerName = $"TestProvider{ukprn}";
-            var providerId = await TestData.CreateProvider(ukprn, providerName, providerType, ukrlpProviderStatusDescription, status: providerStatus);
+            var providerName = $"TestProvider{index}";
+            var provider = await TestData.CreateProvider(providerName, providerType, ukrlpProviderStatusDescription, status: providerStatus);
 
-            return (providerId, ukprn, providerName, providerType, providerStatus, ukrlpProviderStatusDescription);
+            return (provider.ProviderId, provider.Ukprn, providerName, providerType, providerStatus, ukrlpProviderStatusDescription);
         }
     }
 }

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/TLevels/AddTLevel/AddAnotherLocationTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/TLevels/AddTLevel/AddAnotherLocationTests.cs
@@ -31,10 +31,10 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
 
             var authorizedTLevelDefinitionIds = tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray();
 
-            var providerId = await TestData.CreateProvider(providerType: providerType);
+            var provider = await TestData.CreateProvider(providerType: providerType);
 
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
-            var anotherVenueId = (await TestData.CreateVenue(providerId, venueName: "Second Venue")).Id;
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
+            var anotherVenueId = (await TestData.CreateVenue(provider.ProviderId, venueName: "Second Venue")).Id;
 
             var selectedTLevel = tLevelDefinitions.First();
             var whoFor = "Who for";
@@ -62,12 +62,12 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
                 whatYouCanDoNext,
                 isComplete: true);
 
-            var journeyInstance = CreateJourneyInstance(providerId, journeyState);
+            var journeyInstance = CreateJourneyInstance(provider.ProviderId, journeyState);
             var journeyInstanceId = journeyInstance.InstanceId;
 
             var request = new HttpRequestMessage(
                 HttpMethod.Post,
-                $"/t-levels/add/add-location?providerId={providerId}&ffiid={journeyInstanceId.UniqueKey}")
+                $"/t-levels/add/add-location?providerId={provider.ProviderId}&ffiid={journeyInstanceId.UniqueKey}")
             {
                 Content = new FormUrlEncodedContentBuilder()
                     .Add("YourReference", yourReference)
@@ -118,11 +118,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
 
             var authorizedTLevelDefinitionIds = tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: authorizedTLevelDefinitionIds);
 
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
             var yourReference = "YOUR-REF";
             var startDate = new DateTime(2021, 4, 1);
@@ -132,12 +132,12 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
 
             journeyState.CompletedStages.Should().Be(AddTLevelJourneyCompletedStages.None);
 
-            var journeyInstance = CreateJourneyInstance(providerId, journeyState);
+            var journeyInstance = CreateJourneyInstance(provider.ProviderId, journeyState);
             var journeyInstanceId = journeyInstance.InstanceId;
 
             var request = new HttpRequestMessage(
                 HttpMethod.Post,
-                $"/t-levels/add/add-location?providerId={providerId}&ffiid={journeyInstanceId.UniqueKey}")
+                $"/t-levels/add/add-location?providerId={provider.ProviderId}&ffiid={journeyInstanceId.UniqueKey}")
             {
                 Content = new FormUrlEncodedContentBuilder()
                     .Add("YourReference", yourReference)
@@ -164,12 +164,12 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
 
             var authorizedTLevelDefinitionIds = tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: authorizedTLevelDefinitionIds);
 
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
-            var anotherVenueId = (await TestData.CreateVenue(providerId, venueName: "Second Venue")).Id;
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
+            var anotherVenueId = (await TestData.CreateVenue(provider.ProviderId, venueName: "Second Venue")).Id;
 
             var selectedTLevel = tLevelDefinitions.First();
             var whoFor = "Who for";
@@ -197,12 +197,12 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
                 whatYouCanDoNext,
                 isComplete: true);
 
-            var journeyInstance = CreateJourneyInstance(providerId, journeyState);
+            var journeyInstance = CreateJourneyInstance(provider.ProviderId, journeyState);
             var journeyInstanceId = journeyInstance.InstanceId;
 
             var request = new HttpRequestMessage(
                 HttpMethod.Post,
-                $"/t-levels/add/add-location?providerId={providerId}&ffiid={journeyInstanceId.UniqueKey}")
+                $"/t-levels/add/add-location?providerId={provider.ProviderId}&ffiid={journeyInstanceId.UniqueKey}")
             {
                 Content = new FormUrlEncodedContentBuilder()
                     .Add("YourReference", yourReference)

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/TLevels/AddTLevel/AddTLevelTestBase.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/TLevels/AddTLevel/AddTLevelTestBase.cs
@@ -26,16 +26,16 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
 
             var authorizedTLevelDefinitionIds = tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: authorizedTLevelDefinitionIds);
 
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
             var tLevelDefinitionId = tLevelDefinitions.First().TLevelDefinitionId;
 
             var createdTLevel = await TestData.CreateTLevel(
-                providerId,
+                provider.ProviderId,
                 tLevelDefinitionId: tLevelDefinitionId,
                 whoFor: "Who for",
                 entryRequirements: "Entry requirements",
@@ -73,12 +73,12 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
 
             journeyState.SetCreatedTLevel(createdTLevel.TLevelId);
 
-            var journeyInstance = CreateJourneyInstance(providerId, journeyState);
+            var journeyInstance = CreateJourneyInstance(provider.ProviderId, journeyState);
             var journeyInstanceId = journeyInstance.InstanceId;
 
             journeyInstance.Complete();
 
-            var request = createRequest((providerId, createdTLevel, journeyInstanceId));
+            var request = createRequest((provider.ProviderId, createdTLevel, journeyInstanceId));
 
             // Act
             var response = await HttpClient.SendAsync(request);

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/TLevels/AddTLevel/CheckAndPublishTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/TLevels/AddTLevel/CheckAndPublishTests.cs
@@ -34,10 +34,10 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
 
             var authorizedTLevelDefinitionIds = tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: providerType);
 
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
             var selectedTLevel = tLevelDefinitions.First();
 
@@ -63,12 +63,12 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
                 website: "http://example.com/tlevel",
                 isComplete: true);
 
-            var journeyInstance = CreateJourneyInstance(providerId, journeyState);
+            var journeyInstance = CreateJourneyInstance(provider.ProviderId, journeyState);
             var journeyInstanceId = journeyInstance.InstanceId;
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"/t-levels/add/check-publish?providerId={providerId}&ffiid={journeyInstanceId.UniqueKey}");
+                $"/t-levels/add/check-publish?providerId={provider.ProviderId}&ffiid={journeyInstanceId.UniqueKey}");
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -95,20 +95,20 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
 
             var authorizedTLevelDefinitionIds = tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: authorizedTLevelDefinitionIds);
 
             var journeyState = new AddTLevelJourneyModel();
 
-            var journeyInstance = CreateJourneyInstance(providerId, journeyState);
+            var journeyInstance = CreateJourneyInstance(provider.ProviderId, journeyState);
             var journeyInstanceId = journeyInstance.InstanceId;
 
             journeyInstance.State.CompletedStages.Should().Be(AddTLevelJourneyCompletedStages.None);
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"/t-levels/add/check-publish?providerId={providerId}&ffiid={journeyInstanceId.UniqueKey}");
+                $"/t-levels/add/check-publish?providerId={provider.ProviderId}&ffiid={journeyInstanceId.UniqueKey}");
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -125,12 +125,12 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
 
             var authorizedTLevelDefinitionIds = tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: authorizedTLevelDefinitionIds);
 
             var venueName = "T Level test venue";
-            var venueId = (await TestData.CreateVenue(providerId, venueName: venueName)).Id;
+            var venueId = (await TestData.CreateVenue(provider.ProviderId, venueName: venueName)).Id;
 
             var selectedTLevel = tLevelDefinitions.First();
             var whoFor = "Who for";
@@ -165,12 +165,12 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
                 website,
                 isComplete: true);
 
-            var journeyInstance = CreateJourneyInstance(providerId, journeyState);
+            var journeyInstance = CreateJourneyInstance(provider.ProviderId, journeyState);
             var journeyInstanceId = journeyInstance.InstanceId;
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"/t-levels/add/check-publish?providerId={providerId}&ffiid={journeyInstanceId.UniqueKey}");
+                $"/t-levels/add/check-publish?providerId={provider.ProviderId}&ffiid={journeyInstanceId.UniqueKey}");
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -207,9 +207,9 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
 
             var authorizedTLevelDefinitionIds = tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray();
 
-            var providerId = await TestData.CreateProvider(providerType: providerType);
+            var provider = await TestData.CreateProvider(providerType: providerType);
 
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
             var selectedTLevel = tLevelDefinitions.First();
             var whoFor = "Who for";
@@ -244,12 +244,12 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
                 website,
                 isComplete: true);
 
-            var journeyInstance = CreateJourneyInstance(providerId, journeyState);
+            var journeyInstance = CreateJourneyInstance(provider.ProviderId, journeyState);
             var journeyInstanceId = journeyInstance.InstanceId;
 
             var request = new HttpRequestMessage(
                 HttpMethod.Post,
-                $"/t-levels/add/check-publish?providerId={providerId}&ffiid={journeyInstanceId.UniqueKey}")
+                $"/t-levels/add/check-publish?providerId={provider.ProviderId}&ffiid={journeyInstanceId.UniqueKey}")
             {
                 Content = new FormUrlEncodedContentBuilder()
                     .ToContent()
@@ -270,20 +270,20 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
 
             var authorizedTLevelDefinitionIds = tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: authorizedTLevelDefinitionIds);
 
             var journeyState = new AddTLevelJourneyModel();
 
-            var journeyInstance = CreateJourneyInstance(providerId, journeyState);
+            var journeyInstance = CreateJourneyInstance(provider.ProviderId, journeyState);
             var journeyInstanceId = journeyInstance.InstanceId;
 
             journeyInstance.State.CompletedStages.Should().Be(AddTLevelJourneyCompletedStages.None);
 
             var request = new HttpRequestMessage(
                 HttpMethod.Post,
-                $"/t-levels/add/check-publish?providerId={providerId}&ffiid={journeyInstanceId.UniqueKey}")
+                $"/t-levels/add/check-publish?providerId={provider.ProviderId}&ffiid={journeyInstanceId.UniqueKey}")
             {
                 Content = new FormUrlEncodedContentBuilder()
                     .ToContent()
@@ -317,11 +317,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
 
             var authorizedTLevelDefinitionIds = tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: authorizedTLevelDefinitionIds);
 
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
             var selectedTLevel = tLevelDefinitions.First();
             var whoFor = "Who for";
@@ -335,7 +335,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
             var website = "http://example.com/tlevel";
 
             await TestData.CreateTLevel(
-                providerId,
+                provider.ProviderId,
                 selectedTLevel.TLevelDefinitionId,
                 whoFor: whoFor,
                 entryRequirements: entryRequirements,
@@ -371,7 +371,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
                 website,
                 isComplete: true);
 
-            var journeyInstance = CreateJourneyInstance(providerId, journeyState);
+            var journeyInstance = CreateJourneyInstance(provider.ProviderId, journeyState);
             var journeyInstanceId = journeyInstance.InstanceId;
 
             Guid createdTLevelId = default;
@@ -380,7 +380,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
 
             var request = new HttpRequestMessage(
                 HttpMethod.Post,
-                $"/t-levels/add/check-publish?providerId={providerId}&ffiid={journeyInstanceId.UniqueKey}")
+                $"/t-levels/add/check-publish?providerId={provider.ProviderId}&ffiid={journeyInstanceId.UniqueKey}")
             {
                 Content = new FormUrlEncodedContentBuilder()
                     .ToContent()
@@ -404,11 +404,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
 
             var authorizedTLevelDefinitionIds = tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: authorizedTLevelDefinitionIds);
 
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
             var selectedTLevel = tLevelDefinitions.First();
             var whoFor = "Who for";
@@ -443,7 +443,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
                 website,
                 isComplete: true);
 
-            var journeyInstance = CreateJourneyInstance(providerId, journeyState);
+            var journeyInstance = CreateJourneyInstance(provider.ProviderId, journeyState);
             var journeyInstanceId = journeyInstance.InstanceId;
 
             Guid createdTLevelId = default;
@@ -452,7 +452,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
 
             var request = new HttpRequestMessage(
                 HttpMethod.Post,
-                $"/t-levels/add/check-publish?providerId={providerId}&ffiid={journeyInstanceId.UniqueKey}")
+                $"/t-levels/add/check-publish?providerId={provider.ProviderId}&ffiid={journeyInstanceId.UniqueKey}")
             {
                 Content = new FormUrlEncodedContentBuilder()
                     .ToContent()
@@ -464,7 +464,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
             // Assert
             response.StatusCode.Should().Be(HttpStatusCode.Found);
             response.Headers.Location.OriginalString
-                .Should().Be($"/t-levels/add/success?providerId={providerId}&ffiid={journeyInstanceId.UniqueKey}");
+                .Should().Be($"/t-levels/add/success?providerId={provider.ProviderId}&ffiid={journeyInstanceId.UniqueKey}");
 
             SqlQuerySpy.VerifyQuery<CreateTLevel, OneOf<CreateTLevelFailedReason, Success>>(q =>
                 q.CreatedBy.UserId == User.UserId &&
@@ -473,7 +473,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
                 q.HowYoullBeAssessed == howYoullBeAssessed &&
                 q.HowYoullLearn == howYoullLearn &&
                 q.LocationVenueIds.Single() == venueId &&
-                q.ProviderId == providerId &&
+                q.ProviderId == provider.ProviderId &&
                 q.StartDate == startDate &&
                 q.TLevelDefinitionId == selectedTLevel.TLevelDefinitionId &&
                 q.Website == website &&

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/TLevels/AddTLevel/DescriptionTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/TLevels/AddTLevel/DescriptionTests.cs
@@ -34,9 +34,9 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
 
             var authorizedTLevelDefinitionIds = tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray();
 
-            var providerId = await TestData.CreateProvider(providerType: providerType);
+            var provider = await TestData.CreateProvider(providerType: providerType);
 
-            var venueId = await TestData.CreateVenue(providerId);
+            var venueId = await TestData.CreateVenue(provider.ProviderId);
 
             var selectedTLevel = tLevelDefinitions.First();
 
@@ -53,12 +53,12 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
                 selectedTLevel.Name,
                 exemplarContent);
 
-            var journeyInstance = CreateJourneyInstance(providerId, journeyState);
+            var journeyInstance = CreateJourneyInstance(provider.ProviderId, journeyState);
             var journeyInstanceId = journeyInstance.InstanceId;
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"/t-levels/add/description?providerId={providerId}&ffiid={journeyInstanceId.UniqueKey}");
+                $"/t-levels/add/description?providerId={provider.ProviderId}&ffiid={journeyInstanceId.UniqueKey}");
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -85,11 +85,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
 
             var authorizedTLevelDefinitionIds = tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: authorizedTLevelDefinitionIds);
 
-            var venueId = await TestData.CreateVenue(providerId);
+            var venueId = await TestData.CreateVenue(provider.ProviderId);
 
             var selectedTLevel = tLevelDefinitions.First();
 
@@ -97,12 +97,12 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
 
             journeyState.CompletedStages.Should().Be(AddTLevelJourneyCompletedStages.None);
 
-            var journeyInstance = CreateJourneyInstance(providerId, journeyState);
+            var journeyInstance = CreateJourneyInstance(provider.ProviderId, journeyState);
             var journeyInstanceId = journeyInstance.InstanceId;
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"/t-levels/add/description?providerId={providerId}&ffiid={journeyInstanceId.UniqueKey}");
+                $"/t-levels/add/description?providerId={provider.ProviderId}&ffiid={journeyInstanceId.UniqueKey}");
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -119,11 +119,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
 
             var authorizedTLevelDefinitionIds = tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: authorizedTLevelDefinitionIds);
 
-            var venueId = await TestData.CreateVenue(providerId);
+            var venueId = await TestData.CreateVenue(provider.ProviderId);
 
             var selectedTLevel = tLevelDefinitions.First();
 
@@ -140,12 +140,12 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
                 selectedTLevel.Name,
                 exemplarContent);
 
-            var journeyInstance = CreateJourneyInstance(providerId, journeyState);
+            var journeyInstance = CreateJourneyInstance(provider.ProviderId, journeyState);
             var journeyInstanceId = journeyInstance.InstanceId;
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"/t-levels/add/description?providerId={providerId}&ffiid={journeyInstanceId.UniqueKey}");
+                $"/t-levels/add/description?providerId={provider.ProviderId}&ffiid={journeyInstanceId.UniqueKey}");
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -178,9 +178,9 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
 
             var authorizedTLevelDefinitionIds = tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray();
 
-            var providerId = await TestData.CreateProvider(providerType: providerType);
+            var provider = await TestData.CreateProvider(providerType: providerType);
 
-            var venueId = await TestData.CreateVenue(providerId);
+            var venueId = await TestData.CreateVenue(provider.ProviderId);
 
             var selectedTLevel = tLevelDefinitions.First();
             var whoFor = "Who for";
@@ -196,12 +196,12 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
                 selectedTLevel.TLevelDefinitionId,
                 selectedTLevel.Name);
 
-            var journeyInstance = CreateJourneyInstance(providerId, journeyState);
+            var journeyInstance = CreateJourneyInstance(provider.ProviderId, journeyState);
             var journeyInstanceId = journeyInstance.InstanceId;
 
             var request = new HttpRequestMessage(
                 HttpMethod.Post,
-                $"/t-levels/add/description?providerId={providerId}&ffiid={journeyInstanceId.UniqueKey}")
+                $"/t-levels/add/description?providerId={provider.ProviderId}&ffiid={journeyInstanceId.UniqueKey}")
             {
                 Content = new FormUrlEncodedContentBuilder()
                     .Add("WhoFor", whoFor)
@@ -255,11 +255,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
 
             var authorizedTLevelDefinitionIds = tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: authorizedTLevelDefinitionIds);
 
-            var venueId = await TestData.CreateVenue(providerId);
+            var venueId = await TestData.CreateVenue(provider.ProviderId);
 
             var selectedTLevel = tLevelDefinitions.First();
             var whoFor = "Who for";
@@ -273,12 +273,12 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
 
             journeyState.CompletedStages.Should().Be(AddTLevelJourneyCompletedStages.None);
 
-            var journeyInstance = CreateJourneyInstance(providerId, journeyState);
+            var journeyInstance = CreateJourneyInstance(provider.ProviderId, journeyState);
             var journeyInstanceId = journeyInstance.InstanceId;
 
             var request = new HttpRequestMessage(
                 HttpMethod.Post,
-                $"/t-levels/add/description?providerId={providerId}&ffiid={journeyInstanceId.UniqueKey}")
+                $"/t-levels/add/description?providerId={provider.ProviderId}&ffiid={journeyInstanceId.UniqueKey}")
             {
                 Content = new FormUrlEncodedContentBuilder()
                     .Add("WhoFor", whoFor)
@@ -314,11 +314,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
 
             var authorizedTLevelDefinitionIds = tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: authorizedTLevelDefinitionIds);
 
-            var venueId = await TestData.CreateVenue(providerId);
+            var venueId = await TestData.CreateVenue(provider.ProviderId);
 
             var selectedTLevel = tLevelDefinitions.First();
 
@@ -328,12 +328,12 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
                 selectedTLevel.TLevelDefinitionId,
                 selectedTLevel.Name);
 
-            var journeyInstance = CreateJourneyInstance(providerId, journeyState);
+            var journeyInstance = CreateJourneyInstance(provider.ProviderId, journeyState);
             var journeyInstanceId = journeyInstance.InstanceId;
 
             var request = new HttpRequestMessage(
                 HttpMethod.Post,
-                $"/t-levels/add/description?providerId={providerId}&ffiid={journeyInstanceId.UniqueKey}")
+                $"/t-levels/add/description?providerId={provider.ProviderId}&ffiid={journeyInstanceId.UniqueKey}")
             {
                 Content = new FormUrlEncodedContentBuilder()
                     .Add("WhoFor", whoFor)
@@ -366,11 +366,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
 
             var authorizedTLevelDefinitionIds = tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: authorizedTLevelDefinitionIds);
 
-            var venueId = await TestData.CreateVenue(providerId);
+            var venueId = await TestData.CreateVenue(provider.ProviderId);
 
             var selectedTLevel = tLevelDefinitions.First();
             var whoFor = "Who for";
@@ -386,12 +386,12 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
                 selectedTLevel.TLevelDefinitionId,
                 selectedTLevel.Name);
 
-            var journeyInstance = CreateJourneyInstance(providerId, journeyState);
+            var journeyInstance = CreateJourneyInstance(provider.ProviderId, journeyState);
             var journeyInstanceId = journeyInstance.InstanceId;
 
             var request = new HttpRequestMessage(
                 HttpMethod.Post,
-                $"/t-levels/add/description?providerId={providerId}&ffiid={journeyInstanceId.UniqueKey}")
+                $"/t-levels/add/description?providerId={provider.ProviderId}&ffiid={journeyInstanceId.UniqueKey}")
             {
                 Content = new FormUrlEncodedContentBuilder()
                     .Add("WhoFor", whoFor)
@@ -409,7 +409,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
             // Assert
             response.StatusCode.Should().Be(HttpStatusCode.Found);
             response.Headers.Location.OriginalString
-                .Should().Be($"/t-levels/add/details?providerId={providerId}&ffiid={journeyInstanceId.UniqueKey}");
+                .Should().Be($"/t-levels/add/details?providerId={provider.ProviderId}&ffiid={journeyInstanceId.UniqueKey}");
 
             journeyState = GetJourneyInstance<AddTLevelJourneyModel>(journeyInstanceId).State;
 

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/TLevels/AddTLevel/DetailsTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/TLevels/AddTLevel/DetailsTests.cs
@@ -31,9 +31,9 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
 
             var authorizedTLevelDefinitionIds = tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray();
 
-            var providerId = await TestData.CreateProvider(providerType: providerType);
+            var provider = await TestData.CreateProvider(providerType: providerType);
 
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
             var selectedTLevel = tLevelDefinitions.First();
             var whoFor = "Who for";
@@ -68,12 +68,12 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
                 website,
                 isComplete: true);
 
-            var journeyInstance = CreateJourneyInstance(providerId, journeyState);
+            var journeyInstance = CreateJourneyInstance(provider.ProviderId, journeyState);
             var journeyInstanceId = journeyInstance.InstanceId;
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"/t-levels/add/details?providerId={providerId}&ffiid={journeyInstanceId.UniqueKey}");
+                $"/t-levels/add/details?providerId={provider.ProviderId}&ffiid={journeyInstanceId.UniqueKey}");
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -100,11 +100,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
 
             var authorizedTLevelDefinitionIds = tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: authorizedTLevelDefinitionIds);
 
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
             var selectedTLevel = tLevelDefinitions.First();
 
@@ -112,12 +112,12 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
 
             journeyState.CompletedStages.Should().Be(AddTLevelJourneyCompletedStages.None);
 
-            var journeyInstance = CreateJourneyInstance(providerId, journeyState);
+            var journeyInstance = CreateJourneyInstance(provider.ProviderId, journeyState);
             var journeyInstanceId = journeyInstance.InstanceId;
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"/t-levels/add/details?providerId={providerId}&ffiid={journeyInstanceId.UniqueKey}");
+                $"/t-levels/add/details?providerId={provider.ProviderId}&ffiid={journeyInstanceId.UniqueKey}");
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -134,12 +134,12 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
 
             var authorizedTLevelDefinitionIds = tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: authorizedTLevelDefinitionIds);
 
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
-            var anotherVenueId = (await TestData.CreateVenue(providerId, venueName: "Second Venue")).Id;
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
+            var anotherVenueId = (await TestData.CreateVenue(provider.ProviderId, venueName: "Second Venue")).Id;
 
             var selectedTLevel = tLevelDefinitions.First();
             var whoFor = "Who for";
@@ -174,12 +174,12 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
                 website,
                 isComplete: true);
 
-            var journeyInstance = CreateJourneyInstance(providerId, journeyState);
+            var journeyInstance = CreateJourneyInstance(provider.ProviderId, journeyState);
             var journeyInstanceId = journeyInstance.InstanceId;
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"/t-levels/add/details?providerId={providerId}&ffiid={journeyInstanceId.UniqueKey}");
+                $"/t-levels/add/details?providerId={provider.ProviderId}&ffiid={journeyInstanceId.UniqueKey}");
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -209,12 +209,12 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
 
             var authorizedTLevelDefinitionIds = tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: authorizedTLevelDefinitionIds);
 
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
-            var anotherVenueId = (await TestData.CreateVenue(providerId, venueName: "Second Venue")).Id;
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
+            var anotherVenueId = (await TestData.CreateVenue(provider.ProviderId, venueName: "Second Venue")).Id;
 
             var selectedTLevel = tLevelDefinitions.First();
             var whoFor = "Who for";
@@ -239,12 +239,12 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
                 whatYouCanDoNext,
                 isComplete: true);
 
-            var journeyInstance = CreateJourneyInstance(providerId, journeyState);
+            var journeyInstance = CreateJourneyInstance(provider.ProviderId, journeyState);
             var journeyInstanceId = journeyInstance.InstanceId;
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"/t-levels/add/details?providerId={providerId}&ffiid={journeyInstanceId.UniqueKey}&venueId={venueId}");
+                $"/t-levels/add/details?providerId={provider.ProviderId}&ffiid={journeyInstanceId.UniqueKey}&venueId={venueId}");
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -268,9 +268,9 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
 
             var authorizedTLevelDefinitionIds = tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray();
 
-            var providerId = await TestData.CreateProvider(providerType: providerType);
+            var provider = await TestData.CreateProvider(providerType: providerType);
 
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
             var selectedTLevel = tLevelDefinitions.First();
             var whoFor = "Who for";
@@ -305,12 +305,12 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
                 website,
                 isComplete: true);
 
-            var journeyInstance = CreateJourneyInstance(providerId, journeyState);
+            var journeyInstance = CreateJourneyInstance(provider.ProviderId, journeyState);
             var journeyInstanceId = journeyInstance.InstanceId;
 
             var request = new HttpRequestMessage(
                 HttpMethod.Post,
-                $"/t-levels/add/details?providerId={providerId}&ffiid={journeyInstanceId.UniqueKey}")
+                $"/t-levels/add/details?providerId={provider.ProviderId}&ffiid={journeyInstanceId.UniqueKey}")
             {
                 Content = new FormUrlEncodedContentBuilder()
                     .Add("YourReference", yourReference)
@@ -361,11 +361,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
 
             var authorizedTLevelDefinitionIds = tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: authorizedTLevelDefinitionIds);
 
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
             var yourReference = "YOUR-REF";
             var startDate = new DateTime(2021, 4, 1);
@@ -375,12 +375,12 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
 
             journeyState.CompletedStages.Should().Be(AddTLevelJourneyCompletedStages.None);
 
-            var journeyInstance = CreateJourneyInstance(providerId, journeyState);
+            var journeyInstance = CreateJourneyInstance(provider.ProviderId, journeyState);
             var journeyInstanceId = journeyInstance.InstanceId;
 
             var request = new HttpRequestMessage(
                 HttpMethod.Post,
-                $"/t-levels/add/details?providerId={providerId}&ffiid={journeyInstanceId.UniqueKey}")
+                $"/t-levels/add/details?providerId={provider.ProviderId}&ffiid={journeyInstanceId.UniqueKey}")
             {
                 Content = new FormUrlEncodedContentBuilder()
                     .Add("YourReference", yourReference)
@@ -415,18 +415,18 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
 
             var authorizedTLevelDefinitionIds = tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: authorizedTLevelDefinitionIds);
 
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
             var selectedTLevel = tLevelDefinitions.First();
 
             if (addTLevelWithSameStartDate)
             {
                 await TestData.CreateTLevel(
-                    providerId,
+                    provider.ProviderId,
                     selectedTLevel.TLevelDefinitionId,
                     startDate: startDate.Value,
                     locationVenueIds: new[] { venueId },
@@ -455,12 +455,12 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
                 whatYouCanDoNext,
                 isComplete: true);
 
-            var journeyInstance = CreateJourneyInstance(providerId, journeyState);
+            var journeyInstance = CreateJourneyInstance(provider.ProviderId, journeyState);
             var journeyInstanceId = journeyInstance.InstanceId;
 
             var request = new HttpRequestMessage(
                 HttpMethod.Post,
-                $"/t-levels/add/details?providerId={providerId}&ffiid={journeyInstanceId.UniqueKey}")
+                $"/t-levels/add/details?providerId={provider.ProviderId}&ffiid={journeyInstanceId.UniqueKey}")
             {
                 Content = new FormUrlEncodedContentBuilder()
                     .Add("YourReference", yourReference)
@@ -493,11 +493,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
 
             var authorizedTLevelDefinitionIds = tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: authorizedTLevelDefinitionIds);
 
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
             var selectedTLevel = tLevelDefinitions.First();
             var whoFor = "Who for";
@@ -525,12 +525,12 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
                 whatYouCanDoNext,
                 isComplete: true);
 
-            var journeyInstance = CreateJourneyInstance(providerId, journeyState);
+            var journeyInstance = CreateJourneyInstance(provider.ProviderId, journeyState);
             var journeyInstanceId = journeyInstance.InstanceId;
 
             var request = new HttpRequestMessage(
                 HttpMethod.Post,
-                $"/t-levels/add/details?providerId={providerId}&ffiid={journeyInstanceId.UniqueKey}")
+                $"/t-levels/add/details?providerId={provider.ProviderId}&ffiid={journeyInstanceId.UniqueKey}")
             {
                 Content = new FormUrlEncodedContentBuilder()
                     .Add("YourReference", yourReference)
@@ -548,7 +548,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
             // Assert
             response.StatusCode.Should().Be(HttpStatusCode.Found);
             response.Headers.Location.OriginalString
-                .Should().Be($"/t-levels/add/check-publish?providerId={providerId}&ffiid={journeyInstanceId.UniqueKey}");
+                .Should().Be($"/t-levels/add/check-publish?providerId={provider.ProviderId}&ffiid={journeyInstanceId.UniqueKey}");
 
             journeyState = GetJourneyInstance<AddTLevelJourneyModel>(journeyInstanceId).State;
 

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/TLevels/AddTLevel/PublishedTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/TLevels/AddTLevel/PublishedTests.cs
@@ -29,13 +29,13 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
 
             var authorizedTLevelDefinitionIds = tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: providerType);
 
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
             var createdTLevel = await TestData.CreateTLevel(
-                providerId,
+                provider.ProviderId,
                 tLevelDefinitionId: tLevelDefinitions.First().TLevelDefinitionId,
                 whoFor: "Who for",
                 entryRequirements: "Entry requirements",
@@ -73,14 +73,14 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
 
             journeyState.SetCreatedTLevel(createdTLevel.TLevelId);
 
-            var journeyInstance = CreateJourneyInstance(providerId, journeyState);
+            var journeyInstance = CreateJourneyInstance(provider.ProviderId, journeyState);
             var journeyInstanceId = journeyInstance.InstanceId;
 
             journeyInstance.Complete();
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"/t-levels/add/success?providerId={providerId}&ffiid={journeyInstanceId.UniqueKey}");
+                $"/t-levels/add/success?providerId={provider.ProviderId}&ffiid={journeyInstanceId.UniqueKey}");
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -97,20 +97,20 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
 
             var authorizedTLevelDefinitionIds = tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: authorizedTLevelDefinitionIds);
 
             var journeyState = new AddTLevelJourneyModel();
 
-            var journeyInstance = CreateJourneyInstance(providerId, journeyState);
+            var journeyInstance = CreateJourneyInstance(provider.ProviderId, journeyState);
             var journeyInstanceId = journeyInstance.InstanceId;
 
             journeyInstance.Completed.Should().BeFalse();
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"/t-levels/add/success?providerId={providerId}&ffiid={journeyInstanceId.UniqueKey}");
+                $"/t-levels/add/success?providerId={provider.ProviderId}&ffiid={journeyInstanceId.UniqueKey}");
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -127,14 +127,14 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
 
             var authorizedTLevelDefinitionIds = tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: authorizedTLevelDefinitionIds);
 
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
             var createdTLevel = await TestData.CreateTLevel(
-                providerId,
+                provider.ProviderId,
                 tLevelDefinitionId: tLevelDefinitions.First().TLevelDefinitionId,
                 whoFor: "Who for",
                 entryRequirements: "Entry requirements",
@@ -172,14 +172,14 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
 
             journeyState.SetCreatedTLevel(createdTLevel.TLevelId);
 
-            var journeyInstance = CreateJourneyInstance(providerId, journeyState);
+            var journeyInstance = CreateJourneyInstance(provider.ProviderId, journeyState);
             var journeyInstanceId = journeyInstance.InstanceId;
 
             journeyInstance.Complete();
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"/t-levels/add/success?providerId={providerId}&ffiid={journeyInstanceId.UniqueKey}");
+                $"/t-levels/add/success?providerId={provider.ProviderId}&ffiid={journeyInstanceId.UniqueKey}");
 
             // Act
             var response = await HttpClient.SendAsync(request);

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/TLevels/AddTLevel/SelectTLevelTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/TLevels/AddTLevel/SelectTLevelTests.cs
@@ -28,14 +28,14 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
         public async Task Get_ProviderIsNotTLevelsProvider_ReturnsForbidden(ProviderType providerType)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(providerType: providerType);
+            var provider = await TestData.CreateProvider(providerType: providerType);
 
-            var journeyInstance = CreateJourneyInstance(providerId);
+            var journeyInstance = CreateJourneyInstance(provider.ProviderId);
             var journeyInstanceId = journeyInstance.InstanceId;
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"/t-levels/add?providerId={providerId}&ffiid={journeyInstanceId.UniqueKey}");
+                $"/t-levels/add?providerId={provider.ProviderId}&ffiid={journeyInstanceId.UniqueKey}");
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -62,16 +62,16 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
 
             var authorizedTLevelDefinitionIds = tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: authorizedTLevelDefinitionIds);
 
-            var journeyInstance = CreateJourneyInstance(providerId);
+            var journeyInstance = CreateJourneyInstance(provider.ProviderId);
             var journeyInstanceId = journeyInstance.InstanceId;
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"/t-levels/add?providerId={providerId}&ffiid={journeyInstanceId.UniqueKey}");
+                $"/t-levels/add?providerId={provider.ProviderId}&ffiid={journeyInstanceId.UniqueKey}");
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -96,7 +96,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
 
             var authorizedTLevelDefinitionIds = tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: authorizedTLevelDefinitionIds);
 
@@ -107,12 +107,12 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
                 selectedTLevel.TLevelDefinitionId,
                 selectedTLevel.Name);
 
-            var journeyInstance = CreateJourneyInstance(providerId, journeyState);
+            var journeyInstance = CreateJourneyInstance(provider.ProviderId, journeyState);
             var journeyInstanceId = journeyInstance.InstanceId;
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"/t-levels/add?providerId={providerId}&ffiid={journeyInstanceId.UniqueKey}");
+                $"/t-levels/add?providerId={provider.ProviderId}&ffiid={journeyInstanceId.UniqueKey}");
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -151,16 +151,16 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
             // Arrange
             var tLevelDefinitions = await TestData.CreateInitialTLevelDefinitions();
 
-            var providerId = await TestData.CreateProvider(providerType: providerType);
+            var provider = await TestData.CreateProvider(providerType: providerType);
 
             var selectedTLevelId = tLevelDefinitions.First().TLevelDefinitionId;
 
-            var journeyInstance = CreateJourneyInstance(providerId);
+            var journeyInstance = CreateJourneyInstance(provider.ProviderId);
             var journeyInstanceId = journeyInstance.InstanceId;
 
             var request = new HttpRequestMessage(
                 HttpMethod.Post,
-                $"/t-levels/add?providerId={providerId}&ffiid={journeyInstanceId.UniqueKey}")
+                $"/t-levels/add?providerId={provider.ProviderId}&ffiid={journeyInstanceId.UniqueKey}")
             {
                 Content = new FormUrlEncodedContentBuilder()
                     .Add("SelectedTLevelDefinitionId", selectedTLevelId)
@@ -195,18 +195,18 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
             // Arrange
             var tLevelDefinitions = await TestData.CreateInitialTLevelDefinitions();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray());
 
             var selectedTLevelId = tLevelDefinitions.First().TLevelDefinitionId;
 
-            var journeyInstance = CreateJourneyInstance(providerId);
+            var journeyInstance = CreateJourneyInstance(provider.ProviderId);
             var journeyInstanceId = journeyInstance.InstanceId;
 
             var request = new HttpRequestMessage(
                 HttpMethod.Post,
-                $"/t-levels/add?providerId={providerId}&ffiid={journeyInstanceId.UniqueKey}")
+                $"/t-levels/add?providerId={provider.ProviderId}&ffiid={journeyInstanceId.UniqueKey}")
             {
                 Content = new FormUrlEncodedContentBuilder()
                     .ToContent()
@@ -230,18 +230,18 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
             // Arrange
             var tLevelDefinitions = await TestData.CreateInitialTLevelDefinitions();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray());
 
             var selectedTLevelId = Guid.NewGuid();
 
-            var journeyInstance = CreateJourneyInstance(providerId);
+            var journeyInstance = CreateJourneyInstance(provider.ProviderId);
             var journeyInstanceId = journeyInstance.InstanceId;
 
             var request = new HttpRequestMessage(
                 HttpMethod.Post,
-                $"/t-levels/add?providerId={providerId}&ffiid={journeyInstanceId.UniqueKey}")
+                $"/t-levels/add?providerId={provider.ProviderId}&ffiid={journeyInstanceId.UniqueKey}")
             {
                 Content = new FormUrlEncodedContentBuilder()
                     .Add("SelectedTLevelDefinitionId", selectedTLevelId)
@@ -270,16 +270,16 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
             var selectedTLevelId = tLevelDefinitions.Last().TLevelDefinitionId;
             selectedTLevelId.Should().NotBe(authorizedTLevelDefinitionId);
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: new[] { authorizedTLevelDefinitionId });
 
-            var journeyInstance = CreateJourneyInstance(providerId);
+            var journeyInstance = CreateJourneyInstance(provider.ProviderId);
             var journeyInstanceId = journeyInstance.InstanceId;
 
             var request = new HttpRequestMessage(
                 HttpMethod.Post,
-                $"/t-levels/add?providerId={providerId}&ffiid={journeyInstanceId.UniqueKey}")
+                $"/t-levels/add?providerId={provider.ProviderId}&ffiid={journeyInstanceId.UniqueKey}")
             {
                 Content = new FormUrlEncodedContentBuilder()
                     .Add("SelectedTLevelDefinitionId", selectedTLevelId)
@@ -304,18 +304,18 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
             // Arrange
             var tLevelDefinitions = await TestData.CreateInitialTLevelDefinitions();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray());
 
             var selectedTLevelId = tLevelDefinitions.First().TLevelDefinitionId;
 
-            var journeyInstance = CreateJourneyInstance(providerId);
+            var journeyInstance = CreateJourneyInstance(provider.ProviderId);
             var journeyInstanceId = journeyInstance.InstanceId;
 
             var request = new HttpRequestMessage(
                 HttpMethod.Post,
-                $"/t-levels/add?providerId={providerId}&ffiid={journeyInstanceId.UniqueKey}")
+                $"/t-levels/add?providerId={provider.ProviderId}&ffiid={journeyInstanceId.UniqueKey}")
             {
                 Content = new FormUrlEncodedContentBuilder()
                     .Add("SelectedTLevelDefinitionId", selectedTLevelId)
@@ -328,7 +328,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
             // Assert
             response.StatusCode.Should().Be(HttpStatusCode.Found);
             response.Headers.Location.OriginalString.Should().Be(
-                $"/t-levels/add/description?providerId={providerId}&ffiid={journeyInstanceId.UniqueKey}");
+                $"/t-levels/add/description?providerId={provider.ProviderId}&ffiid={journeyInstanceId.UniqueKey}");
 
             var journeyState = GetJourneyInstance<AddTLevelJourneyModel>(journeyInstanceId).State;
             journeyState.TLevelDefinitionId.Should().Be(selectedTLevelId);
@@ -341,7 +341,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
             // Arrange
             var tLevelDefinitions = await TestData.CreateInitialTLevelDefinitions();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray());
 
@@ -377,12 +377,12 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
                     TLevelDefinitionId = newSelectedTLevelDefinitionId
                 }));
 
-            var journeyInstance = CreateJourneyInstance(providerId, journeyState);
+            var journeyInstance = CreateJourneyInstance(provider.ProviderId, journeyState);
             var journeyInstanceId = journeyInstance.InstanceId;
 
             var request = new HttpRequestMessage(
                 HttpMethod.Post,
-                $"/t-levels/add?providerId={providerId}&ffiid={journeyInstanceId.UniqueKey}")
+                $"/t-levels/add?providerId={provider.ProviderId}&ffiid={journeyInstanceId.UniqueKey}")
             {
                 Content = new FormUrlEncodedContentBuilder()
                     .Add("SelectedTLevelDefinitionId", newSelectedTLevelDefinitionId)
@@ -415,7 +415,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
             // Arrange
             var tLevelDefinitions = await TestData.CreateInitialTLevelDefinitions();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray());
 
@@ -442,12 +442,12 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.AddTLevel
                 isComplete: true);
             journeyState.CompletedStages.Should().Be(AddTLevelJourneyCompletedStages.SelectTLevel | AddTLevelJourneyCompletedStages.Description);
 
-            var journeyInstance = CreateJourneyInstance(providerId, journeyState);
+            var journeyInstance = CreateJourneyInstance(provider.ProviderId, journeyState);
             var journeyInstanceId = journeyInstance.InstanceId;
 
             var request = new HttpRequestMessage(
                 HttpMethod.Post,
-                $"/t-levels/add?providerId={providerId}&ffiid={journeyInstanceId.UniqueKey}")
+                $"/t-levels/add?providerId={provider.ProviderId}&ffiid={journeyInstanceId.UniqueKey}")
             {
                 Content = new FormUrlEncodedContentBuilder()
                     .Add("SelectedTLevelDefinitionId", selectedTLevel.TLevelDefinitionId)

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/TLevels/DeleteTLevel/DeleteTLevelTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/TLevels/DeleteTLevel/DeleteTLevelTests.cs
@@ -29,7 +29,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.DeleteTLevel
             // Arrange
             var tLevelDefinitions = await TestData.CreateInitialTLevelDefinitions();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray());
 
@@ -52,27 +52,25 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.DeleteTLevel
             // Arrange
             var tLevelDefinitions = await TestData.CreateInitialTLevelDefinitions();
 
-            var anotherProviderId = await TestData.CreateProvider(
-                ukprn: 23456,
+            var anotherProvider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray());
 
-            var providerId = await TestData.CreateProvider(
-                ukprn: 12345,
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray());
 
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
             var tLevel = await TestData.CreateTLevel(
-                providerId,
+                provider.ProviderId,
                 tLevelDefinitions.First().TLevelDefinitionId,
                 locationVenueIds: new[] { venueId },
                 createdBy: User.ToUserInfo());
 
             var request = new HttpRequestMessage(HttpMethod.Get, $"/t-levels/{tLevel.TLevelId}/delete");
 
-            await User.AsTestUser(userType, anotherProviderId);
+            await User.AsTestUser(userType, anotherProvider.ProviderId);
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -87,12 +85,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.DeleteTLevel
             // Arrange
             var tLevelDefinitions = await TestData.CreateInitialTLevelDefinitions();
 
-            var providerId = await TestData.CreateProvider(
-                ukprn: 12345,
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray());
 
-            var venueId = (await TestData.CreateVenue(providerId, venueName: "T Level venue")).Id;
+            var venueId = (await TestData.CreateVenue(provider.ProviderId, venueName: "T Level venue")).Id;
 
             var tLevelDefinition = tLevelDefinitions.First();
 
@@ -100,7 +97,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.DeleteTLevel
             var startDate = new DateTime(2021, 10, 1);
 
             var tLevel = await TestData.CreateTLevel(
-                providerId,
+                provider.ProviderId,
                 tLevelDefinition.TLevelDefinitionId,
                 locationVenueIds: new[] { venueId },
                 yourReference: yourReference,
@@ -132,7 +129,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.DeleteTLevel
             // Arrange
             var tLevelDefinitions = await TestData.CreateInitialTLevelDefinitions();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray());
 
@@ -164,17 +161,15 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.DeleteTLevel
             // Arrange
             var tLevelDefinitions = await TestData.CreateInitialTLevelDefinitions();
 
-            var anotherProviderId = await TestData.CreateProvider(
-                ukprn: 23456,
+            var anotherProvider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray());
 
-            var providerId = await TestData.CreateProvider(
-                ukprn: 12345,
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray());
 
-            var venueId = (await TestData.CreateVenue(providerId, venueName: "T Level venue")).Id;
+            var venueId = (await TestData.CreateVenue(provider.ProviderId, venueName: "T Level venue")).Id;
 
             var tLevelDefinition = tLevelDefinitions.First();
 
@@ -182,7 +177,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.DeleteTLevel
             var startDate = new DateTime(2021, 10, 1);
 
             var tLevel = await TestData.CreateTLevel(
-                providerId,
+                provider.ProviderId,
                 tLevelDefinition.TLevelDefinitionId,
                 locationVenueIds: new[] { venueId },
                 yourReference: yourReference,
@@ -200,7 +195,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.DeleteTLevel
 
             CreateJourneyInstance(tLevel.TLevelId);
 
-            await User.AsTestUser(userType, anotherProviderId);
+            await User.AsTestUser(userType, anotherProvider.ProviderId);
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -215,12 +210,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.DeleteTLevel
             // Arrange
             var tLevelDefinitions = await TestData.CreateInitialTLevelDefinitions();
 
-            var providerId = await TestData.CreateProvider(
-                ukprn: 12345,
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray());
 
-            var venueId = (await TestData.CreateVenue(providerId, venueName: "T Level venue")).Id;
+            var venueId = (await TestData.CreateVenue(provider.ProviderId, venueName: "T Level venue")).Id;
 
             var tLevelDefinition = tLevelDefinitions.First();
 
@@ -228,7 +222,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.DeleteTLevel
             var startDate = new DateTime(2021, 10, 1);
 
             var tLevel = await TestData.CreateTLevel(
-                providerId,
+                provider.ProviderId,
                 tLevelDefinition.TLevelDefinitionId,
                 locationVenueIds: new[] { venueId },
                 yourReference: yourReference,
@@ -259,12 +253,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.DeleteTLevel
             // Arrange
             var tLevelDefinitions = await TestData.CreateInitialTLevelDefinitions();
 
-            var providerId = await TestData.CreateProvider(
-                ukprn: 12345,
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray());
 
-            var venueId = (await TestData.CreateVenue(providerId, venueName: "T Level venue")).Id;
+            var venueId = (await TestData.CreateVenue(provider.ProviderId, venueName: "T Level venue")).Id;
 
             var tLevelDefinition = tLevelDefinitions.First();
 
@@ -272,7 +265,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.DeleteTLevel
             var startDate = new DateTime(2021, 10, 1);
 
             var tLevel = await TestData.CreateTLevel(
-                providerId,
+                provider.ProviderId,
                 tLevelDefinition.TLevelDefinitionId,
                 locationVenueIds: new[] { venueId },
                 yourReference: yourReference,
@@ -297,7 +290,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.DeleteTLevel
             response.StatusCode.Should().Be(HttpStatusCode.Found);
 
             response.Headers.Location.OriginalString.Should()
-                .Be($"/t-levels/{tLevel.TLevelId}/delete/success?providerId={providerId}");
+                .Be($"/t-levels/{tLevel.TLevelId}/delete/success?providerId={provider.ProviderId}");
 
             SqlQuerySpy.VerifyQuery<SqlQueries.DeleteTLevel, OneOf<NotFound, Success>>(q => q.TLevelId == tLevel.TLevelId);
         }
@@ -308,12 +301,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.DeleteTLevel
             // Arrange
             var tLevelDefinitions = await TestData.CreateInitialTLevelDefinitions();
 
-            var providerId = await TestData.CreateProvider(
-                ukprn: 12345,
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray());
 
-            var venueId = (await TestData.CreateVenue(providerId, venueName: "T Level venue")).Id;
+            var venueId = (await TestData.CreateVenue(provider.ProviderId, venueName: "T Level venue")).Id;
 
             var tLevelDefinition = tLevelDefinitions.First();
 
@@ -321,7 +313,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.DeleteTLevel
             var startDate = new DateTime(2021, 10, 1);
 
             var tLevel = await TestData.CreateTLevel(
-                providerId,
+                provider.ProviderId,
                 tLevelDefinition.TLevelDefinitionId,
                 locationVenueIds: new[] { venueId },
                 yourReference: yourReference,
@@ -338,16 +330,16 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.DeleteTLevel
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"/t-levels/{tLevel.TLevelId}/delete/success?providerId={providerId}");
+                $"/t-levels/{tLevel.TLevelId}/delete/success?providerId={provider.ProviderId}");
 
-            await User.AsProviderUser(providerId, ProviderType.FE);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.FE);
 
             var journeyInstance = CreateJourneyInstance(
                 tLevel.TLevelId,
                 new JourneyModel()
                 {
                     TLevelName = tLevelDefinition.Name,
-                    ProviderId = providerId,
+                    ProviderId = provider.ProviderId,
                     YourReference = yourReference
                 });
 
@@ -369,12 +361,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.DeleteTLevel
             // Arrange
             var tLevelDefinitions = await TestData.CreateInitialTLevelDefinitions();
 
-            var providerId = await TestData.CreateProvider(
-                ukprn: 12345,
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray());
 
-            var venueId = (await TestData.CreateVenue(providerId, venueName: "T Level venue")).Id;
+            var venueId = (await TestData.CreateVenue(provider.ProviderId, venueName: "T Level venue")).Id;
 
             var tLevelDefinition = tLevelDefinitions.First();
 
@@ -382,7 +373,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.DeleteTLevel
             var startDate = new DateTime(2021, 10, 1);
 
             var tLevel = await TestData.CreateTLevel(
-                providerId,
+                provider.ProviderId,
                 tLevelDefinition.TLevelDefinitionId,
                 locationVenueIds: new[] { venueId },
                 yourReference: yourReference,
@@ -399,16 +390,16 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.DeleteTLevel
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"/t-levels/{tLevel.TLevelId}/delete/success?providerId={providerId}");
+                $"/t-levels/{tLevel.TLevelId}/delete/success?providerId={provider.ProviderId}");
 
-            await User.AsProviderUser(providerId, ProviderType.FE);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.FE);
 
             var journeyInstance = CreateJourneyInstance(
                 tLevel.TLevelId,
                 new JourneyModel()
                 {
                     TLevelName = tLevelDefinition.Name,
-                    ProviderId = providerId,
+                    ProviderId = provider.ProviderId,
                     YourReference = yourReference
                 });
 
@@ -430,12 +421,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.DeleteTLevel
             // Arrange
             var tLevelDefinitions = await TestData.CreateInitialTLevelDefinitions();
 
-            var providerId = await TestData.CreateProvider(
-                ukprn: 12345,
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray());
 
-            var venueId = (await TestData.CreateVenue(providerId, venueName: "T Level venue")).Id;
+            var venueId = (await TestData.CreateVenue(provider.ProviderId, venueName: "T Level venue")).Id;
 
             var tLevelDefinition = tLevelDefinitions.First();
 
@@ -443,7 +433,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.DeleteTLevel
             var startDate = new DateTime(2021, 10, 1);
 
             var tLevel = await TestData.CreateTLevel(
-                providerId,
+                provider.ProviderId,
                 tLevelDefinition.TLevelDefinitionId,
                 locationVenueIds: new[] { venueId },
                 yourReference: yourReference,
@@ -459,23 +449,23 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.DeleteTLevel
                 }));
 
             var anotherTLevel = await TestData.CreateTLevel(
-                providerId,
+                provider.ProviderId,
                 tLevelDefinitions.Last().TLevelDefinitionId,
                 locationVenueIds: new[] { venueId },
                 createdBy: User.ToUserInfo());
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"/t-levels/{tLevel.TLevelId}/delete/success?providerId={providerId}");
+                $"/t-levels/{tLevel.TLevelId}/delete/success?providerId={provider.ProviderId}");
 
-            await User.AsProviderUser(providerId, ProviderType.FE);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.FE);
 
             var journeyInstance = CreateJourneyInstance(
                 tLevel.TLevelId,
                 new JourneyModel()
                 {
                     TLevelName = tLevelDefinition.Name,
-                    ProviderId = providerId,
+                    ProviderId = provider.ProviderId,
                     YourReference = yourReference
                 });
 
@@ -497,12 +487,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.DeleteTLevel
             // Arrange
             var tLevelDefinitions = await TestData.CreateInitialTLevelDefinitions();
 
-            var providerId = await TestData.CreateProvider(
-                ukprn: 12345,
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray());
 
-            var venueId = (await TestData.CreateVenue(providerId, venueName: "T Level venue")).Id;
+            var venueId = (await TestData.CreateVenue(provider.ProviderId, venueName: "T Level venue")).Id;
 
             var tLevelDefinition = tLevelDefinitions.First();
 
@@ -510,7 +499,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.DeleteTLevel
             var startDate = new DateTime(2021, 10, 1);
 
             var tLevel = await TestData.CreateTLevel(
-                providerId,
+                provider.ProviderId,
                 tLevelDefinition.TLevelDefinitionId,
                 locationVenueIds: new[] { venueId },
                 yourReference: yourReference,
@@ -527,16 +516,16 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.DeleteTLevel
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"/t-levels/{tLevel.TLevelId}/delete/success?providerId={providerId}");
+                $"/t-levels/{tLevel.TLevelId}/delete/success?providerId={provider.ProviderId}");
 
-            await User.AsProviderUser(providerId, ProviderType.FE);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.FE);
 
             var journeyInstance = CreateJourneyInstance(
                 tLevel.TLevelId,
                 new JourneyModel()
                 {
                     TLevelName = tLevelDefinition.Name,
-                    ProviderId = providerId,
+                    ProviderId = provider.ProviderId,
                     YourReference = yourReference
                 });
 
@@ -561,19 +550,18 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.DeleteTLevel
             // Arrange
             var tLevelDefinitions = await TestData.CreateInitialTLevelDefinitions();
 
-            var providerId = await TestData.CreateProvider(
-                ukprn: 12345,
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray());
 
-            var venueId = (await TestData.CreateVenue(providerId, venueName: "T Level venue")).Id;
+            var venueId = (await TestData.CreateVenue(provider.ProviderId, venueName: "T Level venue")).Id;
 
             var tLevelDefinition = tLevelDefinitions.First();
 
             var startDate = new DateTime(2021, 10, 1);
 
             var tLevel = await TestData.CreateTLevel(
-                providerId,
+                provider.ProviderId,
                 tLevelDefinition.TLevelDefinitionId,
                 locationVenueIds: new[] { venueId },
                 yourReference: yourReference,
@@ -590,16 +578,16 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.DeleteTLevel
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"/t-levels/{tLevel.TLevelId}/delete/success?providerId={providerId}");
+                $"/t-levels/{tLevel.TLevelId}/delete/success?providerId={provider.ProviderId}");
 
-            await User.AsProviderUser(providerId, ProviderType.FE);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.FE);
 
             var journeyInstance = CreateJourneyInstance(
                 tLevel.TLevelId,
                 new JourneyModel()
                 {
                     TLevelName = tLevelDefinition.Name,
-                    ProviderId = providerId,
+                    ProviderId = provider.ProviderId,
                     YourReference = yourReference
                 });
 

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/TLevels/Reporting/LiveTLevelsReportTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/TLevels/Reporting/LiveTLevelsReportTests.cs
@@ -25,8 +25,8 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.Reporting
         public async Task LiveTLevelsReport_WithProviderUser_ReturnsForbidden(TestUserType userType)
         {
             //Arange
-            var providerId = await TestData.CreateProvider();
-            await User.AsTestUser(userType, providerId);
+            var provider = await TestData.CreateProvider();
+            await User.AsTestUser(userType, provider.ProviderId);
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
@@ -51,9 +51,9 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.Reporting
             {
                 var providerName = $"TestProvider{i}";
 
-                var providerId = await TestData.CreateProvider(ukprn: i, providerName: providerName, providerType: ProviderType.TLevels, tLevelDefinitionIds: tLevelDefinitions.Select(d => d.TLevelDefinitionId).ToArray());
+                var provider = await TestData.CreateProvider(providerName: providerName, providerType: ProviderType.TLevels, tLevelDefinitionIds: tLevelDefinitions.Select(d => d.TLevelDefinitionId).ToArray());
 
-                return new { ProviderId = providerId, Ukprn = i, ProviderName = providerName };
+                return new { ProviderId = provider.ProviderId, Ukprn = provider.Ukprn, ProviderName = providerName };
             }));
 
             var tLevels = (await Task.WhenAll(providers.Select(async (p, i) =>

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/TLevels/ViewAndEditTLevel/AddAnotherLocationTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/TLevels/ViewAndEditTLevel/AddAnotherLocationTests.cs
@@ -26,18 +26,18 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.ViewAndEditTLevel
         public async Task Post_UserCannotAccessTLevel_ReturnsForbidden(TestUserType userType)
         {
             // Arrange
-            var anotherProviderId = await TestData.CreateProvider(ukprn: 23456, providerType: ProviderType.TLevels);
+            var anotherProvider = await TestData.CreateProvider(providerType: ProviderType.TLevels);
 
             var tLevelDefinitions = await TestData.CreateInitialTLevelDefinitions();
 
             var authorizedTLevelDefinitionIds = tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: authorizedTLevelDefinitionIds);
 
-            var venue = await TestData.CreateVenue(providerId, venueName: "T Level venue");
-            var venue2 = await TestData.CreateVenue(providerId, venueName: "Another T Level venue");
+            var venue = await TestData.CreateVenue(provider.ProviderId, venueName: "T Level venue");
+            var venue2 = await TestData.CreateVenue(provider.ProviderId, venueName: "Another T Level venue");
 
             var tLevelDefinition = tLevelDefinitions.First();
             var initialWhoFor = "Who for";
@@ -51,7 +51,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.ViewAndEditTLevel
             var initialWebsite = "http://example.com/tlevel";
 
             var tLevel = await TestData.CreateTLevel(
-                providerId,
+                provider.ProviderId,
                 tLevelDefinition.TLevelDefinitionId,
                 whoFor: initialWhoFor,
                 entryRequirements: initialEntryRequirements,
@@ -98,7 +98,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.ViewAndEditTLevel
                     .ToContent()
             };
 
-            await User.AsTestUser(userType, anotherProviderId);
+            await User.AsTestUser(userType, anotherProvider.ProviderId);
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -135,12 +135,12 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.ViewAndEditTLevel
 
             var authorizedTLevelDefinitionIds = tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: authorizedTLevelDefinitionIds);
 
-            var venue = await TestData.CreateVenue(providerId, venueName: "T Level venue");
-            var venue2 = await TestData.CreateVenue(providerId, venueName: "Another T Level venue");
+            var venue = await TestData.CreateVenue(provider.ProviderId, venueName: "T Level venue");
+            var venue2 = await TestData.CreateVenue(provider.ProviderId, venueName: "Another T Level venue");
 
             var tLevelDefinition = tLevelDefinitions.First();
             var initialWhoFor = "Who for";
@@ -154,7 +154,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.ViewAndEditTLevel
             var initialWebsite = "http://example.com/tlevel";
 
             var tLevel = await TestData.CreateTLevel(
-                providerId,
+                provider.ProviderId,
                 tLevelDefinition.TLevelDefinitionId,
                 whoFor: initialWhoFor,
                 entryRequirements: initialEntryRequirements,

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/TLevels/ViewAndEditTLevel/CheckAndPublishTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/TLevels/ViewAndEditTLevel/CheckAndPublishTests.cs
@@ -29,17 +29,17 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.ViewAndEditTLevel
         public async Task Get_UserCannotAccessTLevel_ReturnsForbidden(TestUserType userType)
         {
             // Arrange
-            var anotherProviderId = await TestData.CreateProvider(ukprn: 23456, providerType: ProviderType.TLevels);
+            var anotherProvider = await TestData.CreateProvider(providerType: ProviderType.TLevels);
 
             var tLevelDefinitions = await TestData.CreateInitialTLevelDefinitions();
 
             var authorizedTLevelDefinitionIds = tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: authorizedTLevelDefinitionIds);
 
-            var venue = await TestData.CreateVenue(providerId, venueName: "T Level venue");
+            var venue = await TestData.CreateVenue(provider.ProviderId, venueName: "T Level venue");
 
             var tLevelDefinition = tLevelDefinitions.First();
             var whoFor = "Who for";
@@ -53,7 +53,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.ViewAndEditTLevel
             var website = "http://example.com/tlevel";
 
             var tLevel = await TestData.CreateTLevel(
-                providerId,
+                provider.ProviderId,
                 tLevelDefinition.TLevelDefinitionId,
                 whoFor: whoFor,
                 entryRequirements: entryRequirements,
@@ -73,7 +73,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.ViewAndEditTLevel
                 HttpMethod.Get,
                 $"/t-levels/{tLevel.TLevelId}/check-publish?ffiid={journeyInstance.InstanceId.UniqueKey}");
 
-            await User.AsTestUser(userType, anotherProviderId);
+            await User.AsTestUser(userType, anotherProvider.ProviderId);
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -107,11 +107,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.ViewAndEditTLevel
 
             var authorizedTLevelDefinitionIds = tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: authorizedTLevelDefinitionIds);
 
-            var venue = await TestData.CreateVenue(providerId, venueName: "T Level venue");
+            var venue = await TestData.CreateVenue(provider.ProviderId, venueName: "T Level venue");
 
             var tLevelDefinition = tLevelDefinitions.First();
             var whoFor = "Who for";
@@ -125,7 +125,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.ViewAndEditTLevel
             var website = "http://example.com/tlevel";
 
             var tLevel = await TestData.CreateTLevel(
-                providerId,
+                provider.ProviderId,
                 tLevelDefinition.TLevelDefinitionId,
                 whoFor: whoFor,
                 entryRequirements: entryRequirements,
@@ -175,17 +175,17 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.ViewAndEditTLevel
         public async Task Post_UserCannotAccessTLevel_ReturnsForbidden(TestUserType userType)
         {
             // Arrange
-            var anotherProviderId = await TestData.CreateProvider(ukprn: 23456, providerType: ProviderType.TLevels);
+            var anotherProvider = await TestData.CreateProvider(providerType: ProviderType.TLevels);
 
             var tLevelDefinitions = await TestData.CreateInitialTLevelDefinitions();
 
             var authorizedTLevelDefinitionIds = tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: authorizedTLevelDefinitionIds);
 
-            var venue = await TestData.CreateVenue(providerId, venueName: "T Level venue");
+            var venue = await TestData.CreateVenue(provider.ProviderId, venueName: "T Level venue");
 
             var tLevelDefinition = tLevelDefinitions.First();
             var whoFor = "Who for";
@@ -199,7 +199,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.ViewAndEditTLevel
             var website = "http://example.com/tlevel";
 
             var tLevel = await TestData.CreateTLevel(
-                providerId,
+                provider.ProviderId,
                 tLevelDefinition.TLevelDefinitionId,
                 whoFor: whoFor,
                 entryRequirements: entryRequirements,
@@ -222,7 +222,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.ViewAndEditTLevel
                 Content = new FormUrlEncodedContentBuilder().ToContent()
             };
 
-            await User.AsTestUser(userType, anotherProviderId);
+            await User.AsTestUser(userType, anotherProvider.ProviderId);
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -259,11 +259,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.ViewAndEditTLevel
 
             var authorizedTLevelDefinitionIds = tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: authorizedTLevelDefinitionIds);
 
-            var venue = await TestData.CreateVenue(providerId, venueName: "T Level venue");
+            var venue = await TestData.CreateVenue(provider.ProviderId, venueName: "T Level venue");
 
             var tLevelDefinition = tLevelDefinitions.First();
             var whoFor = "Who for";
@@ -277,7 +277,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.ViewAndEditTLevel
             var website = "http://example.com/tlevel";
 
             var tLevel = await TestData.CreateTLevel(
-                providerId,
+                provider.ProviderId,
                 tLevelDefinition.TLevelDefinitionId,
                 whoFor: whoFor,
                 entryRequirements: entryRequirements,
@@ -316,11 +316,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.ViewAndEditTLevel
 
             var authorizedTLevelDefinitionIds = tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: authorizedTLevelDefinitionIds);
 
-            var venue = await TestData.CreateVenue(providerId, venueName: "T Level venue");
+            var venue = await TestData.CreateVenue(provider.ProviderId, venueName: "T Level venue");
 
             var tLevelDefinition = tLevelDefinitions.First();
             var whoFor = "Who for";
@@ -334,7 +334,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.ViewAndEditTLevel
             var website = "http://example.com/tlevel";
 
             var tLevel = await TestData.CreateTLevel(
-                providerId,
+                provider.ProviderId,
                 tLevelDefinition.TLevelDefinitionId,
                 whoFor: whoFor,
                 entryRequirements: entryRequirements,
@@ -354,7 +354,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.ViewAndEditTLevel
             journeyInstance.UpdateState(state => state.StartDate = updatedStartDate);
 
             var anotherTLevel = await TestData.CreateTLevel(
-                providerId,
+                provider.ProviderId,
                 tLevelDefinition.TLevelDefinitionId,
                 whoFor: whoFor,
                 entryRequirements: entryRequirements,
@@ -393,11 +393,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.ViewAndEditTLevel
 
             var authorizedTLevelDefinitionIds = tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: authorizedTLevelDefinitionIds);
 
-            var venue = await TestData.CreateVenue(providerId, venueName: "T Level venue");
+            var venue = await TestData.CreateVenue(provider.ProviderId, venueName: "T Level venue");
 
             var tLevelDefinition = tLevelDefinitions.First();
             var whoFor = "Who for";
@@ -411,7 +411,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.ViewAndEditTLevel
             var website = "http://example.com/tlevel";
 
             var tLevel = await TestData.CreateTLevel(
-                providerId,
+                provider.ProviderId,
                 tLevelDefinition.TLevelDefinitionId,
                 whoFor: whoFor,
                 entryRequirements: entryRequirements,

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/TLevels/ViewAndEditTLevel/EditTLevelTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/TLevels/ViewAndEditTLevel/EditTLevelTests.cs
@@ -26,17 +26,17 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.ViewAndEditTLevel
         public async Task Get_UserCannotAccessTLevel_ReturnsForbidden(TestUserType userType)
         {
             // Arrange
-            var anotherProviderId = await TestData.CreateProvider(ukprn: 23456, providerType: ProviderType.TLevels);
+            var anotherProvider = await TestData.CreateProvider(providerType: ProviderType.TLevels);
 
             var tLevelDefinitions = await TestData.CreateInitialTLevelDefinitions();
 
             var authorizedTLevelDefinitionIds = tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: authorizedTLevelDefinitionIds);
 
-            var venue = await TestData.CreateVenue(providerId, venueName: "T Level venue");
+            var venue = await TestData.CreateVenue(provider.ProviderId, venueName: "T Level venue");
 
             var tLevelDefinition = tLevelDefinitions.First();
             var whoFor = "Who for";
@@ -50,7 +50,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.ViewAndEditTLevel
             var website = "http://example.com/tlevel";
 
             var tLevel = await TestData.CreateTLevel(
-                providerId,
+                provider.ProviderId,
                 tLevelDefinition.TLevelDefinitionId,
                 whoFor: whoFor,
                 entryRequirements: entryRequirements,
@@ -70,7 +70,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.ViewAndEditTLevel
                 HttpMethod.Get,
                 $"/t-levels/{tLevel.TLevelId}/edit?ffiid={journeyInstance.InstanceId.UniqueKey}");
 
-            await User.AsTestUser(userType, anotherProviderId);
+            await User.AsTestUser(userType, anotherProvider.ProviderId);
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -83,13 +83,13 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.ViewAndEditTLevel
         public async Task Get_TLevelDoesNotExist_ReturnsNotFound()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(providerType: ProviderType.TLevels);
+            var provider = await TestData.CreateProvider(providerType: ProviderType.TLevels);
 
             var tLevelId = Guid.NewGuid();
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"/t-levels/{tLevelId}/edit&providerId={providerId}");
+                $"/t-levels/{tLevelId}/edit&providerId={provider.ProviderId}");
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -106,12 +106,12 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.ViewAndEditTLevel
 
             var authorizedTLevelDefinitionIds = tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: authorizedTLevelDefinitionIds);
 
-            var venue = await TestData.CreateVenue(providerId, venueName: "T Level venue");
-            var anotherVenue = await TestData.CreateVenue(providerId, venueName: "Another T Level venue");
+            var venue = await TestData.CreateVenue(provider.ProviderId, venueName: "T Level venue");
+            var anotherVenue = await TestData.CreateVenue(provider.ProviderId, venueName: "Another T Level venue");
 
             var tLevelDefinition = tLevelDefinitions.First();
             var whoFor = "Who for";
@@ -125,7 +125,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.ViewAndEditTLevel
             var website = "http://example.com/tlevel";
 
             var tLevel = await TestData.CreateTLevel(
-                providerId,
+                provider.ProviderId,
                 tLevelDefinition.TLevelDefinitionId,
                 whoFor: whoFor,
                 entryRequirements: entryRequirements,
@@ -163,11 +163,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.ViewAndEditTLevel
 
             var authorizedTLevelDefinitionIds = tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: authorizedTLevelDefinitionIds);
 
-            var venue = await TestData.CreateVenue(providerId, venueName: "T Level venue");
+            var venue = await TestData.CreateVenue(provider.ProviderId, venueName: "T Level venue");
 
             var tLevelDefinition = tLevelDefinitions.First();
             var whoFor = "Who for";
@@ -181,7 +181,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.ViewAndEditTLevel
             var website = "http://example.com/tlevel";
 
             var tLevel = await TestData.CreateTLevel(
-                providerId,
+                provider.ProviderId,
                 tLevelDefinition.TLevelDefinitionId,
                 whoFor: whoFor,
                 entryRequirements: entryRequirements,
@@ -235,18 +235,18 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.ViewAndEditTLevel
         public async Task Post_UserCannotAccessTLevel_ReturnsForbidden(TestUserType userType)
         {
             // Arrange
-            var anotherProviderId = await TestData.CreateProvider(ukprn: 23456, providerType: ProviderType.TLevels);
+            var anotherProvider = await TestData.CreateProvider(providerType: ProviderType.TLevels);
 
             var tLevelDefinitions = await TestData.CreateInitialTLevelDefinitions();
 
             var authorizedTLevelDefinitionIds = tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: authorizedTLevelDefinitionIds);
 
-            var venue = await TestData.CreateVenue(providerId, venueName: "T Level venue");
-            var venue2 = await TestData.CreateVenue(providerId, venueName: "Another T Level venue");
+            var venue = await TestData.CreateVenue(provider.ProviderId, venueName: "T Level venue");
+            var venue2 = await TestData.CreateVenue(provider.ProviderId, venueName: "Another T Level venue");
 
             var tLevelDefinition = tLevelDefinitions.First();
             var initialWhoFor = "Who for";
@@ -260,7 +260,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.ViewAndEditTLevel
             var initialWebsite = "http://example.com/tlevel";
 
             var tLevel = await TestData.CreateTLevel(
-                providerId,
+                provider.ProviderId,
                 tLevelDefinition.TLevelDefinitionId,
                 whoFor: initialWhoFor,
                 entryRequirements: initialEntryRequirements,
@@ -308,7 +308,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.ViewAndEditTLevel
                     .ToContent()
             };
 
-            await User.AsTestUser(userType, anotherProviderId);
+            await User.AsTestUser(userType, anotherProvider.ProviderId);
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -325,11 +325,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.ViewAndEditTLevel
 
             var authorizedTLevelDefinitionIds = tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: authorizedTLevelDefinitionIds);
 
-            var venue2 = await TestData.CreateVenue(providerId, venueName: "Another T Level venue");
+            var venue2 = await TestData.CreateVenue(provider.ProviderId, venueName: "Another T Level venue");
 
             var tLevelId = Guid.NewGuid();
 
@@ -378,12 +378,12 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.ViewAndEditTLevel
 
             var authorizedTLevelDefinitionIds = tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: authorizedTLevelDefinitionIds);
 
-            var venue = await TestData.CreateVenue(providerId, venueName: "T Level venue");
-            var venue2 = await TestData.CreateVenue(providerId, venueName: "Another T Level venue");
+            var venue = await TestData.CreateVenue(provider.ProviderId, venueName: "T Level venue");
+            var venue2 = await TestData.CreateVenue(provider.ProviderId, venueName: "Another T Level venue");
 
             var tLevelDefinition = tLevelDefinitions.First();
             var initialWhoFor = "Who for";
@@ -397,7 +397,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.ViewAndEditTLevel
             var initialWebsite = "http://example.com/tlevel";
 
             var tLevel = await TestData.CreateTLevel(
-                providerId,
+                provider.ProviderId,
                 tLevelDefinition.TLevelDefinitionId,
                 whoFor: initialWhoFor,
                 entryRequirements: initialEntryRequirements,

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/TLevels/ViewAndEditTLevel/ViewTLevelTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/TLevels/ViewAndEditTLevel/ViewTLevelTests.cs
@@ -23,18 +23,18 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.ViewAndEditTLevel
         public async Task Get_UserCannotAccessTLevel_ReturnsForbidden(TestUserType userType)
         {
             // Arrange
-            var anotherProviderId = await TestData.CreateProvider(ukprn: 23456, providerType: ProviderType.TLevels);
+            var anotherProvider = await TestData.CreateProvider(providerType: ProviderType.TLevels);
 
             var tLevelDefinitions = await TestData.CreateInitialTLevelDefinitions();
 
             var authorizedTLevelDefinitionIds = tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: authorizedTLevelDefinitionIds);
 
-            var venue = await TestData.CreateVenue(providerId, venueName: "T Level venue");
-            var anotherVenue = await TestData.CreateVenue(providerId, venueName: "Another T Level venue");
+            var venue = await TestData.CreateVenue(provider.ProviderId, venueName: "T Level venue");
+            var anotherVenue = await TestData.CreateVenue(provider.ProviderId, venueName: "Another T Level venue");
 
             var tLevelDefinition = tLevelDefinitions.First();
             var whoFor = "Who for";
@@ -48,7 +48,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.ViewAndEditTLevel
             var website = "http://example.com/tlevel";
 
             var tLevel = await TestData.CreateTLevel(
-                providerId,
+                provider.ProviderId,
                 tLevelDefinition.TLevelDefinitionId,
                 whoFor: whoFor,
                 entryRequirements: entryRequirements,
@@ -64,7 +64,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.ViewAndEditTLevel
 
             var request = new HttpRequestMessage(HttpMethod.Get, $"/t-levels/{tLevel.TLevelId}");
 
-            await User.AsTestUser(userType, anotherProviderId);
+            await User.AsTestUser(userType, anotherProvider.ProviderId);
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -96,12 +96,12 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.ViewAndEditTLevel
 
             var authorizedTLevelDefinitionIds = tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: authorizedTLevelDefinitionIds);
 
-            var venue = await TestData.CreateVenue(providerId, venueName: "T Level venue");
-            var anotherVenue = await TestData.CreateVenue(providerId, venueName: "Another T Level venue");
+            var venue = await TestData.CreateVenue(provider.ProviderId, venueName: "T Level venue");
+            var anotherVenue = await TestData.CreateVenue(provider.ProviderId, venueName: "Another T Level venue");
 
             var tLevelDefinition = tLevelDefinitions.First();
             var whoFor = "Who for";
@@ -115,7 +115,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.ViewAndEditTLevel
             var website = "http://example.com/tlevel";
 
             var tLevel = await TestData.CreateTLevel(
-                providerId,
+                provider.ProviderId,
                 tLevelDefinition.TLevelDefinitionId,
                 whoFor: whoFor,
                 entryRequirements: entryRequirements,

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/TLevels/ViewTLevels/ViewTLevelsTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/TLevels/ViewTLevels/ViewTLevelsTests.cs
@@ -27,12 +27,12 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.ViewTLevels
         public async Task List_Get_ProviderIsNotTLevelsProvider_ReturnsForbidden(ProviderType providerType)
         {
             //Arange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: providerType);
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"/t-levels?providerId={providerId}");
+                $"/t-levels?providerId={provider.ProviderId}");
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -45,12 +45,12 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.ViewTLevels
         public async Task List_Get_WithNoTLevels_ReturnsExpectedContent()
         {
             //Arange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels);
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"/t-levels?providerId={providerId}");
+                $"/t-levels?providerId={provider.ProviderId}");
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -70,22 +70,22 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.TLevels.ViewTLevels
 
             var providerTLevelDefinitionIds = tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: providerTLevelDefinitionIds);
 
-            var venue1 = await TestData.CreateVenue(providerId, venueName: "TestVenue1");
-            var venue2 = await TestData.CreateVenue(providerId, venueName: "TestVenue2");
+            var venue1 = await TestData.CreateVenue(provider.ProviderId, venueName: "TestVenue1");
+            var venue2 = await TestData.CreateVenue(provider.ProviderId, venueName: "TestVenue2");
 
             var user = await TestData.CreateUser();
 
-            var tLevel1 = await CreateTLevel(providerId, tLevelDefinitions.First().TLevelDefinitionId, new[] { venue1.Id }, user, DateTime.UtcNow.AddMonths(1).Date, 1);
-            var tLevel2 = await CreateTLevel(providerId, tLevelDefinitions.Skip(1).First().TLevelDefinitionId, new[] { venue1.Id, venue2.Id }, user, DateTime.UtcNow.AddMonths(2).Date, 2);
-            var tLevel3 = await CreateTLevel(providerId, tLevelDefinitions.First().TLevelDefinitionId, new[] { venue2.Id }, user, DateTime.UtcNow.AddMonths(6).Date, 3);
+            var tLevel1 = await CreateTLevel(provider.ProviderId, tLevelDefinitions.First().TLevelDefinitionId, new[] { venue1.Id }, user, DateTime.UtcNow.AddMonths(1).Date, 1);
+            var tLevel2 = await CreateTLevel(provider.ProviderId, tLevelDefinitions.Skip(1).First().TLevelDefinitionId, new[] { venue1.Id, venue2.Id }, user, DateTime.UtcNow.AddMonths(2).Date, 2);
+            var tLevel3 = await CreateTLevel(provider.ProviderId, tLevelDefinitions.First().TLevelDefinitionId, new[] { venue2.Id }, user, DateTime.UtcNow.AddMonths(6).Date, 3);
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"/t-levels?providerId={providerId}");
+                $"/t-levels?providerId={provider.ProviderId}");
 
             // Act
             var response = await HttpClient.SendAsync(request);

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/Venues/AddVenue/AddressTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/Venues/AddVenue/AddressTests.cs
@@ -27,7 +27,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.AddVenue
         public async Task Get_JourneyIsCompleted_ReturnsConflict()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
+            var provider = await TestData.CreateProvider();
 
             var addressLine1 = "Test Venue line 1";
             var addressLine2 = "Test Venue line 2";
@@ -36,7 +36,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.AddVenue
             var postcode = "AB1 2DE";
 
             var journeyInstance = CreateJourneyInstance(
-                providerId,
+                provider.ProviderId,
                 new AddVenueJourneyModel()
                 {
                     AddressLine1 = addressLine1,
@@ -50,7 +50,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.AddVenue
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"/venues/add/address?providerId={providerId}&ffiid={journeyInstance.InstanceId.UniqueKey}");
+                $"/venues/add/address?providerId={provider.ProviderId}&ffiid={journeyInstance.InstanceId.UniqueKey}");
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -68,13 +68,13 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.AddVenue
             string expectedPostcodeInputValue)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
+            var provider = await TestData.CreateProvider();
 
-            var journeyInstance = CreateJourneyInstance(providerId);
+            var journeyInstance = CreateJourneyInstance(provider.ProviderId);
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"/venues/add/address?providerId={providerId}&ffiid={journeyInstance.InstanceId.UniqueKey}&postcode={requestPostcode}");
+                $"/venues/add/address?providerId={provider.ProviderId}&ffiid={journeyInstance.InstanceId.UniqueKey}&postcode={requestPostcode}");
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -97,7 +97,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.AddVenue
         public async Task Get_ValidRequest_RendersExpectedOutput()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
+            var provider = await TestData.CreateProvider();
 
             var addressLine1 = "Test Venue line 1";
             var addressLine2 = "Test Venue line 2";
@@ -106,7 +106,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.AddVenue
             var postcode = "AB1 2DE";
 
             var journeyInstance = CreateJourneyInstance(
-                providerId,
+                provider.ProviderId,
                 new AddVenueJourneyModel()
                 {
                     AddressLine1 = addressLine1,
@@ -118,7 +118,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.AddVenue
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"/venues/add/address?providerId={providerId}&ffiid={journeyInstance.InstanceId.UniqueKey}");
+                $"/venues/add/address?providerId={provider.ProviderId}&ffiid={journeyInstance.InstanceId.UniqueKey}");
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -141,7 +141,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.AddVenue
         public async Task Post_JourneyIsCompleted_ReturnsConflict()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
+            var provider = await TestData.CreateProvider();
 
             var addressLine1 = "Test Venue line 1";
             var addressLine2 = "Test Venue line 2";
@@ -172,13 +172,13 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.AddVenue
                     }
                 });
 
-            var journeyInstance = CreateJourneyInstance(providerId);
+            var journeyInstance = CreateJourneyInstance(provider.ProviderId);
 
             GetJourneyInstance<AddVenueJourneyModel>(journeyInstance.InstanceId).Complete();
 
             var request = new HttpRequestMessage(
                 HttpMethod.Post,
-                $"/venues/add/address?providerId={providerId}&ffiid={journeyInstance.InstanceId.UniqueKey}")
+                $"/venues/add/address?providerId={provider.ProviderId}&ffiid={journeyInstance.InstanceId.UniqueKey}")
             {
                 Content = new FormUrlEncodedContentBuilder()
                     .Add("AddressLine1", addressLine1)
@@ -208,7 +208,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.AddVenue
             string expectedErrorMessage)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
+            var provider = await TestData.CreateProvider();
 
             var postcodeLatitude = 42M;
             var postcodeLongitude = 43M;
@@ -232,11 +232,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.AddVenue
                     }
                 });
 
-            var journeyInstance = CreateJourneyInstance(providerId);
+            var journeyInstance = CreateJourneyInstance(provider.ProviderId);
 
             var request = new HttpRequestMessage(
                 HttpMethod.Post,
-                $"/venues/add/address?providerId={providerId}&ffiid={journeyInstance.InstanceId.UniqueKey}")
+                $"/venues/add/address?providerId={provider.ProviderId}&ffiid={journeyInstance.InstanceId.UniqueKey}")
             {
                 Content = new FormUrlEncodedContentBuilder()
                     .Add("AddressLine1", addressLine1)
@@ -265,7 +265,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.AddVenue
             bool expectedNewAddressIsOutsideOfEnglandValue)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
+            var provider = await TestData.CreateProvider();
 
             var addressLine1 = "Test Venue line 1";
             var addressLine2 = "Test Venue line 2";
@@ -295,11 +295,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.AddVenue
                     }
                 });
 
-            var journeyInstance = CreateJourneyInstance(providerId);
+            var journeyInstance = CreateJourneyInstance(provider.ProviderId);
 
             var request = new HttpRequestMessage(
                 HttpMethod.Post,
-                $"/venues/add/address?providerId={providerId}&ffiid={journeyInstance.InstanceId.UniqueKey}")
+                $"/venues/add/address?providerId={provider.ProviderId}&ffiid={journeyInstance.InstanceId.UniqueKey}")
             {
                 Content = new FormUrlEncodedContentBuilder()
                     .Add("AddressLine1", addressLine1)
@@ -317,7 +317,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.AddVenue
             response.StatusCode.Should().Be(HttpStatusCode.Found);
 
             response.Headers.Location.OriginalString.Should()
-                .Be($"/venues/add/details?providerId={providerId}&ffiid={journeyInstance.InstanceId.UniqueKey}");
+                .Be($"/venues/add/details?providerId={provider.ProviderId}&ffiid={journeyInstance.InstanceId.UniqueKey}");
 
             using (new AssertionScope())
             {
@@ -337,7 +337,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.AddVenue
         public async Task Post_ValidRequest_NormalizesPostcode()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
+            var provider = await TestData.CreateProvider();
 
             var inputPostcode = "ab12de";
 
@@ -370,11 +370,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.AddVenue
                     }
                 });
 
-            var journeyInstance = CreateJourneyInstance(providerId);
+            var journeyInstance = CreateJourneyInstance(provider.ProviderId);
 
             var request = new HttpRequestMessage(
                 HttpMethod.Post,
-                $"/venues/add/address?providerId={providerId}&ffiid={journeyInstance.InstanceId.UniqueKey}")
+                $"/venues/add/address?providerId={provider.ProviderId}&ffiid={journeyInstance.InstanceId.UniqueKey}")
             {
                 Content = new FormUrlEncodedContentBuilder()
                     .Add("AddressLine1", addressLine1)
@@ -392,7 +392,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.AddVenue
             response.StatusCode.Should().Be(HttpStatusCode.Found);
 
             response.Headers.Location.OriginalString.Should()
-                .Be($"/venues/add/details?providerId={providerId}&ffiid={journeyInstance.InstanceId.UniqueKey}");
+                .Be($"/venues/add/details?providerId={provider.ProviderId}&ffiid={journeyInstance.InstanceId.UniqueKey}");
 
             journeyInstance = GetJourneyInstance<AddVenueJourneyModel>(journeyInstance.InstanceId);
             journeyInstance.State.Postcode.Should().Be(normalizedPostcode);

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/Venues/AddVenue/CheckAndPublishTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/Venues/AddVenue/CheckAndPublishTests.cs
@@ -26,7 +26,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.AddVenue
         public async Task Get_ReturnsExpectedOutput(bool addressIsOutsideOfEngland)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
+            var provider = await TestData.CreateProvider();
 
             var addressLine1 = "Test Venue line 1";
             var addressLine2 = "Test Venue line 2";
@@ -39,7 +39,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.AddVenue
             var website = "example.com";
 
             var journeyInstance = CreateJourneyInstance(
-                providerId,
+                provider.ProviderId,
                 new AddVenueJourneyModel()
                 {
                     AddressLine1 = addressLine1,
@@ -59,7 +59,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.AddVenue
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"/venues/add/check-publish?providerId={providerId}&ffiid={journeyInstance.InstanceId.UniqueKey}");
+                $"/venues/add/check-publish?providerId={provider.ProviderId}&ffiid={journeyInstance.InstanceId.UniqueKey}");
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -91,8 +91,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.AddVenue
         public async Task Post_ValidRequest_CreatesVenueCompletesJourneyAndRedirects()
         {
             // Arrange
-            var ukprn = 12345;
-            var providerId = await TestData.CreateProvider(ukprn: ukprn);
+            var provider = await TestData.CreateProvider();
 
             var addressLine1 = "Test Venue line 1";
             var addressLine2 = "Test Venue line 2";
@@ -107,7 +106,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.AddVenue
             var longitude = 43M;
 
             var journeyInstance = CreateJourneyInstance(
-                providerId,
+                provider.ProviderId,
                 new AddVenueJourneyModel()
                 {
                     AddressLine1 = addressLine1,
@@ -127,7 +126,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.AddVenue
 
             var request = new HttpRequestMessage(
                 HttpMethod.Post,
-                $"/venues/add/publish?providerId={providerId}&ffiid={journeyInstance.InstanceId.UniqueKey}");
+                $"/venues/add/publish?providerId={provider.ProviderId}&ffiid={journeyInstance.InstanceId.UniqueKey}");
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -136,12 +135,12 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.AddVenue
             response.StatusCode.Should().Be(HttpStatusCode.Found);
 
             response.Headers.Location.OriginalString.Should().Be(
-                $"/venues/add/success?providerId={providerId}&ffiid={journeyInstance.InstanceId.UniqueKey}");
+                $"/venues/add/success?providerId={provider.ProviderId}&ffiid={journeyInstance.InstanceId.UniqueKey}");
 
             GetJourneyInstance<AddVenueJourneyModel>(journeyInstance.InstanceId).Completed.Should().BeTrue();
 
             CosmosDbQueryDispatcher.VerifyExecuteQuery<CreateVenue, Success>(q =>
-                q.ProviderUkprn == ukprn &&
+                q.ProviderUkprn == provider.Ukprn &&
                 q.Name == name &&
                 q.Email == email &&
                 q.Telephone == telephone &&

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/Venues/AddVenue/DetailsTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/Venues/AddVenue/DetailsTests.cs
@@ -24,7 +24,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.AddVenue
         public async Task Get_ValidRequest_ReturnsExpectedOutput()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
+            var provider = await TestData.CreateProvider();
 
             var name = "My Venue";
             var email = "email@example.com";
@@ -32,7 +32,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.AddVenue
             var website = "example.com";
 
             var journeyInstance = CreateJourneyInstance(
-                providerId,
+                provider.ProviderId,
                 new AddVenueJourneyModel()
                 {
                     Name = name,
@@ -44,7 +44,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.AddVenue
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"/venues/add/details?providerId={providerId}&ffiid={journeyInstance.InstanceId.UniqueKey}");
+                $"/venues/add/details?providerId={provider.ProviderId}&ffiid={journeyInstance.InstanceId.UniqueKey}");
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -73,13 +73,13 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.AddVenue
             string expectedErrorMessage)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
+            var provider = await TestData.CreateProvider();
 
             // Create another venue for the provider for testing the unique venue name error case
-            await TestData.CreateVenue(providerId, venueName: "Existing Venue");
+            await TestData.CreateVenue(provider.ProviderId, venueName: "Existing Venue");
 
             var journeyInstance = CreateJourneyInstance(
-                providerId,
+                provider.ProviderId,
                 new AddVenueJourneyModel()
                 {
                     ValidStages = AddVenueCompletedStages.Address
@@ -87,7 +87,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.AddVenue
 
             var request = new HttpRequestMessage(
                 HttpMethod.Post,
-                $"/venues/add/details?providerId={providerId}&ffiid={journeyInstance.InstanceId.UniqueKey}")
+                $"/venues/add/details?providerId={provider.ProviderId}&ffiid={journeyInstance.InstanceId.UniqueKey}")
             {
                 Content = new FormUrlEncodedContentBuilder()
                     .Add("Name", name)
@@ -111,7 +111,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.AddVenue
         public async Task Post_ValidRequest_UpdatesJourneyStateAndRedirects()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
+            var provider = await TestData.CreateProvider();
 
             var name = "My Venue";
             var email = "email@example.com";
@@ -119,7 +119,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.AddVenue
             var website = "example.com";
 
             var journeyInstance = CreateJourneyInstance(
-                providerId,
+                provider.ProviderId,
                 new AddVenueJourneyModel()
                 {
                     ValidStages = AddVenueCompletedStages.Address
@@ -127,7 +127,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.AddVenue
 
             var request = new HttpRequestMessage(
                 HttpMethod.Post,
-                $"/venues/add/details?providerId={providerId}&ffiid={journeyInstance.InstanceId.UniqueKey}")
+                $"/venues/add/details?providerId={provider.ProviderId}&ffiid={journeyInstance.InstanceId.UniqueKey}")
             {
                 Content = new FormUrlEncodedContentBuilder()
                     .Add("Name", name)
@@ -144,7 +144,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.AddVenue
             response.StatusCode.Should().Be(HttpStatusCode.Found);
 
             response.Headers.Location.OriginalString.Should()
-                .Be($"/venues/add/check-publish?providerId={providerId}&ffiid={journeyInstance.InstanceId.UniqueKey}");
+                .Be($"/venues/add/check-publish?providerId={provider.ProviderId}&ffiid={journeyInstance.InstanceId.UniqueKey}");
 
             using (new AssertionScope())
             {

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/Venues/AddVenue/PostcodeSearchTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/Venues/AddVenue/PostcodeSearchTests.cs
@@ -27,15 +27,15 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.AddVenue
         public async Task PostcodeSearch_InvalidPostcode_RendersError()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
+            var provider = await TestData.CreateProvider();
 
             var postcode = "xxx";
 
-            var journeyInstance = CreateJourneyInstance(providerId);
+            var journeyInstance = CreateJourneyInstance(provider.ProviderId);
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"/venues/add/postcode-search?providerId={providerId}&ffiid={journeyInstance.InstanceId.UniqueKey}&postcode={postcode}");
+                $"/venues/add/postcode-search?providerId={provider.ProviderId}&ffiid={journeyInstance.InstanceId.UniqueKey}&postcode={postcode}");
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -51,7 +51,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.AddVenue
         public async Task PostcodeSearch_PostcodeNotInOnspdData_RendersError()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
+            var provider = await TestData.CreateProvider();
 
             var town = "Town";
             var postcode = "AB1 2DE";
@@ -65,11 +65,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.AddVenue
 
             ConfigureAddressSearchServiceResults(postcode, town, resultCount: 3);
 
-            var journeyInstance = CreateJourneyInstance(providerId);
+            var journeyInstance = CreateJourneyInstance(provider.ProviderId);
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"/venues/add/postcode-search?providerId={providerId}&ffiid={journeyInstance.InstanceId.UniqueKey}&postcode={postcode}");
+                $"/venues/add/postcode-search?providerId={provider.ProviderId}&ffiid={journeyInstance.InstanceId.UniqueKey}&postcode={postcode}");
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -85,7 +85,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.AddVenue
         public async Task PostcodeSearch_SearchReturnsZeroResults_RendersError()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
+            var provider = await TestData.CreateProvider();
 
             var town = "Town";
             var country = "England";
@@ -98,11 +98,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.AddVenue
 
             ConfigureAddressSearchServiceResults(postcode, town, resultCount: 0);
 
-            var journeyInstance = CreateJourneyInstance(providerId);
+            var journeyInstance = CreateJourneyInstance(provider.ProviderId);
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"/venues/add/postcode-search?providerId={providerId}&ffiid={journeyInstance.InstanceId.UniqueKey}&postcode={postcode}");
+                $"/venues/add/postcode-search?providerId={provider.ProviderId}&ffiid={journeyInstance.InstanceId.UniqueKey}&postcode={postcode}");
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -118,7 +118,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.AddVenue
         public async Task PostcodeSearch_ValidRequest_RendersExpectedOutput()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
+            var provider = await TestData.CreateProvider();
 
             var town = "Town";
             var country = "England";
@@ -131,11 +131,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.AddVenue
 
             ConfigureAddressSearchServiceResults(postcode, town, resultCount: 3);
 
-            var journeyInstance = CreateJourneyInstance(providerId);
+            var journeyInstance = CreateJourneyInstance(provider.ProviderId);
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"/venues/add/postcode-search?providerId={providerId}&ffiid={journeyInstance.InstanceId.UniqueKey}&postcode={postcode}");
+                $"/venues/add/postcode-search?providerId={provider.ProviderId}&ffiid={journeyInstance.InstanceId.UniqueKey}&postcode={postcode}");
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -166,7 +166,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.AddVenue
         public async Task PostcodeSearch_ValidRequest_NormalizesPostcode()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
+            var provider = await TestData.CreateProvider();
 
             var inputPostcode = "ab12de";
 
@@ -181,11 +181,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.AddVenue
 
             ConfigureAddressSearchServiceResults(normalizedPostcode, town, resultCount: 3);
 
-            var journeyInstance = CreateJourneyInstance(providerId);
+            var journeyInstance = CreateJourneyInstance(provider.ProviderId);
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"/venues/add/postcode-search?providerId={providerId}&ffiid={journeyInstance.InstanceId.UniqueKey}&postcode={inputPostcode}");
+                $"/venues/add/postcode-search?providerId={provider.ProviderId}&ffiid={journeyInstance.InstanceId.UniqueKey}&postcode={inputPostcode}");
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -204,7 +204,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.AddVenue
         public async Task SelectPostcode_NoAddressSelected_ReturnsError()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
+            var provider = await TestData.CreateProvider();
 
             var town = "Town";
             var country = "England";
@@ -218,7 +218,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.AddVenue
             var postcodeSearchResults = ConfigureAddressSearchServiceResults(postcode, town, resultCount: 3);
 
             var journeyInstance = CreateJourneyInstance(
-                providerId,
+                provider.ProviderId,
                 new AddVenueJourneyModel()
                 {
                     PostcodeSearchResults = postcodeSearchResults,
@@ -227,7 +227,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.AddVenue
 
             var request = new HttpRequestMessage(
                 HttpMethod.Post,
-                $"/venues/add/select-postcode?providerId={providerId}&ffiid={journeyInstance.InstanceId.UniqueKey}&postcode={postcode}")
+                $"/venues/add/select-postcode?providerId={provider.ProviderId}&ffiid={journeyInstance.InstanceId.UniqueKey}&postcode={postcode}")
             {
                 Content = new FormUrlEncodedContentBuilder()
                     .ToContent()
@@ -247,7 +247,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.AddVenue
         public async Task SelectPostcode_InvalidAddressSelected_ReturnsBadRequest()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
+            var provider = await TestData.CreateProvider();
 
             var addressId = "42";
             var town = "Town";
@@ -262,7 +262,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.AddVenue
             var postcodeSearchResults = ConfigureAddressSearchServiceResults(postcode, town, resultCount: 3);
 
             var journeyInstance = CreateJourneyInstance(
-                providerId,
+                provider.ProviderId,
                 new AddVenueJourneyModel()
                 {
                     PostcodeSearchResults = postcodeSearchResults,
@@ -271,7 +271,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.AddVenue
 
             var request = new HttpRequestMessage(
                 HttpMethod.Post,
-                $"/venues/add/select-postcode?providerId={providerId}&ffiid={journeyInstance.InstanceId.UniqueKey}&postcode={postcode}")
+                $"/venues/add/select-postcode?providerId={provider.ProviderId}&ffiid={journeyInstance.InstanceId.UniqueKey}&postcode={postcode}")
             {
                 Content = new FormUrlEncodedContentBuilder()
                     .Add("AddressId", addressId)
@@ -293,7 +293,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.AddVenue
             bool expectedNewAddressIsOutsideOfEnglandValue)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
+            var provider = await TestData.CreateProvider();
 
             var addressId = "42";
             var addressLine1 = "Test Venue line 1";
@@ -318,7 +318,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.AddVenue
             };
 
             var journeyInstance = CreateJourneyInstance(
-                providerId,
+                provider.ProviderId,
                 new AddVenueJourneyModel()
                 {
                     PostcodeSearchResults = postcodeSearchResults,
@@ -339,7 +339,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.AddVenue
 
             var request = new HttpRequestMessage(
                 HttpMethod.Post,
-                $"/venues/add/select-postcode?providerId={providerId}&ffiid={journeyInstance.InstanceId.UniqueKey}&postcode={postcode}")
+                $"/venues/add/select-postcode?providerId={provider.ProviderId}&ffiid={journeyInstance.InstanceId.UniqueKey}&postcode={postcode}")
             {
                 Content = new FormUrlEncodedContentBuilder()
                     .Add("AddressId", addressId)
@@ -353,7 +353,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.AddVenue
             response.StatusCode.Should().Be(HttpStatusCode.Found);
 
             response.Headers.Location.OriginalString.Should()
-                .Be($"/venues/add/details?providerId={providerId}&ffiid={journeyInstance.InstanceId.UniqueKey}");
+                .Be($"/venues/add/details?providerId={provider.ProviderId}&ffiid={journeyInstance.InstanceId.UniqueKey}");
 
             using (new AssertionScope())
             {

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/Venues/AddVenue/PublishedTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/Venues/AddVenue/PublishedTests.cs
@@ -20,7 +20,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.AddVenue
         public async Task Get_JourneyStateIsNotValid_ReturnsBadRequest()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
+            var provider = await TestData.CreateProvider();
 
             var addressLine1 = "Test Venue line 1";
             var addressLine2 = "Test Venue line 2";
@@ -33,7 +33,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.AddVenue
             var website = "example.com";
 
             var journeyInstance = CreateJourneyInstance(
-                providerId,
+                provider.ProviderId,
                 new AddVenueJourneyModel()
                 {
                     AddressLine1 = addressLine1,
@@ -52,7 +52,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.AddVenue
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"/venues/add/success?providerId={providerId}&ffiid={journeyInstance.InstanceId.UniqueKey}");
+                $"/venues/add/success?providerId={provider.ProviderId}&ffiid={journeyInstance.InstanceId.UniqueKey}");
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -65,7 +65,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.AddVenue
         public async Task Get_ValidRequest_ReturnsExpectedOutput()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
+            var provider = await TestData.CreateProvider();
 
             var addressLine1 = "Test Venue line 1";
             var addressLine2 = "Test Venue line 2";
@@ -78,7 +78,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.AddVenue
             var website = "example.com";
 
             var journeyInstance = CreateJourneyInstance(
-                providerId,
+                provider.ProviderId,
                 new AddVenueJourneyModel()
                 {
                     AddressLine1 = addressLine1,
@@ -98,7 +98,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.AddVenue
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"/venues/add/success?providerId={providerId}&ffiid={journeyInstance.InstanceId.UniqueKey}");
+                $"/venues/add/success?providerId={provider.ProviderId}&ffiid={journeyInstance.InstanceId.UniqueKey}");
 
             // Act
             var response = await HttpClient.SendAsync(request);

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/Venues/EditVenue/AddressTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/Venues/EditVenue/AddressTests.cs
@@ -28,9 +28,9 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.EditVenue
         public async Task Get_ValidRequest_RendersExpectedOutput()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
+            var provider = await TestData.CreateProvider();
             var venueId = (await TestData.CreateVenue(
-                providerId,
+                provider.ProviderId,
                 addressLine1: "Test Venue line 1",
                 addressLine2: "Test Venue line 2",
                 town: "Town",
@@ -60,8 +60,8 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.EditVenue
         public async Task Get_NewAddressAlreadySetInJourneyInstance_RendersExpectedOutput()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var provider = await TestData.CreateProvider();
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
             var journeyInstance = await CreateJourneyInstance(venueId);
             journeyInstance.UpdateState(state =>
@@ -98,10 +98,10 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.EditVenue
         public async Task Post_UserCannotAccessVenue_ReturnsForbidden(TestUserType userType)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(ukprn: 12345);
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var provider = await TestData.CreateProvider();
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
-            var anotherProviderId = await TestData.CreateProvider(ukprn: 67890);
+            var anotherProvider = await TestData.CreateProvider();
 
             OnspdSearchClient
                 .Setup(c => c.Search(It.Is<OnspdSearchQuery>(q => q.Postcode == "CV1 2AA")))
@@ -135,7 +135,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.EditVenue
                 Content = requestContent
             };
 
-            await User.AsTestUser(userType, anotherProviderId);
+            await User.AsTestUser(userType, anotherProvider.ProviderId);
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -201,8 +201,8 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.EditVenue
             string expectedErrorMessage)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var provider = await TestData.CreateProvider();
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
             OnspdSearchClient
                 .Setup(c => c.Search(It.Is<OnspdSearchQuery>(q => q.Postcode == "CV1 2AA")))
@@ -254,8 +254,8 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.EditVenue
             bool expectedNewAddressIsOutsideOfEnglandValue)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var provider = await TestData.CreateProvider();
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
             OnspdSearchClient
                 .Setup(c => c.Search(It.Is<OnspdSearchQuery>(q => q.Postcode == "CV1 2AA")))

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/Venues/EditVenue/CommonVenueTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/Venues/EditVenue/CommonVenueTests.cs
@@ -30,14 +30,14 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.EditVenue
         public async Task Get_UserCannotAccessVenue_ReturnsForbidden(string urlFragment, TestUserType userType)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(ukprn: 12345);
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var provider = await TestData.CreateProvider();
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
-            var anotherProviderId = await TestData.CreateProvider(ukprn: 67890);
+            var anotherProvider = await TestData.CreateProvider();
 
             var request = new HttpRequestMessage(HttpMethod.Get, $"venues/{venueId}{urlFragment}");
 
-            await User.AsTestUser(userType, anotherProviderId);
+            await User.AsTestUser(userType, anotherProvider.ProviderId);
 
             // Act
             var response = await HttpClient.SendAsync(request);

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/Venues/EditVenue/DetailsTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/Venues/EditVenue/DetailsTests.cs
@@ -22,9 +22,9 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.EditVenue
         public async Task Get_ValidRequestNoExistingJourneyInstance_RendersExpectedOutputFromDatabase()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
+            var provider = await TestData.CreateProvider();
             var venueId = (await TestData.CreateVenue(
-                providerId,
+                provider.ProviderId,
                 venueName: "Test Venue",
                 email: "test-venue@provider.com",
                 telephone: "02079460000",
@@ -58,8 +58,8 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.EditVenue
         public async Task Get_ValidRequestWithExistingJourneyInstance_RendersExpectedOutputFromState()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var provider = await TestData.CreateProvider();
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
             var journeyInstance = await CreateJourneyInstance(venueId);
             journeyInstance.UpdateState(state =>
@@ -104,8 +104,8 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.EditVenue
         public async Task Get_NewAddressOutsideOfEngland_RendersExpectedOutput()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var provider = await TestData.CreateProvider();
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
             var journeyInstance = await CreateJourneyInstance(venueId);
             journeyInstance.UpdateState(state =>

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/Venues/EditVenue/EmailTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/Venues/EditVenue/EmailTests.cs
@@ -22,8 +22,8 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.EditVenue
         public async Task Get_ValidRequest_RendersExpectedOutput()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
-            var venueId = (await TestData.CreateVenue(providerId, email: "person@provider.com")).Id;
+            var provider = await TestData.CreateProvider();
+            var venueId = (await TestData.CreateVenue(provider.ProviderId, email: "person@provider.com")).Id;
 
             var request = new HttpRequestMessage(HttpMethod.Get, $"venues/{venueId}/email");
 
@@ -43,8 +43,8 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.EditVenue
         public async Task Get_NewEmailAlreadySetInJourneyInstance_RendersExpectedOutput(string existingValue)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
-            var venueId = (await TestData.CreateVenue(providerId, email: "person@provider.com")).Id;
+            var provider = await TestData.CreateProvider();
+            var venueId = (await TestData.CreateVenue(provider.ProviderId, email: "person@provider.com")).Id;
 
             var journeyInstance = await CreateJourneyInstance(venueId);
             journeyInstance.UpdateState(state => state.Email = existingValue);
@@ -67,10 +67,10 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.EditVenue
         public async Task Post_UserCannotAccessVenue_ReturnsForbidden(TestUserType userType)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(ukprn: 12345);
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var provider = await TestData.CreateProvider();
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
-            var anotherProviderId = await TestData.CreateProvider(ukprn: 67890);
+            var anotherProvider = await TestData.CreateProvider();
 
             var requestContent = new FormUrlEncodedContentBuilder()
                 .Add("Email", "user@provider.com")
@@ -81,7 +81,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.EditVenue
                 Content = requestContent
             };
 
-            await User.AsTestUser(userType, anotherProviderId);
+            await User.AsTestUser(userType, anotherProvider.ProviderId);
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -116,8 +116,8 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.EditVenue
         public async Task Post_InvalidEmail_RendersError()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var provider = await TestData.CreateProvider();
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
             var requestContent = new FormUrlEncodedContentBuilder()
                 .Add("Email", "bademail")
@@ -144,8 +144,8 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.EditVenue
         public async Task Post_ValidRequest_UpdatesJourneyInstanceAndRedirects(string email)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var provider = await TestData.CreateProvider();
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
             var requestContent = new FormUrlEncodedContentBuilder()
                 .Add("Email", email)

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/Venues/EditVenue/NameTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/Venues/EditVenue/NameTests.cs
@@ -22,8 +22,8 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.EditVenue
         public async Task Get_ValidRequest_RendersExpectedOutput()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
-            var venueId = (await TestData.CreateVenue(providerId, venueName: "Test Venue")).Id;
+            var provider = await TestData.CreateProvider();
+            var venueId = (await TestData.CreateVenue(provider.ProviderId, venueName: "Test Venue")).Id;
 
             var request = new HttpRequestMessage(HttpMethod.Get, $"venues/{venueId}/name");
 
@@ -42,8 +42,8 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.EditVenue
         public async Task Get_NewNameAlreadySetInJourneyInstance_RendersExpectedOutput(string existingValue)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
-            var venueId = (await TestData.CreateVenue(providerId, venueName: "Test Venue")).Id;
+            var provider = await TestData.CreateProvider();
+            var venueId = (await TestData.CreateVenue(provider.ProviderId, venueName: "Test Venue")).Id;
 
             var journeyInstance = await CreateJourneyInstance(venueId);
             journeyInstance.UpdateState(state => state.Name = existingValue);
@@ -66,10 +66,10 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.EditVenue
         public async Task Post_UserCannotAccessVenue_ReturnsForbidden(TestUserType userType)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(ukprn: 12345);
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var provider = await TestData.CreateProvider();
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
-            var anotherProviderId = await TestData.CreateProvider(ukprn: 67890);
+            var anotherProvider = await TestData.CreateProvider();
 
             var requestContent = new FormUrlEncodedContentBuilder()
                 .Add("Name", "Another Venue")
@@ -80,7 +80,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.EditVenue
                 Content = requestContent
             };
 
-            await User.AsTestUser(userType, anotherProviderId);
+            await User.AsTestUser(userType, anotherProvider.ProviderId);
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -115,8 +115,8 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.EditVenue
         public async Task Post_NameEmpty_RendersError()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var provider = await TestData.CreateProvider();
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
             var requestContent = new FormUrlEncodedContentBuilder()
                 .Add("Name", "")
@@ -141,8 +141,8 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.EditVenue
         public async Task Post_NameTooLong_RendersError()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var provider = await TestData.CreateProvider();
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
             var requestContent = new FormUrlEncodedContentBuilder()
                 .Add("Name", new string('x', 251))  // limit is 250
@@ -167,10 +167,10 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.EditVenue
         public async Task Post_DuplicateName_RendersError()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var provider = await TestData.CreateProvider();
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
-            await TestData.CreateVenue(providerId, venueName: "Venue B");
+            await TestData.CreateVenue(provider.ProviderId, venueName: "Venue B");
 
             var requestContent = new FormUrlEncodedContentBuilder()
                 .Add("Name", "Venue B")
@@ -195,8 +195,8 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.EditVenue
         public async Task Post_ValidRequest_UpdatesJourneyInstanceAndRedirects()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var provider = await TestData.CreateProvider();
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
             var requestContent = new FormUrlEncodedContentBuilder()
                 .Add("Name", "Another Venue")

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/Venues/EditVenue/PhoneNumberTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/Venues/EditVenue/PhoneNumberTests.cs
@@ -22,8 +22,8 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.EditVenue
         public async Task Get_ValidRequest_RendersExpectedOutput()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
-            var venueId = (await TestData.CreateVenue(providerId, telephone: "020 7946 0000")).Id;
+            var provider = await TestData.CreateProvider();
+            var venueId = (await TestData.CreateVenue(provider.ProviderId, telephone: "020 7946 0000")).Id;
 
             var request = new HttpRequestMessage(HttpMethod.Get, $"venues/{venueId}/phone-number");
 
@@ -43,8 +43,8 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.EditVenue
         public async Task Get_NewPhoneNumberAlreadySetInJourneyInstance_RendersExpectedOutput(string existingValue)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
-            var venueId = (await TestData.CreateVenue(providerId, telephone: "020 7946 0000")).Id;
+            var provider = await TestData.CreateProvider();
+            var venueId = (await TestData.CreateVenue(provider.ProviderId, telephone: "020 7946 0000")).Id;
 
             var journeyInstance = await CreateJourneyInstance(venueId);
             journeyInstance.UpdateState(state => state.PhoneNumber = existingValue);
@@ -67,10 +67,10 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.EditVenue
         public async Task Post_UserCannotAccessVenue_ReturnsForbidden(TestUserType userType)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(ukprn: 12345);
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var provider = await TestData.CreateProvider();
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
-            var anotherProviderId = await TestData.CreateProvider(ukprn: 67890);
+            var anotherProvider = await TestData.CreateProvider();
 
             var requestContent = new FormUrlEncodedContentBuilder()
                 .Add("PhoneNumber", "020 7946 0000")
@@ -81,7 +81,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.EditVenue
                 Content = requestContent
             };
 
-            await User.AsTestUser(userType, anotherProviderId);
+            await User.AsTestUser(userType, anotherProvider.ProviderId);
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -116,8 +116,8 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.EditVenue
         public async Task Post_InvalidPhoneNumber_RendersError()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var provider = await TestData.CreateProvider();
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
             var requestContent = new FormUrlEncodedContentBuilder()
                 .Add("PhoneNumber", "xxx")
@@ -144,8 +144,8 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.EditVenue
         public async Task Post_ValidRequest_UpdatesJourneyInstanceAndRedirects(string phoneNumber)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var provider = await TestData.CreateProvider();
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
             var requestContent = new FormUrlEncodedContentBuilder()
                 .Add("PhoneNumber", phoneNumber)

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/Venues/EditVenue/SaveTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/Venues/EditVenue/SaveTests.cs
@@ -28,10 +28,10 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.EditVenue
         public async Task Post_UserCannotAccessVenue_ReturnsForbidden(TestUserType userType)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(ukprn: 12345);
-            var venueId = (await TestData.CreateVenue(providerId, email: "person@provider.com")).Id;
+            var provider = await TestData.CreateProvider();
+            var venueId = (await TestData.CreateVenue(provider.ProviderId, email: "person@provider.com")).Id;
 
-            var anotherProviderId = await TestData.CreateProvider(ukprn: 67890);
+            var anotherProvider = await TestData.CreateProvider();
 
             var journeyInstance = await CreateJourneyInstance(venueId);
             journeyInstance.UpdateState(state =>
@@ -57,7 +57,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.EditVenue
                 Content = requestContent
             };
 
-            await User.AsTestUser(userType, anotherProviderId);
+            await User.AsTestUser(userType, anotherProvider.ProviderId);
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -91,8 +91,8 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.EditVenue
         public async Task Post_ValidRequest_UpdatesDatabaseAndRedirects()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var provider = await TestData.CreateProvider();
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
             var journeyInstance = await CreateJourneyInstance(venueId);
             journeyInstance.UpdateState(state =>
@@ -123,7 +123,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.EditVenue
 
             // Assert
             response.StatusCode.Should().Be(HttpStatusCode.Found);
-            response.Headers.Location.OriginalString.Should().Be($"/venues?providerId={providerId}");
+            response.Headers.Location.OriginalString.Should().Be($"/venues?providerId={provider.ProviderId}");
 
             CosmosDbQueryDispatcher.VerifyExecuteQuery<UpdateVenue, OneOf<NotFound, Venue>>(q =>
                 q.VenueId == venueId &&

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/Venues/EditVenue/WebsiteTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/Venues/EditVenue/WebsiteTests.cs
@@ -22,8 +22,8 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.EditVenue
         public async Task Get_ValidRequest_RendersExpectedOutput()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
-            var venueId = (await TestData.CreateVenue(providerId, website: "provider.com")).Id;
+            var provider = await TestData.CreateProvider();
+            var venueId = (await TestData.CreateVenue(provider.ProviderId, website: "provider.com")).Id;
 
             var request = new HttpRequestMessage(HttpMethod.Get, $"venues/{venueId}/website");
 
@@ -43,8 +43,8 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.EditVenue
         public async Task Get_NewWebsiteAlreadySetInJourneyInstance_RendersExpectedOutput(string existingValue)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
-            var venueId = (await TestData.CreateVenue(providerId, website: "provider.com")).Id;
+            var provider = await TestData.CreateProvider();
+            var venueId = (await TestData.CreateVenue(provider.ProviderId, website: "provider.com")).Id;
 
             var journeyInstance = await CreateJourneyInstance(venueId);
             journeyInstance.UpdateState(state => state.Website = existingValue);
@@ -67,10 +67,10 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.EditVenue
         public async Task Post_UserCannotAccessVenue_ReturnsForbidden(TestUserType userType)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(ukprn: 12345);
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var provider = await TestData.CreateProvider();
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
-            var anotherProviderId = await TestData.CreateProvider(ukprn: 67890);
+            var anotherProvider = await TestData.CreateProvider();
 
             var requestContent = new FormUrlEncodedContentBuilder()
                 .Add("Website", "new-provider.com")
@@ -81,7 +81,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.EditVenue
                 Content = requestContent
             };
 
-            await User.AsTestUser(userType, anotherProviderId);
+            await User.AsTestUser(userType, anotherProvider.ProviderId);
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -116,8 +116,8 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.EditVenue
         public async Task Post_InvalidWebsite_RendersError()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var provider = await TestData.CreateProvider();
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
             var requestContent = new FormUrlEncodedContentBuilder()
                 .Add("Website", ":bad/website")
@@ -146,8 +146,8 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.EditVenue
         public async Task Post_ValidRequest_UpdatesJourneyInstanceAndRedirects(string website)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var provider = await TestData.CreateProvider();
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
             var requestContent = new FormUrlEncodedContentBuilder()
                 .Add("Website", website)

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/Venues/ViewVenues/ViewVenuesTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/Venues/ViewVenues/ViewVenuesTests.cs
@@ -21,10 +21,10 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.ViewVenues
         public async Task ViewVenues_Get_WithNoVenues_ReturnsExpectedContent()
         {
             //Arange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.FE | ProviderType.Apprenticeships | ProviderType.TLevels);
 
-            var request = new HttpRequestMessage(HttpMethod.Get, $"/venues?providerId={providerId}");
+            var request = new HttpRequestMessage(HttpMethod.Get, $"/venues?providerId={provider.ProviderId}");
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -40,12 +40,12 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.ViewVenues
         public async Task ViewVenues_Get_WithVenues_ReturnsExpectedContent()
         {
             //Arange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.FE | ProviderType.Apprenticeships | ProviderType.TLevels);
 
-            var request = new HttpRequestMessage(HttpMethod.Get, $"/venues?providerId={providerId}");
+            var request = new HttpRequestMessage(HttpMethod.Get, $"/venues?providerId={provider.ProviderId}");
 
-            var venues = await Task.WhenAll(Enumerable.Range(0, 3).Select(i => TestData.CreateVenue(providerId, venueName: $"TestVenue{i}")));
+            var venues = await Task.WhenAll(Enumerable.Range(0, 3).Select(i => TestData.CreateVenue(provider.ProviderId, venueName: $"TestVenue{i}")));
 
             // Act
             var response = await HttpClient.SendAsync(request);

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FilterTests/AuthorizeAdminAttributeTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FilterTests/AuthorizeAdminAttributeTests.cs
@@ -38,11 +38,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FilterTests
         public async Task ProviderUsers_AreBlocked(TestUserType userType)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
+            var provider = await TestData.CreateProvider();
 
             var request = new HttpRequestMessage(HttpMethod.Get, "/AuthorizeAdminAttributeTests");
 
-            await User.AsTestUser(userType, providerId);
+            await User.AsTestUser(userType, provider.ProviderId);
 
             // Act
             var response = await HttpClient.SendAsync(request);

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FilterTests/AuthorizeApprenticeshipAttributeTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FilterTests/AuthorizeApprenticeshipAttributeTests.cs
@@ -19,9 +19,9 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FilterTests
         public async Task DeveloperUser_CanAccess()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
+            var provider = await TestData.CreateProvider();
             var standard = await TestData.CreateStandard(standardCode: 1234, version: 1, standardName: "Test Standard");
-            var apprenticeshipId = (await TestData.CreateApprenticeship(providerId, standard, createdBy: User.ToUserInfo())).Id;
+            var apprenticeshipId = (await TestData.CreateApprenticeship(provider.ProviderId, standard, createdBy: User.ToUserInfo())).Id;
             await User.AsDeveloper();
 
             // Act
@@ -35,9 +35,9 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FilterTests
         public async Task HelpdeskUser_CanAccess()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
+            var provider = await TestData.CreateProvider();
             var standard = await TestData.CreateStandard(standardCode: 1234, version: 1, standardName: "Test Standard");
-            var apprenticeshipId = (await TestData.CreateApprenticeship(providerId, standard, createdBy: User.ToUserInfo())).Id;
+            var apprenticeshipId = (await TestData.CreateApprenticeship(provider.ProviderId, standard, createdBy: User.ToUserInfo())).Id;
             await User.AsHelpdesk();
 
             // Act
@@ -51,10 +51,10 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FilterTests
         public async Task ProviderUserForApprenticeshipsProvider_CanAccess()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
+            var provider = await TestData.CreateProvider();
             var standard = await TestData.CreateStandard(standardCode: 1234, version: 1, standardName: "Test Standard");
-            var apprenticeshipId = (await TestData.CreateApprenticeship(providerId, standard, createdBy: User.ToUserInfo())).Id;
-            await User.AsProviderUser(providerId, ProviderType.Apprenticeships);
+            var apprenticeshipId = (await TestData.CreateApprenticeship(provider.ProviderId, standard, createdBy: User.ToUserInfo())).Id;
+            await User.AsProviderUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             // Act
             var response = await HttpClient.GetAsync($"filtertests/authorizeapprenticeshipattribute/{apprenticeshipId}");
@@ -67,10 +67,10 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FilterTests
         public async Task ProviderSuperUserForApprenticeshipsProvider_CanAccess()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
+            var provider = await TestData.CreateProvider();
             var standard = await TestData.CreateStandard(standardCode: 1234, version: 1, standardName: "Test Standard");
-            var apprenticeshipId = (await TestData.CreateApprenticeship(providerId, standard, createdBy: User.ToUserInfo())).Id;
-            await User.AsProviderSuperUser(providerId, ProviderType.Apprenticeships);
+            var apprenticeshipId = (await TestData.CreateApprenticeship(provider.ProviderId, standard, createdBy: User.ToUserInfo())).Id;
+            await User.AsProviderSuperUser(provider.ProviderId, ProviderType.Apprenticeships);
 
             // Act
             var response = await HttpClient.GetAsync($"filtertests/authorizeapprenticeshipattribute/{apprenticeshipId}");
@@ -83,12 +83,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FilterTests
         public async Task ProviderUserForDifferentProvider_CannotAccess()
         {
             // Arrange
-            var ukprn = 123456;
-            var providerId = await TestData.CreateProvider(ukprn);
-            var anotherProviderId = await TestData.CreateProvider(ukprn: 23456);
+            var provider = await TestData.CreateProvider();
+            var anotherProvider = await TestData.CreateProvider();
             var standard = await TestData.CreateStandard(standardCode: 1234, version: 1, standardName: "Test Standard");
-            var apprenticeshipId = (await TestData.CreateApprenticeship(providerId, standard, createdBy: User.ToUserInfo())).Id;
-            await User.AsProviderUser(anotherProviderId, ProviderType.Apprenticeships);
+            var apprenticeshipId = (await TestData.CreateApprenticeship(provider.ProviderId, standard, createdBy: User.ToUserInfo())).Id;
+            await User.AsProviderUser(anotherProvider.ProviderId, ProviderType.Apprenticeships);
 
             // Act
             var response = await HttpClient.GetAsync($"filtertests/authorizeapprenticeshipattribute/{apprenticeshipId}");
@@ -101,12 +100,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FilterTests
         public async Task ProviderSuperUserForDifferentProvider_CannotAccess()
         {
             // Arrange
-            var ukprn = 123456;
-            var providerId = await TestData.CreateProvider(ukprn);
-            var anotherProviderId = await TestData.CreateProvider(ukprn: 23456);
+            var provider = await TestData.CreateProvider();
+            var anotherProvider = await TestData.CreateProvider();
             var standard = await TestData.CreateStandard(standardCode: 1234, version: 1, standardName: "Test Standard");
-            var apprenticeshipId = (await TestData.CreateApprenticeship(providerId, standard, createdBy: User.ToUserInfo())).Id;
-            await User.AsProviderSuperUser(anotherProviderId, ProviderType.Apprenticeships);
+            var apprenticeshipId = (await TestData.CreateApprenticeship(provider.ProviderId, standard, createdBy: User.ToUserInfo())).Id;
+            await User.AsProviderSuperUser(anotherProvider.ProviderId, ProviderType.Apprenticeships);
 
             // Act
             var response = await HttpClient.GetAsync($"filtertests/authorizeapprenticeshipattribute/{apprenticeshipId}");

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FilterTests/AuthorizeCourseAttributeTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FilterTests/AuthorizeCourseAttributeTests.cs
@@ -21,9 +21,9 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FilterTests
         public async Task AdminUsers_AreNotBlocked(TestUserType userType)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
-            var providerUser = await TestData.CreateUser("provider-user", "user@provider.com", "Test", "User", providerId);
-            var courseId = await TestData.CreateCourse(providerId, createdBy: providerUser);
+            var provider = await TestData.CreateProvider();
+            var providerUser = await TestData.CreateUser(providerId: provider.ProviderId);
+            var courseId = await TestData.CreateCourse(provider.ProviderId, createdBy: providerUser);
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
@@ -44,15 +44,15 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FilterTests
         public async Task ProviderUsersForSameProviderAsCourse_AreNotBlocked(TestUserType userType)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
-            var providerUser = await TestData.CreateUser("provider-user", "user@provider.com", "Test", "User", providerId);
-            var courseId = await TestData.CreateCourse(providerId, createdBy: providerUser);
+            var provider = await TestData.CreateProvider();
+            var providerUser = await TestData.CreateUser(providerId: provider.ProviderId);
+            var courseId = await TestData.CreateCourse(provider.ProviderId, createdBy: providerUser);
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
                 $"/AuthorizeCourseAttributeTests/{courseId}");
 
-            await User.AsTestUser(userType, providerId);
+            await User.AsTestUser(userType, provider.ProviderId);
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -67,17 +67,17 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FilterTests
         public async Task ProviderUsersForDifferentProviderAsCourse_AreBlocked(TestUserType userType)
         {
             // Arrange
-            var anotherProviderId = await TestData.CreateProvider(ukprn: 23456);
+            var anotherProvider = await TestData.CreateProvider();
 
-            var providerId = await TestData.CreateProvider(ukprn: 12345);
-            var providerUser = await TestData.CreateUser("provider-user", "user@provider.com", "Test", "User", providerId);
-            var courseId = await TestData.CreateCourse(providerId, createdBy: providerUser);
+            var provider = await TestData.CreateProvider();
+            var providerUser = await TestData.CreateUser(providerId: provider.ProviderId);
+            var courseId = await TestData.CreateCourse(provider.ProviderId, createdBy: providerUser);
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
                 $"/AuthorizeCourseAttributeTests/{courseId}");
 
-            await User.AsTestUser(userType, anotherProviderId);
+            await User.AsTestUser(userType, anotherProvider.ProviderId);
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -90,9 +90,9 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FilterTests
         public async Task UnauthenticatedUser_IsBlocked()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(ukprn: 12345);
-            var providerUser = await TestData.CreateUser("provider-user", "user@provider.com", "Test", "User", providerId);
-            var courseId = await TestData.CreateCourse(providerId, createdBy: providerUser);
+            var provider = await TestData.CreateProvider();
+            var providerUser = await TestData.CreateUser(providerId: provider.ProviderId);
+            var courseId = await TestData.CreateCourse(provider.ProviderId, createdBy: providerUser);
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FilterTests/AuthorizeTLevelAttributeTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FilterTests/AuthorizeTLevelAttributeTests.cs
@@ -25,16 +25,16 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FilterTests
             // Arrange
             var tLevelDefinitions = await TestData.CreateInitialTLevelDefinitions();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray());
 
-            var providerUser = await TestData.CreateUser("provider-user", "user@provider.com", "Test", "User", providerId);
+            var providerUser = await TestData.CreateUser(providerId: provider.ProviderId);
 
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
             var tLevel = await TestData.CreateTLevel(
-                providerId,
+                provider.ProviderId,
                 tLevelDefinitions.First().TLevelDefinitionId,
                 locationVenueIds: new[] { venueId },
                 createdBy: User.ToUserInfo());
@@ -60,16 +60,16 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FilterTests
             // Arrange
             var tLevelDefinitions = await TestData.CreateInitialTLevelDefinitions();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray());
 
-            var providerUser = await TestData.CreateUser("provider-user", "user@provider.com", "Test", "User", providerId);
+            var providerUser = await TestData.CreateUser(providerId: provider.ProviderId);
 
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
             var tLevel = await TestData.CreateTLevel(
-                providerId,
+                provider.ProviderId,
                 tLevelDefinitions.First().TLevelDefinitionId,
                 locationVenueIds: new[] { venueId },
                 createdBy: User.ToUserInfo());
@@ -78,7 +78,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FilterTests
                 HttpMethod.Get,
                 $"/AuthorizeTLevelAttributeTests/{tLevel.TLevelId}");
 
-            await User.AsTestUser(userType, providerId);
+            await User.AsTestUser(userType, provider.ProviderId);
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -93,20 +93,20 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FilterTests
         public async Task ProviderUsersForDifferentProviderAsCourse_AreBlocked(TestUserType userType)
         {
             // Arrange
-            var anotherProviderId = await TestData.CreateProvider(ukprn: 23456);
+            var anotherProvider = await TestData.CreateProvider();
 
             var tLevelDefinitions = await TestData.CreateInitialTLevelDefinitions();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray());
 
-            var providerUser = await TestData.CreateUser("provider-user", "user@provider.com", "Test", "User", providerId);
+            var providerUser = await TestData.CreateUser(providerId: provider.ProviderId);
 
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
             var tLevel = await TestData.CreateTLevel(
-                providerId,
+                provider.ProviderId,
                 tLevelDefinitions.First().TLevelDefinitionId,
                 locationVenueIds: new[] { venueId },
                 createdBy: User.ToUserInfo());
@@ -115,7 +115,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FilterTests
                 HttpMethod.Get,
                 $"/AuthorizeTLevelAttributeTests/{tLevel.TLevelId}");
 
-            await User.AsTestUser(userType, anotherProviderId);
+            await User.AsTestUser(userType, anotherProvider.ProviderId);
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -130,16 +130,16 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FilterTests
             // Arrange
             var tLevelDefinitions = await TestData.CreateInitialTLevelDefinitions();
 
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 tLevelDefinitionIds: tLevelDefinitions.Select(tld => tld.TLevelDefinitionId).ToArray());
 
-            var providerUser = await TestData.CreateUser("provider-user", "user@provider.com", "Test", "User", providerId);
+            var providerUser = await TestData.CreateUser(providerId: provider.ProviderId);
 
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
             var tLevel = await TestData.CreateTLevel(
-                providerId,
+                provider.ProviderId,
                 tLevelDefinitions.First().TLevelDefinitionId,
                 locationVenueIds: new[] { venueId },
                 createdBy: User.ToUserInfo());

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FilterTests/AuthorizeVenueAttributeTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FilterTests/AuthorizeVenueAttributeTests.cs
@@ -21,8 +21,8 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FilterTests
         public async Task AdminUsers_AreNotBlocked(TestUserType userType)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var provider = await TestData.CreateProvider();
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
@@ -43,14 +43,14 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FilterTests
         public async Task ProviderUsersForSameProviderAsVenue_AreNotBlocked(TestUserType userType)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var provider = await TestData.CreateProvider();
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
                 $"/AuthorizeVenueAttributeTests/{venueId}");
 
-            await User.AsTestUser(userType, providerId);
+            await User.AsTestUser(userType, provider.ProviderId);
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -65,15 +65,15 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FilterTests
         public async Task ProviderUsersForDifferentProviderAsVenue_AreBlocked(TestUserType userType)
         {
             // Arrange
-            var anotherProviderId = await TestData.CreateProvider(ukprn: 23456);
-            var providerId = await TestData.CreateProvider(ukprn: 12345);
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var anotherProvider = await TestData.CreateProvider();
+            var provider = await TestData.CreateProvider();
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
                 $"/AuthorizeVenueAttributeTests/{venueId}");
 
-            await User.AsTestUser(userType, anotherProviderId);
+            await User.AsTestUser(userType, anotherProvider.ProviderId);
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -86,8 +86,8 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FilterTests
         public async Task UnauthenticatedUser_IsBlocked()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(ukprn: 12345);
-            var venueId = (await TestData.CreateVenue(providerId)).Id;
+            var provider = await TestData.CreateProvider();
+            var venueId = (await TestData.CreateVenue(provider.ProviderId)).Id;
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FilterTests/DeactivatedProviderErrorActionFilterTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FilterTests/DeactivatedProviderErrorActionFilterTests.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Net;
-using System.Text;
 using System.Threading.Tasks;
 using Dfc.CourseDirectory.Core.Models;
 using Dfc.CourseDirectory.WebV2.Filters;
@@ -22,9 +20,9 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FilterTests
         public async Task ProviderStatusNotPermitted_ReturnsProviderDeactivatedView(string providerStatus)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(ukprn: 12345);
+            var provider = await TestData.CreateProvider();
 
-            await User.AsProviderUser(providerId, ProviderType.FE | ProviderType.Apprenticeships, providerStatus);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.FE | ProviderType.Apprenticeships, providerStatus);
 
             // Act
             var response = await HttpClient.GetAsync("deactivatedprovidererroractionfiltertests/deactivated-not-allowed");
@@ -41,9 +39,9 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FilterTests
         public async Task ProviderStatusPermitted_ReturnsOk(string providerStatus)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(ukprn: 12345);
+            var provider = await TestData.CreateProvider();
 
-            await User.AsProviderUser(providerId, ProviderType.FE | ProviderType.Apprenticeships, providerStatus);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.FE | ProviderType.Apprenticeships, providerStatus);
 
             // Act
             var response = await HttpClient.GetAsync("deactivatedprovidererroractionfiltertests/deactivated-not-allowed");
@@ -57,9 +55,9 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FilterTests
         public async Task ProviderStatusIgnored_ReturnsOk(string providerStatus)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(ukprn: 12345);
+            var provider = await TestData.CreateProvider();
 
-            await User.AsProviderUser(providerId, ProviderType.FE | ProviderType.Apprenticeships, providerStatus);
+            await User.AsProviderUser(provider.ProviderId, ProviderType.FE | ProviderType.Apprenticeships, providerStatus);
 
             // Act
             var response = await HttpClient.GetAsync("deactivatedprovidererroractionfiltertests/deactivated-allowed");

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FilterTests/RestrictProviderTypesAttributeTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FilterTests/RestrictProviderTypesAttributeTests.cs
@@ -39,13 +39,13 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FilterTests
         public async Task CurrentProviderDoesNotHaveAnySpecifiedPermittedProviderTypes_ReturnsForbidden(ProviderType providerType)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(providerType: providerType);
+            var provider = await TestData.CreateProvider(providerType: providerType);
 
             await User.AsHelpdesk();
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"RestrictProviderTypesAttributeTests?providerId={providerId}");
+                $"RestrictProviderTypesAttributeTests?providerId={provider.ProviderId}");
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -60,13 +60,13 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FilterTests
         public async Task CurrentProviderDoesHaveAnySpecifiedPermittedProviderTypes_ReturnsOk(ProviderType providerType)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(providerType: providerType);
+            var provider = await TestData.CreateProvider(providerType: providerType);
 
             await User.AsHelpdesk();
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"RestrictProviderTypesAttributeTests?providerId={providerId}");
+                $"RestrictProviderTypesAttributeTests?providerId={provider.ProviderId}");
 
             // Act
             var response = await HttpClient.SendAsync(request);

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FilterTests/VerifyApprenticeshipIdAttributeTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FilterTests/VerifyApprenticeshipIdAttributeTests.cs
@@ -32,9 +32,9 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FilterTests
         public async Task ApprenticeshipDoesExist_ReturnsOk()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
+            var provider = await TestData.CreateProvider();
             var standard = await TestData.CreateStandard(standardCode: 1234, version: 1, standardName: "Test Standard");
-            var apprenticeshipId = (await TestData.CreateApprenticeship(providerId, standard, createdBy: User.ToUserInfo())).Id;
+            var apprenticeshipId = (await TestData.CreateApprenticeship(provider.ProviderId, standard, createdBy: User.ToUserInfo())).Id;
 
             // Act
             var response = await HttpClient.GetAsync($"filtertests/verifyapprenticeshipidattributetests/{apprenticeshipId}");

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/LayoutTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/LayoutTests.cs
@@ -89,14 +89,14 @@ namespace Dfc.CourseDirectory.WebV2.Tests
         public async Task AdminUserWithFEOnlyProviderContext_RendersExpectedNav(TestUserType testUserType)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.FE,
                 providerName: "Test Provider");
 
             await User.AsTestUser(testUserType);
 
             // Act
-            var response = await HttpClient.GetAsync($"/tests/empty-provider-context?providerId={providerId}");
+            var response = await HttpClient.GetAsync($"/tests/empty-provider-context?providerId={provider.ProviderId}");
 
             // Assert
             response.EnsureSuccessStatusCode();
@@ -134,14 +134,14 @@ namespace Dfc.CourseDirectory.WebV2.Tests
         public async Task AdminUserWithApprenticeshipsOnlyProviderContext_RendersExpectedNav(TestUserType testUserType)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.Apprenticeships,
                 providerName: "Test Provider");
 
             await User.AsTestUser(testUserType);
 
             // Act
-            var response = await HttpClient.GetAsync($"/tests/empty-provider-context?providerId={providerId}");
+            var response = await HttpClient.GetAsync($"/tests/empty-provider-context?providerId={provider.ProviderId}");
 
             // Assert
             response.EnsureSuccessStatusCode();
@@ -179,14 +179,14 @@ namespace Dfc.CourseDirectory.WebV2.Tests
         public async Task AdminUserWithTLevelsOnlyProviderContext_RendersExpectedNav(TestUserType testUserType)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 providerName: "Test Provider");
 
             await User.AsTestUser(testUserType);
 
             // Act
-            var response = await HttpClient.GetAsync($"/tests/empty-provider-context?providerId={providerId}");
+            var response = await HttpClient.GetAsync($"/tests/empty-provider-context?providerId={provider.ProviderId}");
 
             // Assert
             response.EnsureSuccessStatusCode();
@@ -222,14 +222,14 @@ namespace Dfc.CourseDirectory.WebV2.Tests
         public async Task AdminUserWithFEAndApprenticeshipsAndTLevelsProviderContext_RendersExpectedNav(TestUserType testUserType)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.FE | ProviderType.Apprenticeships | ProviderType.TLevels,
                 providerName: "Test Provider");
 
             await User.AsTestUser(testUserType);
 
             // Act
-            var response = await HttpClient.GetAsync($"/tests/empty-provider-context?providerId={providerId}");
+            var response = await HttpClient.GetAsync($"/tests/empty-provider-context?providerId={provider.ProviderId}");
 
             // Assert
             response.EnsureSuccessStatusCode();
@@ -269,11 +269,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests
         public async Task ProviderUserForFEOnlyProvider_RendersExpectedNav(TestUserType testUserType)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.FE,
                 providerName: "Test Provider");
 
-            await User.AsTestUser(testUserType, providerId);
+            await User.AsTestUser(testUserType, provider.ProviderId);
 
             // Act
             var response = await HttpClient.GetAsync($"/tests/empty-provider-context");
@@ -306,11 +306,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests
         public async Task ProviderUserForApprenticeshipsOnlyProvider_RendersExpectedNav(TestUserType testUserType)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.Apprenticeships,
                 providerName: "Test Provider");
 
-            await User.AsTestUser(testUserType, providerId);
+            await User.AsTestUser(testUserType, provider.ProviderId);
 
             // Act
             var response = await HttpClient.GetAsync($"/tests/empty-provider-context");
@@ -343,11 +343,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests
         public async Task ProviderUserForTLevelsOnlyProvider_RendersExpectedNav(TestUserType testUserType)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.TLevels,
                 providerName: "Test Provider");
 
-            await User.AsTestUser(testUserType, providerId);
+            await User.AsTestUser(testUserType, provider.ProviderId);
 
             // Act
             var response = await HttpClient.GetAsync($"/tests/empty-provider-context");
@@ -378,11 +378,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests
         public async Task ProviderUserForFEAndApprenticeshipsAndTLevels_RendersExpectedNav(TestUserType testUserType)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.FE | ProviderType.Apprenticeships | ProviderType.TLevels,
                 providerName: "Test Provider");
 
-            await User.AsTestUser(testUserType, providerId);
+            await User.AsTestUser(testUserType, provider.ProviderId);
 
             // Act
             var response = await HttpClient.GetAsync($"/tests/empty-provider-context");
@@ -419,14 +419,14 @@ namespace Dfc.CourseDirectory.WebV2.Tests
             string expectedHref)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: providerType,
                 providerName: "Test Provider");
 
             await User.AsDeveloper();
 
             // Act
-            var response = await HttpClient.GetAsync($"/tests/empty-provider-context?providerId={providerId}");
+            var response = await HttpClient.GetAsync($"/tests/empty-provider-context?providerId={provider.ProviderId}");
 
             // Assert
             response.EnsureSuccessStatusCode();
@@ -445,11 +445,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests
             string expectedHref)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: providerType,
                 providerName: "Test Provider");
 
-            await User.AsProviderUser(providerId, providerType);
+            await User.AsProviderUser(provider.ProviderId, providerType);
 
             // Act
             var response = await HttpClient.GetAsync($"/tests/empty-provider-context");
@@ -468,12 +468,12 @@ namespace Dfc.CourseDirectory.WebV2.Tests
         public async Task ProviderUserProviderNotPassedQA_DoesNotRenderApprenticeshipsLink(TestUserType userType)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.FE | ProviderType.Apprenticeships,
                 providerName: "Test Provider",
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
 
-            await User.AsTestUser(userType, providerId);
+            await User.AsTestUser(userType, provider.ProviderId);
 
             // Act
             var response = await HttpClient.GetAsync($"/tests/empty-provider-context");
@@ -491,12 +491,12 @@ namespace Dfc.CourseDirectory.WebV2.Tests
         public async Task AdminUserProviderNotPassedQA_DoesNotRenderApprenticeshipsLink(TestUserType userType)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: ProviderType.FE | ProviderType.Apprenticeships,
                 providerName: "Test Provider",
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.NotStarted);
 
-            await User.AsTestUser(userType, providerId);
+            await User.AsTestUser(userType, provider.ProviderId);
 
             // Act
             var response = await HttpClient.GetAsync($"/tests/empty-provider-context");

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/MiddlewareTests/ProviderContextMiddlewareTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/MiddlewareTests/ProviderContextMiddlewareTests.cs
@@ -20,18 +20,17 @@ namespace Dfc.CourseDirectory.WebV2.Tests.MiddlewareTests
         public async Task AdminUser_QueryParamSpecified_AssignsContext(TestUserType userType)
         {
             // Arrange
-            var ukprn = 12345;
-            var providerId = await TestData.CreateProvider(ukprn);
+            var provider = await TestData.CreateProvider();
             await User.AsTestUser(userType);
 
             // Act
-            var response = await HttpClient.GetAsync($"currentprovideractionfiltertests?providerId={providerId}");
+            var response = await HttpClient.GetAsync($"currentprovideractionfiltertests?providerId={provider.ProviderId}");
 
             // Assert
             response.EnsureSuccessStatusCode();
             var responseJson = JToken.Parse(await response.Content.ReadAsStringAsync());
             Assert.True(Guid.TryParse(responseJson["providerInfo"]["providerId"].ToString(), out var boundProviderId), "Binding failed.");
-            Assert.Equal(providerId, boundProviderId);
+            Assert.Equal(provider.ProviderId, boundProviderId);
         }
 
         [Theory]
@@ -40,18 +39,17 @@ namespace Dfc.CourseDirectory.WebV2.Tests.MiddlewareTests
         public async Task AdminUser_RouteValueSpecified_AssignsContext(TestUserType userType)
         {
             // Arrange
-            var ukprn = 12345;
-            var providerId = await TestData.CreateProvider(ukprn);
+            var provider = await TestData.CreateProvider();
             await User.AsTestUser(userType);
 
             // Act
-            var response = await HttpClient.GetAsync($"currentprovideractionfiltertests/from-route/{providerId}");
+            var response = await HttpClient.GetAsync($"currentprovideractionfiltertests/from-route/{provider.ProviderId}");
 
             // Assert
             response.EnsureSuccessStatusCode();
             var responseJson = JToken.Parse(await response.Content.ReadAsStringAsync());
             Assert.True(Guid.TryParse(responseJson["providerInfo"]["providerId"].ToString(), out var boundProviderId), "Binding failed.");
-            Assert.Equal(providerId, boundProviderId);
+            Assert.Equal(provider.ProviderId, boundProviderId);
         }
 
         [Theory]
@@ -60,12 +58,11 @@ namespace Dfc.CourseDirectory.WebV2.Tests.MiddlewareTests
         public async Task AdminUser_QueryParamAndRouteSpecifiedButDontMatch_DoesNotAssignContext(TestUserType userType)
         {
             // Arrange
-            var ukprn = 12345;
-            var providerId = await TestData.CreateProvider(ukprn);
+            var provider = await TestData.CreateProvider();
             await User.AsTestUser(userType);
 
             // Act
-            var response = await HttpClient.GetAsync($"currentprovideractionfiltertests/from-route/{providerId}?providerId={Guid.NewGuid()}");
+            var response = await HttpClient.GetAsync($"currentprovideractionfiltertests/from-route/{provider.ProviderId}?providerId={Guid.NewGuid()}");
 
             // Assert
             Assert.False(response.IsSuccessStatusCode);
@@ -92,8 +89,8 @@ namespace Dfc.CourseDirectory.WebV2.Tests.MiddlewareTests
         public async Task ProviderUser_AssignsContextFromAuthToken(TestUserType userType)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(ukprn: 12345);
-            await User.AsTestUser(userType, providerId);
+            var provider = await TestData.CreateProvider();
+            await User.AsTestUser(userType, provider.ProviderId);
 
             // Act
             var response = await HttpClient.GetAsync($"currentprovideractionfiltertests");
@@ -102,7 +99,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.MiddlewareTests
             response.EnsureSuccessStatusCode();
             var responseJson = JToken.Parse(await response.Content.ReadAsStringAsync());
             Assert.True(Guid.TryParse(responseJson["providerInfo"]["providerId"].ToString(), out var boundProviderId), "Binding failed.");
-            Assert.Equal(providerId, boundProviderId);
+            Assert.Equal(provider.ProviderId, boundProviderId);
         }
 
         [Theory]
@@ -111,8 +108,8 @@ namespace Dfc.CourseDirectory.WebV2.Tests.MiddlewareTests
         public async Task ProviderUser_QueryParamSpecifiedDoesntMatchAuthToken_ReturnsForbidden(TestUserType userType)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(ukprn: 12345);
-            await User.AsTestUser(userType, providerId);
+            var provider = await TestData.CreateProvider();
+            await User.AsTestUser(userType, provider.ProviderId);
 
             // Act
             var response = await HttpClient.GetAsync($"currentprovideractionfiltertests?providerId={Guid.NewGuid()}");
@@ -127,8 +124,8 @@ namespace Dfc.CourseDirectory.WebV2.Tests.MiddlewareTests
         public async Task ProviderUser_RouteParamSpecifiedDoesntMatchAuthToken_ReturnsForbidden(TestUserType userType)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(ukprn: 12345);
-            await User.AsTestUser(userType, providerId);
+            var provider = await TestData.CreateProvider();
+            await User.AsTestUser(userType, provider.ProviderId);
 
             // Act
             var response = await HttpClient.GetAsync($"currentprovideractionfiltertests/from-route/{Guid.NewGuid()}");

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/RedirectToActionResultExtensionsTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/RedirectToActionResultExtensionsTests.cs
@@ -16,17 +16,17 @@ namespace Dfc.CourseDirectory.WebV2.Tests
         public async Task WithProviderContext_AppendsProviderIdToRouteValues()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(ukprn: 12345);
+            var provider = await TestData.CreateProvider();
             await User.AsDeveloper();  // Ensure ukprn is bound from query param
 
             // Act
             var response = await HttpClient.GetAsync(
-                $"redirecttoactionresultextensionstestcontroller/first?providerId={providerId}");
+                $"redirecttoactionresultextensionstestcontroller/first?providerId={provider.ProviderId}");
 
             // Assert
             Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
             var location = response.Headers.Location;
-            Assert.Equal($"/redirecttoactionresultextensionstestcontroller/second?providerId={providerId}", location.OriginalString);
+            Assert.Equal($"/redirecttoactionresultextensionstestcontroller/second?providerId={provider.ProviderId}", location.OriginalString);
         }
     }
 

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/Security/AuthorizationPolicyTests/ProviderTypeAuthorizationHandlerTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/Security/AuthorizationPolicyTests/ProviderTypeAuthorizationHandlerTests.cs
@@ -49,9 +49,9 @@ namespace Dfc.CourseDirectory.WebV2.Tests.Security.AuthorizationPolicyTests
             // Arrange
             var providerType = ProviderType.FE;
 
-            var providerId = await TestData.CreateProvider(providerType: providerType);
+            var provider = await TestData.CreateProvider(providerType: providerType);
 
-            await User.AsProviderUser(providerId, providerType);
+            await User.AsProviderUser(provider.ProviderId, providerType);
 
             var request = new HttpRequestMessage(HttpMethod.Get, "ProviderTypeAuthorizationHandlerTests/FeOnly");
 
@@ -68,9 +68,9 @@ namespace Dfc.CourseDirectory.WebV2.Tests.Security.AuthorizationPolicyTests
             // Arrange
             var providerType = ProviderType.Apprenticeships | ProviderType.FE;
 
-            var providerId = await TestData.CreateProvider(providerType: providerType);
+            var provider = await TestData.CreateProvider(providerType: providerType);
 
-            await User.AsProviderUser(providerId, providerType);
+            await User.AsProviderUser(provider.ProviderId, providerType);
 
             var request = new HttpRequestMessage(HttpMethod.Get, "ProviderTypeAuthorizationHandlerTests/FeOnly");
 
@@ -88,9 +88,9 @@ namespace Dfc.CourseDirectory.WebV2.Tests.Security.AuthorizationPolicyTests
         public async Task MultipleProviderTypesPermitted_AllowsEither(ProviderType providerType)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(providerType: providerType);
+            var provider = await TestData.CreateProvider(providerType: providerType);
 
-            await User.AsProviderUser(providerId, providerType);
+            await User.AsProviderUser(provider.ProviderId, providerType);
 
             var request = new HttpRequestMessage(HttpMethod.Get, "ProviderTypeAuthorizationHandlerTests/FeOrApprenticeship");
 

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/Security/EnsureApprenticeshipQAStatusSetSignInActionTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/Security/EnsureApprenticeshipQAStatusSetSignInActionTests.cs
@@ -22,22 +22,22 @@ namespace Dfc.CourseDirectory.WebV2.Tests.Security
         public async Task NewApprenticeshipProvider_SetsApprenticeshipQAStatus(ProviderType providerType)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: providerType,
                 apprenticeshipQAStatus: null);
 
-            var provider = await CosmosDbQueryDispatcher.Object.ExecuteQuery(new Core.DataStore.CosmosDb.Queries.GetProviderById()
+            var cosmosProvider = await CosmosDbQueryDispatcher.Object.ExecuteQuery(new Core.DataStore.CosmosDb.Queries.GetProviderById()
             {
-                ProviderId = providerId
+                ProviderId = provider.ProviderId
             });
 
             var signInContext = new SignInContext(new System.Security.Claims.ClaimsPrincipal())
             {
-                Provider = provider,
+                Provider = cosmosProvider,
                 ProviderUkprn = provider.Ukprn,
                 UserInfo = new AuthenticatedUserInfo()
                 {
-                    CurrentProviderId = providerId,
+                    CurrentProviderId = provider.ProviderId,
                     Email = "test.guy@provider.com",
                     FirstName = "Test",
                     LastName = "Guy",
@@ -58,7 +58,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.Security
             var qaStatus = await WithSqlQueryDispatcher(dispatcher => dispatcher.ExecuteQuery(
                 new GetProviderApprenticeshipQAStatus()
                 {
-                    ProviderId = providerId
+                    ProviderId = provider.ProviderId
                 }));
             Assert.Equal(ApprenticeshipQAStatus.NotStarted, qaStatus);
         }
@@ -68,22 +68,22 @@ namespace Dfc.CourseDirectory.WebV2.Tests.Security
         public async Task NewFEOnlyProvider_DoesNotSetApprenticeshipQAStatus(ProviderType providerType)
         {
             // Arrange
-            var providerId = await TestData.CreateProvider(
+            var provider = await TestData.CreateProvider(
                 providerType: providerType,
                 apprenticeshipQAStatus: null);
 
-            var provider = await CosmosDbQueryDispatcher.Object.ExecuteQuery(new Core.DataStore.CosmosDb.Queries.GetProviderById()
+            var cosmosProvider = await CosmosDbQueryDispatcher.Object.ExecuteQuery(new Core.DataStore.CosmosDb.Queries.GetProviderById()
             {
-                ProviderId = providerId
+                ProviderId = provider.ProviderId
             });
 
             var signInContext = new SignInContext(new System.Security.Claims.ClaimsPrincipal())
             {
-                Provider = provider,
+                Provider = cosmosProvider,
                 ProviderUkprn = provider.Ukprn,
                 UserInfo = new AuthenticatedUserInfo()
                 {
-                    CurrentProviderId = providerId,
+                    CurrentProviderId = provider.ProviderId,
                     Email = "test.guy@provider.com",
                     FirstName = "Test",
                     LastName = "Guy",
@@ -104,7 +104,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.Security
             var qaStatus = await WithSqlQueryDispatcher(dispatcher => dispatcher.ExecuteQuery(
                 new GetProviderApprenticeshipQAStatus()
                 {
-                    ProviderId = providerId
+                    ProviderId = provider.ProviderId
                 }));
             Assert.Null(qaStatus);
         }

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/Security/EnsureProviderExistsSignInActionTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/Security/EnsureProviderExistsSignInActionTests.cs
@@ -20,20 +20,20 @@ namespace Dfc.CourseDirectory.WebV2.Tests.Security
         public async Task NewProvider_InsertsProviderRecord()
         {
             // Arrange
-            var providerId = await TestData.CreateProvider();
+            var provider = await TestData.CreateProvider();
 
-            var provider = await CosmosDbQueryDispatcher.Object.ExecuteQuery(new GetProviderById()
+            var cosmosProvider = await CosmosDbQueryDispatcher.Object.ExecuteQuery(new GetProviderById()
             {
-                ProviderId = providerId
+                ProviderId = provider.ProviderId
             });
 
             var signInContext = new SignInContext(new System.Security.Claims.ClaimsPrincipal())
             {
-                Provider = provider,
+                Provider = cosmosProvider,
                 ProviderUkprn = provider.Ukprn,
                 UserInfo = new AuthenticatedUserInfo()
                 {
-                    CurrentProviderId = providerId,
+                    CurrentProviderId = provider.ProviderId,
                     Email = "test.guy@provider.com",
                     FirstName = "Test",
                     LastName = "Guy",
@@ -55,7 +55,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.Security
             {
                 return dispatcher.Transaction.Connection.QuerySingleAsync<int>(
                     "select count(*) from Pttcd.Providers where ProviderId = @ProviderId",
-                    new { ProviderId = providerId },
+                    new { ProviderId = provider.ProviderId },
                     dispatcher.Transaction);
             });
             Assert.Equal(1, rows);

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/ViewComponentTests/ProviderInfoPanelTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/ViewComponentTests/ProviderInfoPanelTests.cs
@@ -21,10 +21,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.ViewComponentTests
         public async Task RendersExpectedOutput()
         {
             // Arrange
-            var ukprn = 12345;
-
-            var providerId = await TestData.CreateProvider(
-                ukprn: ukprn,
+            var provider = await TestData.CreateProvider(
                 providerName: "Provider 1",
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.InProgress,
                 contacts: new[]
@@ -49,16 +46,15 @@ namespace Dfc.CourseDirectory.WebV2.Tests.ViewComponentTests
                     }
                 });
 
-            var providerUserId = $"{ukprn}-user";
-            await TestData.CreateUser(providerUserId, "somebody@provider1.com", "Provider 1", "Person", providerId);
+            var providerUser = await TestData.CreateUser(providerId: provider.ProviderId);
 
             var providerUserSignInDate = new DateTime(2018, 4, 12, 11, 30, 0, DateTimeKind.Utc);
-            await TestData.CreateUserSignIn(providerUserId, providerUserSignInDate);
+            await TestData.CreateUserSignIn(providerUser.UserId, providerUserSignInDate);
 
             await User.AsHelpdesk();
 
             // Act
-            var response = await HttpClient.GetAsync($"providerinfopaneltests/{providerId}");
+            var response = await HttpClient.GetAsync($"providerinfopaneltests/{provider.ProviderId}");
 
             // Assert
             response.EnsureSuccessStatusCode();
@@ -86,10 +82,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.ViewComponentTests
         public async Task NoPTypeContactRendersExpectedOutput()
         {
             // Arrange
-            var ukprn = 12345;
-
-            var providerId = await TestData.CreateProvider(
-                ukprn: ukprn,
+            var provider = await TestData.CreateProvider(
                 providerName: "Provider 1",
                 apprenticeshipQAStatus: ApprenticeshipQAStatus.InProgress,
                 contacts: new[]
@@ -114,16 +107,15 @@ namespace Dfc.CourseDirectory.WebV2.Tests.ViewComponentTests
                     }
                 });
 
-            var providerUserId = $"{ukprn}-user";
-            await TestData.CreateUser(providerUserId, "somebody@provider1.com", "Provider 1", "Person", providerId);
+            var providerUser = await TestData.CreateUser(providerId: provider.ProviderId);
 
             var providerUserSignInDate = new DateTime(2018, 4, 12, 11, 30, 0, DateTimeKind.Utc);
-            await TestData.CreateUserSignIn(providerUserId, providerUserSignInDate);
+            await TestData.CreateUserSignIn(providerUser.UserId, providerUserSignInDate);
 
             await User.AsHelpdesk();
 
             // Act
-            var response = await HttpClient.GetAsync($"providerinfopaneltests/{providerId}");
+            var response = await HttpClient.GetAsync($"providerinfopaneltests/{provider.ProviderId}");
 
             // Assert
             response.EnsureSuccessStatusCode();


### PR DESCRIPTION
The first step in allowing our tests to run in parallel is to ensure that we're not creating duplicate entities over our test base. This change removes the `userId` & `email` parameters from `Test.CreateUser` and the `ukprn` parameter from `Test.CreateProvider` and uses an internal random generation function that ensures that no two calls to these methods ever produce the same IDs.