### PR TITLE
PTCD-964 Decouple fileprocessor

### DIFF
--- a/src/Dfc.CourseDirectory.Core/DataStore/CosmosDb/Queries/UpdateProviderBulkUploadStatus.cs
+++ b/src/Dfc.CourseDirectory.Core/DataStore/CosmosDb/Queries/UpdateProviderBulkUploadStatus.cs
@@ -7,7 +7,9 @@ namespace Dfc.CourseDirectory.Core.DataStore.CosmosDb.Queries
     public class UpdateProviderBulkUploadStatus : ICosmosDbQuery<OneOf<NotFound, Success>>
     {
         public Guid ProviderId { get; set; }
-
-        public bool PublishInProgress { get; set; }
+        public OneOf<None, bool> PublishInProgress { get; set; }
+        public OneOf<None, bool> InProgress { get; set; }
+        public OneOf<None, int> TotalRowCount { get; set; }
+        public OneOf<None, DateTime> StartedTimestamp { get; set; }
     }
 }

--- a/src/Dfc.CourseDirectory.Core/DataStore/CosmosDb/QueryHandlers/UpdateProviderBulkUploadStatusHandler.cs
+++ b/src/Dfc.CourseDirectory.Core/DataStore/CosmosDb/QueryHandlers/UpdateProviderBulkUploadStatusHandler.cs
@@ -26,7 +26,10 @@ namespace Dfc.CourseDirectory.Core.DataStore.CosmosDb.QueryHandlers
 
                 provider.BulkUploadStatus ??= new ProviderBulkUploadStatus();
 
-                provider.BulkUploadStatus.PublishInProgress = request.PublishInProgress;
+                request.PublishInProgress.Switch(_ => { }, v => provider.BulkUploadStatus.PublishInProgress = v);
+                request.InProgress.Switch(_ => { }, v => provider.BulkUploadStatus.InProgress = v);
+                request.TotalRowCount.Switch(_ => { }, v => provider.BulkUploadStatus.TotalRowCount = v);
+                request.StartedTimestamp.Switch(_ => { }, v => provider.BulkUploadStatus.StartedTimestamp = v);
 
                 await client.ReplaceDocumentAsync(documentUri, provider);
 

--- a/src/Dfc.CourseDirectory.Services/BulkUploadService/BulkUploadService.cs
+++ b/src/Dfc.CourseDirectory.Services/BulkUploadService/BulkUploadService.cs
@@ -6,6 +6,8 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Specialized;
 using CsvHelper;
 using Dfc.CourseDirectory.Core.BackgroundWorkers;
 using Dfc.CourseDirectory.Core.DataStore;
@@ -18,7 +20,9 @@ using Dfc.CourseDirectory.Services.CourseService;
 using Dfc.CourseDirectory.Services.Models;
 using Dfc.CourseDirectory.Services.Models.Courses;
 using Dfc.CourseDirectory.Services.Models.Regions;
+using Dfc.CourseDirectory.WebV2;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using static Dfc.CourseDirectory.Services.Models.AlternativeName;
 using Course = Dfc.CourseDirectory.Services.Models.Courses.Course;
@@ -28,12 +32,16 @@ namespace Dfc.CourseDirectory.Services.BulkUploadService
 {
     public class BulkUploadService : IBulkUploadService
     {
+        private const string ContainerName = "provider-files";
+
         private readonly CourseServiceSettings _courseServiceSettings;
         private readonly ICourseService _courseService;
         private readonly ISearchClient<Lars> _larsSearchClient;
         private readonly ICosmosDbQueryDispatcher _cosmosDbQueryDispatcher;
         private readonly IRegionCache _regionCache;
         private readonly IBackgroundWorkScheduler _backgroundWorkScheduler;
+        private readonly IProviderInfoCache _providerInfoCache;
+        private readonly BlobContainerClient _blobContainerClient;
 
         public BulkUploadService(
             IOptions<CourseServiceSettings> courseServiceSettings,
@@ -41,7 +49,9 @@ namespace Dfc.CourseDirectory.Services.BulkUploadService
             ISearchClient<Lars> larsSearchClient,
             ICosmosDbQueryDispatcher cosmosDbQueryDispatcher,
             IRegionCache regionCache,
-            IBackgroundWorkScheduler backgroundWorkScheduler)
+            IBackgroundWorkScheduler backgroundWorkScheduler,
+            BlobServiceClient blobServiceClient,
+            IProviderInfoCache providerInfoCache)
         {
             _courseServiceSettings = courseServiceSettings?.Value ?? throw new ArgumentNullException(nameof(courseServiceSettings));
             _courseService = courseService ?? throw new ArgumentNullException(nameof(courseService));
@@ -49,6 +59,8 @@ namespace Dfc.CourseDirectory.Services.BulkUploadService
             _cosmosDbQueryDispatcher = cosmosDbQueryDispatcher;
             _regionCache = regionCache;
             _backgroundWorkScheduler = backgroundWorkScheduler;
+            _providerInfoCache = providerInfoCache;
+            _blobContainerClient = blobServiceClient.GetBlobContainerClient(ContainerName);
         }
 
         public int BulkUploadSecondsPerRecord
@@ -328,6 +340,22 @@ namespace Dfc.CourseDirectory.Services.BulkUploadService
                     {
                         // Mapping BulkUploadCourse to Course
                         var courses = MappingBulkUploadCourseToCourse(bulkUploadcourses, providerUKPRN, userId, out errors);
+
+                        // Push the courses to the CourseService
+                        foreach (var course in courses)
+                        {
+                            var courseResult = await _courseService.AddCourseAsync(course);
+
+                            if (courseResult.IsSuccess)
+                            {
+                                // Do nothing. Eventually we could have a count on successfully uploaded courses
+                            }
+                            else
+                            {
+                                errors.Add($"The course is NOT BulkUploaded, LARS_QAN = { course.LearnAimRef }. Error -  { courseResult.Error }");
+                            }
+                        }
+
                         return errors;
                     }
                 }
@@ -335,30 +363,78 @@ namespace Dfc.CourseDirectory.Services.BulkUploadService
                 {
                     await _backgroundWorkScheduler.Schedule(Worker, (bulkUploadcourses, providerUKPRN, userId));
 
-                    static Task Worker(object state, IServiceProvider serviceProvider, CancellationToken cancellationToken)
+                    static async Task Worker(object state, IServiceProvider serviceProvider, CancellationToken cancellationToken)
                     {
-                        var bulkUploadService = serviceProvider.GetRequiredService<IBulkUploadService>();
+                        var bulkUploadService = (BulkUploadService)serviceProvider.GetRequiredService<IBulkUploadService>();
+                        var courseService = serviceProvider.GetRequiredService<ICourseService>();
 
                         var (bulkUploadcourses, providerUKPRN, userId) = ((List<BulkUploadCourse>, int, string))state;
 
-                        // Populate LARS data
-                        bulkUploadcourses = bulkUploadService.PolulateLARSData(bulkUploadcourses, out var errors);
-                        if (errors != null && errors.Count > 0)
+                        List<string> errors;
+
+                        await bulkUploadService.SetBulkUploadStatus(providerUKPRN, bulkUploadcourses.Count);
+
+                        bulkUploadcourses = bulkUploadService.PolulateLARSData(bulkUploadcourses, out errors);
+                        if (null != errors && errors.Any())
                         {
-                            // If we have invalid LARS we stop processing
-                        }
-                        else
-                        {
-                            // Mapping BulkUploadCourse to Course
-                            var courses = bulkUploadService.MappingBulkUploadCourseToCourse(bulkUploadcourses, providerUKPRN, userId, out errors);
+                            await bulkUploadService.CreateErrorFileAsync(providerUKPRN, errors);
+                            await bulkUploadService.SetBulkUploadStatus(providerUKPRN, 0);
+                            return;   // Per the web app inline code - if we have invalid LARS we stop processing
                         }
 
-                        return Task.CompletedTask;
+                        var courses = bulkUploadService.MappingBulkUploadCourseToCourse(bulkUploadcourses, providerUKPRN, userId, out errors);
+                        if (null != errors && errors.Any())
+                        {
+                            await bulkUploadService.CreateErrorFileAsync(providerUKPRN, errors);
+                        }
+
+                        var result = await courseService.DeleteBulkUploadCourses(providerUKPRN);
+                        if (!result.IsSuccess)
+                        {
+                            errors.Add($"Failed to delete the existing bulk-uploaded courses.");
+                        }
+
+                        foreach (var course in courses)
+                        {
+                            await courseService.AddCourseAsync(course);
+                        }
+
+                        await bulkUploadService.SetBulkUploadStatus(providerUKPRN, 0);
                     }
 
                     return errors;
                 }
             }
+        }
+
+        private Task CreateErrorFileAsync(int providerUkprn, IEnumerable<string> errors)
+        {
+            var fileName = $"{providerUkprn}/Courses Bulk Upload/Files/{DateTime.UtcNow:yyyyMMddHHmmss}.error";
+
+            using var stream = new MemoryStream();
+            using var streamWriter = new StreamWriter(stream);
+            foreach (var line in errors)
+            {
+                streamWriter.WriteLine(line);
+            }
+
+            stream.Seek(0L, SeekOrigin.Begin);
+
+            return _blobContainerClient.UploadBlobAsync(fileName, stream);
+        }
+
+        private async Task SetBulkUploadStatus(int providerUkprn, int rowCount = 0)
+        {
+            var providerId = (await _providerInfoCache.GetProviderIdForUkprn(providerUkprn)).Value;
+
+            await _cosmosDbQueryDispatcher.ExecuteQuery(new UpdateProviderBulkUploadStatus()
+            {
+                ProviderId = providerId,
+                InProgress = rowCount > 0,
+                StartedTimestamp = rowCount > 0 ? DateTime.Now : default,
+                TotalRowCount = rowCount,
+                PublishInProgress = false
+            });
         }
 
         public List<BulkUploadCourse> PolulateLARSData(List<BulkUploadCourse> bulkUploadcourses, out List<string> errors)
@@ -677,21 +753,6 @@ namespace Dfc.CourseDirectory.Services.BulkUploadService
             //    File.WriteAllText(string.Format(@"{0}\{1}", jsonBulkUploadCoursesFilesPath, jsonFileName), courseJson);
             //    courseNumber++;
             //}
-
-            // Push the courses to the CourseService
-            foreach (var course in courses)
-            {
-                var courseResult = Task.Run(async () => await _courseService.AddCourseAsync(course)).Result;
-
-                if (courseResult.IsSuccess)
-                {
-                    // Do nothing. Eventually we could have a count on successfully uploaded courses
-                }
-                else
-                {
-                    errors.Add($"The course is NOT BulkUploaded, LARS_QAN = { course.LearnAimRef }. Error -  { courseResult.Error }");
-                }
-            }
 
             return courses;
         }

--- a/src/Dfc.CourseDirectory.Services/BulkUploadService/IBulkUploadService.cs
+++ b/src/Dfc.CourseDirectory.Services/BulkUploadService/IBulkUploadService.cs
@@ -9,7 +9,7 @@ namespace Dfc.CourseDirectory.Services.BulkUploadService
     {
         Task<List<string>> ProcessBulkUpload(Stream stream, int providerUKPRN, string userId, bool uploadCourses);        
         List<BulkUploadCourse> PolulateLARSData(List<BulkUploadCourse> bulkUploadcourses, out List<string> errors);
-        List<Course> MappingBulkUploadCourseToCourse(List<BulkUploadCourse> bulkUploadcourses, string userId, out List<string> errors);
+        List<Course> MappingBulkUploadCourseToCourse(List<BulkUploadCourse> bulkUploadcourses, int providerUkprn, string userId, out List<string> errors);
         int CountCsvLines(Stream stream);
         int BulkUploadSecondsPerRecord { get; }
     }

--- a/src/Dfc.CourseDirectory.Web/Controllers/BulkUploadController.cs
+++ b/src/Dfc.CourseDirectory.Web/Controllers/BulkUploadController.cs
@@ -146,9 +146,8 @@ namespace Dfc.CourseDirectory.Web.Controllers
                             "." + DateTime.UtcNow.ToString("yyyyMMddHHmmss") +
                             ".processed"; // stops the Azure trigger from processing the file
 
-                        Task task = _blobService.UploadFileAsync(
-                            $"{UKPRN.ToString()}/Courses Bulk Upload/Files/{bulkUploadFileNewName}", ms);
-                        task.Wait();
+                        await _blobService.UploadFileAsync(
+                            $"{UKPRN}/Courses Bulk Upload/Files/{bulkUploadFileNewName}", ms);
 
                         var errors = await _bulkUploadService.ProcessBulkUpload(ms, providerUKPRN, userId, processInline);
 

--- a/src/Dfc.CourseDirectory.Web/Controllers/BulkUploadController.cs
+++ b/src/Dfc.CourseDirectory.Web/Controllers/BulkUploadController.cs
@@ -142,12 +142,9 @@ namespace Dfc.CourseDirectory.Web.Controllers
                         _logger.LogInformation(
                             $"Csv line count = {csvLineCount} threshold = {_blobService.InlineProcessingThreshold} processInline = {processInline}");
 
-                        if (processInline)
-                        {
-                            bulkUploadFileNewName +=
-                                "." + DateTime.UtcNow.ToString("yyyyMMddHHmmss") +
-                                ".processed"; // stops the Azure trigger from processing the file
-                        }
+                        bulkUploadFileNewName +=
+                            "." + DateTime.UtcNow.ToString("yyyyMMddHHmmss") +
+                            ".processed"; // stops the Azure trigger from processing the file
 
                         Task task = _blobService.UploadFileAsync(
                             $"{UKPRN.ToString()}/Courses Bulk Upload/Files/{bulkUploadFileNewName}", ms);

--- a/src/Dfc.CourseDirectory.Web/Startup.cs
+++ b/src/Dfc.CourseDirectory.Web/Startup.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Net.Http;
+using Azure.Storage.Blobs;
 using Dfc.CourseDirectory.Core.BackgroundWorkers;
 using Dfc.CourseDirectory.Core.BinaryStorageProvider;
 using Dfc.CourseDirectory.Core.ReferenceData.Ukrlp;
@@ -95,6 +96,8 @@ namespace Dfc.CourseDirectory.Web
             services.AddSingleton<QueueBackgroundWorkScheduler>();
             services.AddHostedService(sp => sp.GetRequiredService<QueueBackgroundWorkScheduler>());
             services.AddSingleton<IBackgroundWorkScheduler>(sp => sp.GetRequiredService<QueueBackgroundWorkScheduler>());
+
+            services.AddSingleton(new BlobServiceClient(Configuration["BlobStorageSettings:ConnectionString"]));
 
             services.AddCourseDirectory(_env, Configuration);
             services.AddSignalR();


### PR DESCRIPTION
As part of moving away from Cosmos & micro-services we need to remove
usage of the fileprocessor. The sole remaining use of this is for large
FE Bulk Upload files. This commit prevents fileprocessor from processing
these large files (by appending a suffix to files uploaded to Blob
Storage) and instead does the processing in-proc, using our background
worker bits.

The code is the bare minimum to make this work only, given that all this
is going away soon.