### PR TITLE
Expose Commit() on ISqlQueryDispatcher

### DIFF
--- a/src/Dfc.CourseDirectory.Core/DataStore/Sql/ISqlQueryDispatcher.cs
+++ b/src/Dfc.CourseDirectory.Core/DataStore/Sql/ISqlQueryDispatcher.cs
@@ -8,6 +8,7 @@ namespace Dfc.CourseDirectory.Core.DataStore.Sql
     public interface ISqlQueryDispatcher : IDisposable
     {
         SqlTransaction Transaction { get; }
+        Task Commit();
         Task<T> ExecuteQuery<T>(ISqlQuery<T> query);
         IAsyncEnumerable<T> ExecuteQuery<T>(ISqlQuery<IAsyncEnumerable<T>> query);
     }

--- a/src/Dfc.CourseDirectory.Core/DataStore/Sql/ServiceProviderSqlDispatcherFactory.cs
+++ b/src/Dfc.CourseDirectory.Core/DataStore/Sql/ServiceProviderSqlDispatcherFactory.cs
@@ -46,6 +46,8 @@ namespace Dfc.CourseDirectory.Core.DataStore.Sql
 
             public SqlTransaction Transaction { get; }
 
+            public Task Commit() => Transaction.CommitAsync();
+
             public void Dispose()
             {
                 Transaction.Dispose();

--- a/src/Dfc.CourseDirectory.Core/ReferenceData/Lars/LarsDataImporter.cs
+++ b/src/Dfc.CourseDirectory.Core/ReferenceData/Lars/LarsDataImporter.cs
@@ -338,7 +338,7 @@ namespace Dfc.CourseDirectory.Core.ReferenceData.Lars
             {
                 using var dispatcher = _sqlQueryDispatcherFactory.CreateDispatcher();
                 await action(dispatcher);
-                await dispatcher.Transaction.CommitAsync();
+                await dispatcher.Commit();
             }
         }
 

--- a/src/Dfc.CourseDirectory.Core/SqlDataSync.cs
+++ b/src/Dfc.CourseDirectory.Core/SqlDataSync.cs
@@ -303,8 +303,7 @@ namespace Dfc.CourseDirectory.Core
             using (var sqlDispatcher = _sqlQueryDispatcherFactory.CreateDispatcher(System.Data.IsolationLevel.ReadCommitted))
             {
                 await action(sqlDispatcher);
-
-                sqlDispatcher.Transaction.Commit();
+                await sqlDispatcher.Commit();
             }
         }
     }

--- a/tests/Dfc.CourseDirectory.Testing/DatabaseFixture.cs
+++ b/tests/Dfc.CourseDirectory.Testing/DatabaseFixture.cs
@@ -118,7 +118,7 @@ namespace Dfc.CourseDirectory.Testing
         {
             using var dispatcher = SqlQueryDispatcherFactory.CreateDispatcher();
             var result = await action(dispatcher);
-            dispatcher.Transaction.Commit();
+            await dispatcher.Commit();
             return result;
         }
 

--- a/tests/Dfc.CourseDirectory.Testing/SqlQuerySpy.cs
+++ b/tests/Dfc.CourseDirectory.Testing/SqlQuerySpy.cs
@@ -68,6 +68,8 @@ namespace Dfc.CourseDirectory.Testing
 
             public SqlTransaction Transaction => _inner.Transaction;
 
+            public Task Commit() => _inner.Commit();
+
             public void Dispose() => _inner.Dispose();
 
             public Task<T> ExecuteQuery<T>(ISqlQuery<T> query)

--- a/tests/Dfc.CourseDirectory.Testing/TestData/TestData.cs
+++ b/tests/Dfc.CourseDirectory.Testing/TestData/TestData.cs
@@ -46,7 +46,7 @@ namespace Dfc.CourseDirectory.Testing
             {
                 using var dispatcher = _sqlQueryDispatcherFactory.CreateDispatcher();
                 var result = await action(dispatcher);
-                dispatcher.Transaction.Commit();
+                await dispatcher.Commit();
                 return result;
             }
             finally

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/TestUserInfo.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/TestUserInfo.cs
@@ -223,7 +223,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests
 
                 // REVIEW: Is there a better way of doing this?
                 var sqlQueryDispatcher = scope.ServiceProvider.GetRequiredService<ISqlQueryDispatcher>();
-                sqlQueryDispatcher.Transaction.Commit();
+                await sqlQueryDispatcher.Commit();
             }
         }
     }


### PR DESCRIPTION
Currently we expose `SqlTransaction` then callers can say `Transaction.Commit()`. SqlTransaction is not very mock friendly, however. This is step one in improving this type's mockability.

Removing `SqlTransaction` is the ultimate goal here but we have various places that rely on it. That change is for another day.