### PR TITLE
PTCD-893 -update handlers to stop using cosmos handler to get fechoice …

### DIFF
--- a/src/Dfc.CourseDirectory.FindACourseApi/Features/CourseRunDetail/CourseRunDetail.cs
+++ b/src/Dfc.CourseDirectory.FindACourseApi/Features/CourseRunDetail/CourseRunDetail.cs
@@ -59,14 +59,11 @@ namespace Dfc.CourseDirectory.FindACourseApi.Features.CourseRunDetail
             var getProvider = _cosmosDbQueryDispatcher.ExecuteQuery(new GetProviderByUkprn { Ukprn = course.ProviderUKPRN });
             var getQualification = _larsSearchClient.Search(new LarsLearnAimRefSearchQuery { LearnAimRef = course.LearnAimRef });
             var getVenues = _cosmosDbQueryDispatcher.ExecuteQuery(new GetVenuesByProvider { ProviderUkprn = course.ProviderUKPRN });
-            var getFeChoice = _cosmosDbQueryDispatcher.ExecuteQuery(new GetFeChoiceForProvider { ProviderUkprn = course.ProviderUKPRN });
-
-            await Task.WhenAll(getProvider, getQualification, getVenues, getFeChoice);
+            await Task.WhenAll(getProvider, getQualification, getVenues);
 
             var provider = await getProvider;
             var qualification = (await getQualification).Items.SingleOrDefault();
             var venues = await getVenues;
-            var feChoice = await getFeChoice;
             var sqlProvider = await _sqlQueryDispatcher.ExecuteQuery(new Core.DataStore.Sql.Queries.GetProviderById { ProviderId = provider.Id });
 
             var venue = courseRun.VenueId.HasValue
@@ -146,8 +143,8 @@ namespace Dfc.CourseDirectory.FindACourseApi.Features.CourseRunDetail
                     Fax = providerContact?.ContactFax,
                     Website = ViewModelFormatting.EnsureHttpPrefixed(providerContact?.ContactWebsiteAddress),
                     Email = providerContact?.ContactEmail,
-                    EmployerSatisfaction = feChoice?.EmployerSatisfaction,
-                    LearnerSatisfaction = feChoice?.LearnerSatisfaction,
+                    EmployerSatisfaction = sqlProvider?.EmployerSatisfaction,
+                    LearnerSatisfaction = sqlProvider?.LearnerSatisfaction,
                 },
                 Qualification = new QualificationViewModel
                 {

--- a/src/Dfc.CourseDirectory.FindACourseApi/Features/TLevels/TLevelDetail.cs
+++ b/src/Dfc.CourseDirectory.FindACourseApi/Features/TLevels/TLevelDetail.cs
@@ -51,10 +51,6 @@ namespace Dfc.CourseDirectory.FindACourseApi.Features.TLevels.TLevelDetail
             var provider = await getProvider;
             var sqlProvider = await getSqlProvider;
             var venues = await getVenues;
-
-            var feChoice = await _cosmosDbQueryDispatcher.ExecuteQuery(
-                new Core.DataStore.CosmosDb.Queries.GetFeChoiceForProvider() { ProviderUkprn = provider.Ukprn });
-
             var providerContact = provider.ProviderContact
                 .SingleOrDefault(c => c.ContactType == "P");
 
@@ -82,8 +78,8 @@ namespace Dfc.CourseDirectory.FindACourseApi.Features.TLevels.TLevelDetail
                     Telephone = providerContact?.ContactTelephone1,
                     Fax = providerContact?.ContactFax,
                     Website = ViewModelFormatting.EnsureHttpPrefixed(providerContact?.ContactWebsiteAddress),
-                    LearnerSatisfaction = feChoice?.LearnerSatisfaction,
-                    EmployerSatisfaction = feChoice?.EmployerSatisfaction
+                    LearnerSatisfaction = sqlProvider?.LearnerSatisfaction,
+                    EmployerSatisfaction = sqlProvider?.EmployerSatisfaction
                 },
                 WhoFor = tLevel.WhoFor,
                 EntryRequirements = tLevel.EntryRequirements,

--- a/src/Dfc.CourseDirectory.FindACourseApi/Features/TLevels/TLevels.cs
+++ b/src/Dfc.CourseDirectory.FindACourseApi/Features/TLevels/TLevels.cs
@@ -51,17 +51,12 @@ namespace Dfc.CourseDirectory.FindACourseApi.Features.TLevels
             var providers = await getProviders;
             var sqlProviders = await getSqlProviders;
             var venues = await getVenues;
-
-            var feChoices = await _cosmosDbQueryDispatcher.ExecuteQuery(
-                new CosmosQueries.GetFeChoicesByProviderUkprns { ProviderUkprns = providers.Values.Select(p => p.Ukprn) });
-
             return new ViewModel
             {
                 TLevels = tLevels.Select(t =>
                 {
                     var provider = providers[t.ProviderId];
                     var sqlProvider = sqlProviders[t.ProviderId];
-                    var feChoice = feChoices.GetValueOrDefault(provider.Ukprn);
                     var providerContact = provider.ProviderContact
                         .SingleOrDefault(c => c.ContactType == "P");
 
@@ -89,8 +84,8 @@ namespace Dfc.CourseDirectory.FindACourseApi.Features.TLevels
                             Telephone = providerContact?.ContactTelephone1,
                             Fax = providerContact?.ContactFax,
                             Website = ViewModelFormatting.EnsureHttpPrefixed(providerContact?.ContactWebsiteAddress),
-                            LearnerSatisfaction = feChoice?.LearnerSatisfaction,
-                            EmployerSatisfaction = feChoice?.EmployerSatisfaction
+                            LearnerSatisfaction = sqlProvider?.LearnerSatisfaction,
+                            EmployerSatisfaction = sqlProvider?.EmployerSatisfaction
                         },
                         WhoFor = t.WhoFor,
                         EntryRequirements = t.EntryRequirements,

--- a/src/Dfc.CourseDirectory.FindAnApprenticeshipApi/Helper/DASHelper.cs
+++ b/src/Dfc.CourseDirectory.FindAnApprenticeshipApi/Helper/DASHelper.cs
@@ -31,7 +31,7 @@ namespace Dfc.CourseDirectory.FindAnApprenticeshipApi.Helper
 
         [Obsolete("Please don't use this any more, instead replace with a mapper class using something like AutoMapper",
             false)]
-        public DasProvider CreateDasProviderFromProvider(int exportKey, Provider provider, Core.DataStore.CosmosDb.Models.FeChoice feChoice)
+        public DasProvider CreateDasProviderFromProvider(int exportKey, Provider provider)
         {
             if (!int.TryParse(provider.UnitedKingdomProviderReferenceNumber, out var ukprn))
                 throw new InvalidUkprnException(provider.UnitedKingdomProviderReferenceNumber);
@@ -46,8 +46,8 @@ namespace Dfc.CourseDirectory.FindAnApprenticeshipApi.Helper
                 {
                     Id = provider.ProviderId ?? _intIdentifier + exportKey,
                     Email = contactDetails?.ContactEmail,
-                    EmployerSatisfaction = feChoice?.EmployerSatisfaction,
-                    LearnerSatisfaction = feChoice?.LearnerSatisfaction,
+                    EmployerSatisfaction = provider?.EmployerSatisfaction,
+                    LearnerSatisfaction = provider?.LearnerSatisfaction,
                     MarketingInfo = provider.MarketingInformation,
                     Name = provider.Name,
                     TradingName = provider.Name,

--- a/src/Dfc.CourseDirectory.FindAnApprenticeshipApi/Helper/ProviderService.cs
+++ b/src/Dfc.CourseDirectory.FindAnApprenticeshipApi/Helper/ProviderService.cs
@@ -99,7 +99,9 @@ where p.ProviderStatus = 1 and p.UkrlpProviderStatusDescription = 'Active'";
                             MarketingInformation = p.MarketingInformation,
                             Alias = p.Alias,
                             ProviderType = (ProviderType?)p.ProviderType ?? default,
-                            DisplayNameSource = (ProviderDisplayNameSource)p.DisplayNameSource
+                            DisplayNameSource = (ProviderDisplayNameSource)p.DisplayNameSource,
+                            LearnerSatisfaction = p.LearnerSatisfaction,
+                            EmployerSatisfaction = p.EmployerSatisfaction
                         })
                         .ToArray();
                 }
@@ -124,6 +126,8 @@ where p.ProviderStatus = 1 and p.UkrlpProviderStatusDescription = 'Active'";
             public int DisplayNameSource { get; set; }
             public bool NationalApprenticeshipProvider { get; set; }
             public int? TribalProviderId { get; set; }
+            public decimal? LearnerSatisfaction { get; set; }
+            public decimal? EmployerSatisfaction { get; set; }
         }
 
         private class ProviderContactDataRecord

--- a/src/Dfc.CourseDirectory.FindAnApprenticeshipApi/Interfaces/Helper/IDASHelper.cs
+++ b/src/Dfc.CourseDirectory.FindAnApprenticeshipApi/Interfaces/Helper/IDASHelper.cs
@@ -9,7 +9,7 @@ namespace Dfc.CourseDirectory.FindAnApprenticeshipApi.Interfaces.Helper
     [Obsolete("Please try not to use this any more, and instead create Mapper classes using Automapper or similar", false)]
     public interface IDASHelper
     {
-        DasProvider CreateDasProviderFromProvider(int exportKey, Provider provider, Core.DataStore.CosmosDb.Models.FeChoice feChoice);
+        DasProvider CreateDasProviderFromProvider(int exportKey, Provider provider);
         List<DasLocation> ApprenticeshipLocationsToLocations(int exportKey, Dictionary<string, ApprenticeshipLocation> locations);
         List<DasStandard> ApprenticeshipsToStandards(int exportKey, IEnumerable<Apprenticeship> apprenticeships, Dictionary<string, ApprenticeshipLocation> validLocations);
         List<DasFramework> ApprenticeshipsToFrameworks(int exportKey, IEnumerable<Apprenticeship> apprenticeships, Dictionary<string, ApprenticeshipLocation> validLocations);

--- a/src/Dfc.CourseDirectory.FindAnApprenticeshipApi/Models/Providers/Provider.cs
+++ b/src/Dfc.CourseDirectory.FindAnApprenticeshipApi/Models/Providers/Provider.cs
@@ -28,6 +28,8 @@ namespace Dfc.CourseDirectory.FindAnApprenticeshipApi.Models.Providers
         public string Alias { get; set; }
         public ProviderType ProviderType { get; set; }
         public ProviderDisplayNameSource DisplayNameSource { get; set; }
+        public decimal? LearnerSatisfaction { get; set; }
+        public decimal? EmployerSatisfaction { get; set; }
 
         public string Name =>
             DisplayNameSource == ProviderDisplayNameSource.TradingName && !string.IsNullOrEmpty(Alias)

--- a/tests/Dfc.CourseDirectory.FindACourseApi.Tests/FeatureTests/CourseRunDetailTests.cs
+++ b/tests/Dfc.CourseDirectory.FindACourseApi.Tests/FeatureTests/CourseRunDetailTests.cs
@@ -114,12 +114,7 @@ namespace Dfc.CourseDirectory.FindACourseApi.Tests.FeatureTests
             {
                 ProviderId = provider.Id,
                 ProviderName = "TestProviderAlias",
-                DisplayNameSource = ProviderDisplayNameSource.ProviderName
-            };
-
-            var feChoice = new FeChoice
-            {
-                UKPRN = course.ProviderUKPRN,
+                DisplayNameSource = ProviderDisplayNameSource.ProviderName,
                 EmployerSatisfaction = 1.2M,
                 LearnerSatisfaction = 3.4M
             };
@@ -139,9 +134,6 @@ namespace Dfc.CourseDirectory.FindACourseApi.Tests.FeatureTests
             CosmosDbQueryDispatcher.Setup(s => s.ExecuteQuery(It.IsAny<GetVenuesByProvider>()))
                 .ReturnsAsync(new[] { venue });
 
-            CosmosDbQueryDispatcher.Setup(s => s.ExecuteQuery(It.IsAny<GetFeChoiceForProvider>()))
-                .ReturnsAsync(feChoice);
-
             SqlQueryDispatcher.Setup(s => s.ExecuteQuery(It.IsAny<Core.DataStore.Sql.Queries.GetProviderById>()))
                 .ReturnsAsync(sqlProvider);
 
@@ -159,8 +151,8 @@ namespace Dfc.CourseDirectory.FindACourseApi.Tests.FeatureTests
                 resultJson["provider"]["providerName"].ToObject<string>().Should().Be(sqlProvider.DisplayName);
                 resultJson["provider"]["tradingName"].ToObject<string>().Should().Be(sqlProvider.DisplayName);
                 resultJson["provider"]["email"].ToObject<string>().Should().Be(provider.ProviderContact.Single().ContactEmail);
-                resultJson["provider"]["learnerSatisfaction"].ToObject<decimal>().Should().Be(feChoice.LearnerSatisfaction);
-                resultJson["provider"]["employerSatisfaction"].ToObject<decimal>().Should().Be(feChoice.EmployerSatisfaction);
+                resultJson["provider"]["learnerSatisfaction"].ToObject<decimal>().Should().Be(sqlProvider.LearnerSatisfaction);
+                resultJson["provider"]["employerSatisfaction"].ToObject<decimal>().Should().Be(sqlProvider.EmployerSatisfaction);
                 resultJson["course"].ToObject<object>().Should().NotBeNull();
                 resultJson["course"]["courseId"].ToObject<Guid>().Should().Be(course.Id);
                 resultJson["venue"].ToObject<object>().Should().NotBeNull();

--- a/tests/Dfc.CourseDirectory.FindACourseApi.Tests/FeatureTests/TLevelDetailTests.cs
+++ b/tests/Dfc.CourseDirectory.FindACourseApi.Tests/FeatureTests/TLevelDetailTests.cs
@@ -125,7 +125,9 @@ namespace Dfc.CourseDirectory.FindACourseApi.Tests.FeatureTests
                     ProviderId = providerId,
                     ProviderType = ProviderType.TLevels,
                     ProviderName = providerName,
-                    Ukprn = providerUkprn
+                    Ukprn = providerUkprn,
+                    LearnerSatisfaction = providerLearnerSatisfaction,
+                    EmployerSatisfaction = providerEmployerSatisfaction
                 });
 
             SqlQueryDispatcher
@@ -168,17 +170,6 @@ namespace Dfc.CourseDirectory.FindACourseApi.Tests.FeatureTests
                         }
                     },
                     ProviderAliases = Array.Empty<Core.DataStore.CosmosDb.Models.ProviderAlias>()
-                });
-
-            CosmosDbQueryDispatcher
-                .Setup(d => d.ExecuteQuery(It.Is<Core.DataStore.CosmosDb.Queries.GetFeChoiceForProvider>(q => q.ProviderUkprn == providerUkprn)))
-                .ReturnsAsync(new Core.DataStore.CosmosDb.Models.FeChoice()
-                {
-                    UKPRN = providerUkprn,
-                    Id = Guid.NewGuid(),
-                    EmployerSatisfaction = providerEmployerSatisfaction,
-                    LearnerSatisfaction = providerLearnerSatisfaction,
-                    CreatedDateTimeUtc = now
                 });
 
             // Act

--- a/tests/Dfc.CourseDirectory.FindAnApprenticeship.Tests/Helper/DasHelperTests.cs
+++ b/tests/Dfc.CourseDirectory.FindAnApprenticeship.Tests/Helper/DasHelperTests.cs
@@ -75,7 +75,7 @@ namespace Dfc.CourseDirectory.FindAnApprenticeship.Tests.Helper
                         : contactDetails.ContactTelephone2;
 
                 // Act
-                var result = _sut.CreateDasProviderFromProvider(123, provider, null);
+                var result = _sut.CreateDasProviderFromProvider(123, provider);
                 var actual = result.Phone;
 
                 // Assert


### PR DESCRIPTION
This is the second PR, that updates the handlers that were previously fetching data from cosmos for fechoices.

- Update anywhere that was fetching fechoice data from cosmos and use the sql provider handler as the two fechoice choice data have been moved onto the providers table.
- update json file to include the two extra properties on providers.json
- updated unit tests.