### PR TITLE
Optimise FAC index updates when venues are changed part 2

### DIFF
--- a/src/Dfc.CourseDirectory.Core/DataStore/Sql/Queries/UpdateFindACourseIndexForVenues.cs
+++ b/src/Dfc.CourseDirectory.Core/DataStore/Sql/Queries/UpdateFindACourseIndexForVenues.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using OneOf.Types;
+
+namespace Dfc.CourseDirectory.Core.DataStore.Sql.Queries
+{
+    public class UpdateFindACourseIndexForVenues : ISqlQuery<Success>
+    {
+        public IEnumerable<Guid> VenueIds { get; set; }
+        public DateTime Now { get; set; }
+    }
+}

--- a/src/Dfc.CourseDirectory.Core/DataStore/Sql/QueryHandlers/UpdateFindACourseIndexForVenuesHandler.cs
+++ b/src/Dfc.CourseDirectory.Core/DataStore/Sql/QueryHandlers/UpdateFindACourseIndexForVenuesHandler.cs
@@ -1,0 +1,42 @@
+﻿using System.Data.SqlClient;
+using System.Threading.Tasks;
+using Dapper;
+using Dfc.CourseDirectory.Core.DataStore.Sql.Queries;
+using OneOf.Types;
+
+namespace Dfc.CourseDirectory.Core.DataStore.Sql.QueryHandlers
+{
+    public class UpdateFindACourseIndexForVenuesHandler : ISqlQueryHandler<UpdateFindACourseIndexForVenues, Success>
+    {
+        public async Task<Success> Execute(SqlTransaction transaction, UpdateFindACourseIndexForVenues query)
+        {
+            var sql = $@"
+UPDATE Pttcd.FindACourseIndex SET
+    LastSynced = @Now,
+    VenueName = v.VenueName,
+	VenueAddress = STUFF(
+	    CONCAT(
+		    NULLIF(', ' + v.AddressLine1, ', '),
+		    NULLIF(', ' + v.AddressLine2, ', '),
+		    NULLIF(', ' + v.Town, ', '),
+		    NULLIF(', ' + v.County, ', '),
+		    NULLIF(', ' + v.Postcode, ', ')),
+	    1, 2, NULL),
+    VenueTown = v.Town
+FROM Pttcd.FindACourseIndex i
+JOIN Pttcd.Venues v ON i.VenueId = v.VenueId
+JOIN @VenueIds x ON v.VenueId = x.Id
+WHERE Live = 1";
+
+            var paramz = new
+            {
+                VenueIds = TvpHelper.CreateGuidIdTable(query.VenueIds),
+                query.Now
+            };
+
+            await transaction.Connection.ExecuteAsync(sql, paramz, transaction);
+
+            return new Success();
+        }
+    }
+}

--- a/src/Dfc.CourseDirectory.Core/DataStore/Sql/QueryHandlers/UpdateVenueHandler.cs
+++ b/src/Dfc.CourseDirectory.Core/DataStore/Sql/QueryHandlers/UpdateVenueHandler.cs
@@ -10,6 +10,13 @@ namespace Dfc.CourseDirectory.Core.DataStore.Sql.QueryHandlers
 {
     public class UpdateVenueHandler : ISqlQueryHandler<UpdateVenue, OneOf<NotFound, Success>>
     {
+        private readonly ISqlQueryHandler<UpdateFindACourseIndexForVenues, Success> _updateFindACourseIndexHandler;
+
+        public UpdateVenueHandler(ISqlQueryHandler<UpdateFindACourseIndexForVenues, Success> updateFindACourseIndexHandler)
+        {
+            _updateFindACourseIndexHandler = updateFindACourseIndexHandler;
+        }
+
         public async Task<OneOf<NotFound, Success>> Execute(SqlTransaction transaction, UpdateVenue query)
         {
             var sql = $@"
@@ -51,6 +58,14 @@ AND VenueStatus = {(int)VenueStatus.Live}";
 
             if (updated)
             {
+                await _updateFindACourseIndexHandler.Execute(
+                    transaction,
+                    new UpdateFindACourseIndexForVenues()
+                    {
+                        VenueIds = new[] { query.VenueId },
+                        Now = query.UpdatedOn
+                    });
+
                 return new Success();
             }
             else

--- a/src/Dfc.CourseDirectory.Database/Pttcd/StoredProcedures/RefreshFindACourseIndex.sql
+++ b/src/Dfc.CourseDirectory.Database/Pttcd/StoredProcedures/RefreshFindACourseIndex.sql
@@ -48,7 +48,9 @@ BEGIN
 				WHEN r.RegionId IS NULL THEN 1
 				WHEN r.ParentRegionId IS NOT NULL THEN 4.5  -- Sub region
 				ELSE 2.3  -- Region
-				END AS float) AS ScoreBoost
+				END AS float) AS ScoreBoost,
+
+			v.VenueId
 		FROM @CourseRunIds d
 		INNER JOIN Pttcd.CourseRuns cr WITH (UPDLOCK) ON d.Id = cr.CourseRunId
 		INNER JOIN Pttcd.Courses c ON cr.CourseId = c.CourseId
@@ -92,7 +94,8 @@ BEGIN
 		VenueTown = source.VenueTown,
 		Position = source.Position,
 		RegionName = source.RegionName,
-		ScoreBoost = source.ScoreBoost
+		ScoreBoost = source.ScoreBoost,
+		VenueId = source.VenueId
 	WHEN NOT MATCHED THEN INSERT (
 		Id,
 		LastSynced,
@@ -124,7 +127,8 @@ BEGIN
 		VenueTown,
 		Position,
 		RegionName,
-		ScoreBoost)
+		ScoreBoost,
+		VenueId)
 	VALUES (
 		source.Id,
 		@Now,
@@ -156,7 +160,8 @@ BEGIN
 		source.VenueTown,
 		source.Position,
 		source.RegionName,
-		source.ScoreBoost)
+		source.ScoreBoost,
+		source.VenueId)
 	WHEN NOT MATCHED BY SOURCE AND target.CourseRunId IN (SELECT Id FROM @CourseRunIds) THEN UPDATE SET
 		Live = 0,
 		LastSynced = @Now;

--- a/src/Dfc.CourseDirectory.Database/Pttcd/StoredProcedures/RefreshFindACourseIndexForTLevels.sql
+++ b/src/Dfc.CourseDirectory.Database/Pttcd/StoredProcedures/RefreshFindACourseIndexForTLevels.sql
@@ -43,8 +43,10 @@ BEGIN
 			v.Position,
 			NULL RegionName,
 
-		--	-- Magic numbers and logic from https://github.com/SkillsFundingAgency/dfc-providerportal-changefeedlistener/commit/608340dcfaa5c74ee8b1ae422ad902ee0c529c01#diff-5f9ef9c9ca0b0bc9af8b5c7926cfcfe31fa7e8367b9104357104ad568fbe0302R103-R104
-		1 AS ScoreBoost
+			--	-- Magic numbers and logic from https://github.com/SkillsFundingAgency/dfc-providerportal-changefeedlistener/commit/608340dcfaa5c74ee8b1ae422ad902ee0c529c01#diff-5f9ef9c9ca0b0bc9af8b5c7926cfcfe31fa7e8367b9104357104ad568fbe0302R103-R104
+			1 AS ScoreBoost,
+
+			v.VenueId
 		FROM @TLevelIds d
 		INNER JOIN Pttcd.TLevels t ON d.Id = t.TLevelId
 		INNER JOIN Pttcd.TLevelLocations tll ON t.TLevelId = tll.TLevelId
@@ -84,7 +86,8 @@ BEGIN
 		VenueTown = source.VenueTown,
 		Position = source.Position,
 		RegionName = source.RegionName,
-		ScoreBoost = source.ScoreBoost
+		ScoreBoost = source.ScoreBoost,
+		VenueId = source.VenueId
 	WHEN NOT MATCHED THEN INSERT (
 		Id,
 		LastSynced,
@@ -116,7 +119,8 @@ BEGIN
 		VenueTown,
 		Position,
 		RegionName,
-		ScoreBoost)
+		ScoreBoost,
+		VenueId)
 	VALUES (
 		source.Id,
 		@Now,
@@ -148,7 +152,8 @@ BEGIN
 		source.VenueTown,
 		source.Position,
 		source.RegionName,
-		source.ScoreBoost)
+		source.ScoreBoost,
+		source.VenueId)
 	WHEN NOT MATCHED BY SOURCE AND target.TLevelId IN (SELECT Id FROM @TLevelIds) THEN UPDATE SET
 		Live = 0,
 		LastSynced = @Now;

--- a/src/Dfc.CourseDirectory.Database/Pttcd/Tables/FindACourseIndex.sql
+++ b/src/Dfc.CourseDirectory.Database/Pttcd/Tables/FindACourseIndex.sql
@@ -32,5 +32,6 @@
 	[VenueTown] NVARCHAR(MAX),
 	[Position] GEOGRAPHY,
 	[RegionName] NVARCHAR(100),
-	[ScoreBoost] FLOAT NOT NULL
+	[ScoreBoost] FLOAT NOT NULL,
+	[VenueId] UNIQUEIDENTIFIER
 )

--- a/src/Dfc.CourseDirectory.Database/Pttcd/Triggers/TRG_Venues_UpdateFindACourseIndex.sql
+++ b/src/Dfc.CourseDirectory.Database/Pttcd/Triggers/TRG_Venues_UpdateFindACourseIndex.sql
@@ -4,25 +4,8 @@ AFTER UPDATE
 AS
 BEGIN
 
-	DECLARE @VenueLiveCourseRuns Pttcd.GuidIdTable,
-			@ProviderLiveTLevels Pttcd.GuidIdTable,
-			@Now DATETIME
+	SET NOCOUNT ON
 
-	INSERT INTO @VenueLiveCourseRuns
-	SELECT cr.CourseRunId FROM Pttcd.CourseRuns cr
-	JOIN inserted x ON cr.VenueId = x.VenueId
-	WHERE cr.CourseRunStatus = 1
-
-	INSERT INTO @ProviderLiveTLevels
-	SELECT t.TLevelId FROM Pttcd.TLevels t
-	JOIN Pttcd.TLevelLocations tll ON t.TLevelId = tll.TLevelId
-	JOIN inserted x ON tll.VenueId = x.VenueId
-	WHERE t.TLevelStatus = 1 AND tll.TLevelLocationStatus = 1
-
-	SET @Now = GETUTCDATE()
-
-	EXEC Pttcd.RefreshFindACourseIndex @VenueLiveCourseRuns, @Now
-
-	EXEC Pttcd.RefreshFindACourseIndexForTLevels @ProviderLiveTLevels, @Now
+	-- Empty trigger as {pre}prod deployment won't remove objects
 
 END

--- a/src/Dfc.CourseDirectory.Functions/UpdateFindACourseIndexVenueId.cs
+++ b/src/Dfc.CourseDirectory.Functions/UpdateFindACourseIndexVenueId.cs
@@ -1,0 +1,41 @@
+﻿using System.Threading.Tasks;
+using Dapper;
+using Dfc.CourseDirectory.Core.DataStore.Sql;
+using Microsoft.Azure.WebJobs;
+
+namespace Dfc.CourseDirectory.Functions
+{
+    public class UpdateFindACourseIndexVenueId
+    {
+        private readonly ISqlQueryDispatcherFactory _sqlQueryDispatcherFactory;
+
+        public UpdateFindACourseIndexVenueId(ISqlQueryDispatcherFactory sqlQueryDispatcherFactory)
+        {
+            _sqlQueryDispatcherFactory = sqlQueryDispatcherFactory;
+        }
+
+        [FunctionName(nameof(UpdateFindACourseIndexVenueId))]
+        [NoAutomaticTrigger]
+        public async Task Run(string input)
+        {
+            using (var dispatcher = _sqlQueryDispatcherFactory.CreateDispatcher())
+            {
+                var sql = @"
+UPDATE Pttcd.FindACourseIndex SET VenueId = cr.VenueId
+FROM Pttcd.FindACourseIndex i
+JOIN Pttcd.CourseRuns cr ON i.CourseRunId = cr.CourseRunId
+WHERE cr.VenueId IS NOT NULL
+AND i.Live = 1
+
+UPDATE Pttcd.FindACourseIndex SET VenueId = tl.VenueId
+FROM Pttcd.FindACourseIndex i
+JOIN Pttcd.TLevelLocations tl ON i.TLevelLocationId = tl.TLevelLocationId
+";
+
+                await dispatcher.Transaction.Connection.ExecuteAsync(sql, transaction: dispatcher.Transaction);
+
+                await dispatcher.Commit();
+            }
+        }
+    }
+}


### PR DESCRIPTION
The previous trigger-based update was slow due to its row-by-row update.
This change removes the trigger in favour of a more explicit command
that passes the amended venue IDs.