### PR TITLE
Prevent venue uploads from being processed multiple times

### DIFF
--- a/src/Dfc.CourseDirectory.Core/DataStore/Sql/Queries/SetVenueUploadProcessing.cs
+++ b/src/Dfc.CourseDirectory.Core/DataStore/Sql/Queries/SetVenueUploadProcessing.cs
@@ -1,12 +1,17 @@
 ﻿using System;
-using OneOf;
-using OneOf.Types;
 
 namespace Dfc.CourseDirectory.Core.DataStore.Sql.Queries
 {
-    public class SetVenueUploadProcessing : ISqlQuery<OneOf<NotFound, Success>>
+    public class SetVenueUploadProcessing : ISqlQuery<SetVenueUploadProcessingResult>
     {
         public Guid VenueUploadId { get; set; }
         public DateTime ProcessingStartedOn { get; set; }
+    }
+
+    public enum SetVenueUploadProcessingResult
+    {
+        Success = 0,
+        NotFound = 1,
+        AlreadyProcessed = 2
     }
 }

--- a/tests/Dfc.CourseDirectory.Core.Tests/DataManagementTests/FileUploadProcessorTests.Venues.cs
+++ b/tests/Dfc.CourseDirectory.Core.Tests/DataManagementTests/FileUploadProcessorTests.Venues.cs
@@ -224,7 +224,10 @@ namespace Dfc.CourseDirectory.Core.Tests.DataManagementTests
         public async Task ProcessVenueFile_AllRecordsValid_SetStatusToProcessedSuccessfully()
         {
             // Arrange
-            var fileUploadProcessor = new FileUploadProcessor(SqlQueryDispatcherFactory, Mock.Of<BlobServiceClient>(), Clock);
+            var blobServiceClient = new Mock<BlobServiceClient>();
+            blobServiceClient.Setup(mock => mock.GetBlobContainerClient(It.IsAny<string>())).Returns(Mock.Of<BlobContainerClient>());
+
+            var fileUploadProcessor = new FileUploadProcessor(SqlQueryDispatcherFactory, blobServiceClient.Object, Clock);
 
             var provider = await TestData.CreateProvider();
             var user = await TestData.CreateUser(providerId: provider.ProviderId);
@@ -254,7 +257,10 @@ namespace Dfc.CourseDirectory.Core.Tests.DataManagementTests
         public async Task ProcessVenueFile_RowHasErrors_SetStatusToProcessedWithErrors()
         {
             // Arrange
-            var fileUploadProcessor = new FileUploadProcessor(SqlQueryDispatcherFactory, Mock.Of<BlobServiceClient>(), Clock);
+            var blobServiceClient = new Mock<BlobServiceClient>();
+            blobServiceClient.Setup(mock => mock.GetBlobContainerClient(It.IsAny<string>())).Returns(Mock.Of<BlobContainerClient>());
+
+            var fileUploadProcessor = new FileUploadProcessor(SqlQueryDispatcherFactory, blobServiceClient.Object, Clock);
 
             var provider = await TestData.CreateProvider();
             var user = await TestData.CreateUser(providerId: provider.ProviderId);


### PR DESCRIPTION
For some reason some venue uploads are being picked up by the function app multiple times. This is resulting in some already-abandoned uploads coming back to life as well as making our audit timestamps very strange (e.g. processing started *after* processing completed).

This change adds a check so we don't attempt to re-process files after they've already been processed and it deletes the blob after processing.