### PR TITLE
Amend FileUploadProcessor.DeleteVenueUploadRowForProvider signature

### DIFF
--- a/src/Dfc.CourseDirectory.Core/DataManagement/IFileUploadProcessor.cs
+++ b/src/Dfc.CourseDirectory.Core/DataManagement/IFileUploadProcessor.cs
@@ -22,7 +22,7 @@ namespace Dfc.CourseDirectory.Core.DataManagement
 
         // Venues
         Task DeleteVenueUploadForProvider(Guid providerId);
-        Task<bool> DeleteVenueUploadRowForProvider(Guid providerId, int rowNumber);
+        Task<UploadStatus> DeleteVenueUploadRowForProvider(Guid providerId, int rowNumber);
         Task<(IReadOnlyCollection<VenueUploadRow> Rows, UploadStatus UploadStatus)> GetVenueUploadRowsForProvider(Guid providerId);
         IObservable<UploadStatus> GetVenueUploadStatusUpdatesForProvider(Guid providerId);
         Task ProcessVenueFile(Guid venueUploadId, Stream stream);

--- a/src/Dfc.CourseDirectory.WebV2/Features/DataManagement/Venues/DeleteRow.cshtml
+++ b/src/Dfc.CourseDirectory.WebV2/Features/DataManagement/Venues/DeleteRow.cshtml
@@ -1,4 +1,4 @@
-﻿@model Dfc.CourseDirectory.WebV2.Features.DataManagement.Venues.DeleteRow.Response
+﻿@model Dfc.CourseDirectory.WebV2.Features.DataManagement.Venues.DeleteRow.ViewModel
 @{
     ViewBag.Title = "Data Upload - Resolve errors in venue data";
 }
@@ -14,7 +14,7 @@
 </div>
 
 <div class="govuk-grid-row">
-    <form asp-action="DeleteRow" asp-all-route-data="@ProviderContext.RouteValues" asp-route-rowNumber="@Model.Row"  >
+    <form asp-action="DeleteRow" asp-all-route-data="@ProviderContext.RouteValues" asp-route-rowNumber="@Model.RowNumber">
         <div class="govuk-grid-column-full">
             <table class="govuk-table">
                 <thead class="govuk-table__head">
@@ -27,7 +27,7 @@
                     </tr>
                 </thead>
                 <tbody class="govuk-table__body">
-                    <tr class="govuk-table__row" data-testid="row-@Model.Row">
+                    <tr class="govuk-table__row" data-testid="row-@Model.RowNumber">
                         <th scope="row" class="govuk-table__cell govuk-body-s"><span data-testid="YourRef">@Model.YourRef</span></th>
                         <td class="govuk-table__cell govuk-body-s" data-testid="VenueName">@Model.VenueName</td>
                         <td class="govuk-table__cell govuk-body-s" data-testid="Address">@Model.Address</td>

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/DataManagement/Venues/DeleteRowTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/DataManagement/Venues/DeleteRowTests.cs
@@ -23,7 +23,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.DataManagement.Venues
         [Theory]
         [InlineData(-1)]
         [InlineData(54)]
-        public async Task Get_DeleteNonExistentRowNumber_ReturnsError(int rowNumber)
+        public async Task Get_DeleteNonExistentRowNumber_ReturnsNotFound(int rowNumber)
         {
             // Arrange
             var provider = await TestData.CreateProvider();
@@ -38,7 +38,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.DataManagement.Venues
         }
 
         [Fact]
-        public async Task Get_DeleteRowForNonExistentFileUpload_ReturnsError()
+        public async Task Get_DeleteRowForNonExistentFileUpload_ReturnsBadRequest()
         {
             // Arrange
             var provider = await TestData.CreateProvider();
@@ -48,7 +48,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.DataManagement.Venues
             var response = await HttpClient.GetAsync($"/data-upload/venues/resolve/1/delete");
 
             // Assert
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         }
 
         [Fact]


### PR DESCRIPTION
The previous implementation did a separate call to figure out whether the Upload still had errors outside of the transaction that deleted the row. In general, we don't want to multiple database transactions for a given request. This commit changes the signature so that the `Delete` method returns the new `UploadStatus`. It now throws if the specified row doesn't exist.