### PR TITLE
Normalize 0 for CourseStudyMode and CourseAttendancePattern to null

### DIFF
--- a/src/Dfc.CourseDirectory.Core/DataManagement/ParsedCsvCourseRow.cs
+++ b/src/Dfc.CourseDirectory.Core/DataManagement/ParsedCsvCourseRow.cs
@@ -45,7 +45,7 @@ namespace Dfc.CourseDirectory.Core.DataManagement
 
         public static string MapAttendancePattern(CourseAttendancePattern? value) => value switch
         {
-            0 => null,
+            0 => null,  // TODO - remove when NormalizeClassroomBasedCourseRunFields function has been run
             null => null,
             CourseAttendancePattern.Daytime => "Daytime",
             CourseAttendancePattern.Evening => "Evening",
@@ -106,7 +106,7 @@ namespace Dfc.CourseDirectory.Core.DataManagement
 
         public static string MapStudyMode(CourseStudyMode? value) => value switch
         {
-            0 => null,
+            0 => null,  // TODO - remove when NormalizeClassroomBasedCourseRunFields function has been run
             null => null,
             CourseStudyMode.FullTime => "Full time",
             CourseStudyMode.PartTime => "Part time",

--- a/src/Dfc.CourseDirectory.Core/DataStore/Sql/QueryHandlers/GetCoursesForProviderHandler.cs
+++ b/src/Dfc.CourseDirectory.Core/DataStore/Sql/QueryHandlers/GetCoursesForProviderHandler.cs
@@ -112,8 +112,8 @@ JOIN @CourseIds x ON cr.CourseId = x.Id
                             CostDescription = cr.CostDescription,
                             DurationUnit = cr.DurationUnit,
                             DurationValue = cr.DurationValue,
-                            StudyMode = cr.StudyMode,
-                            AttendancePattern = cr.AttendancePattern,
+                            StudyMode = cr.StudyMode != 0 ? cr.StudyMode : null,  // Normalize 0 to null
+                            AttendancePattern = cr.AttendancePattern != 0 ? cr.AttendancePattern : null,  // Normalize 0 to null
                             National = cr.National,
                             SubRegionIds = courseRunSubRegions.GetValueOrDefault(cr.CourseRunId, Enumerable.Empty<string>()).ToArray(),
                             VenueName = cr.VenueName,

--- a/src/Dfc.CourseDirectory.Core/SqlDataSync.cs
+++ b/src/Dfc.CourseDirectory.Core/SqlDataSync.cs
@@ -170,8 +170,8 @@ namespace Dfc.CourseDirectory.Core
                         CostDescription = courseRun.CostDescription,
                         DurationUnit = courseRun.DurationUnit,
                         DurationValue = courseRun.DurationValue,
-                        StudyMode = courseRun.StudyMode,
-                        AttendancePattern = courseRun.AttendancePattern,
+                        StudyMode = courseRun.StudyMode != 0 ? courseRun.StudyMode : null,  // Normalize 0 to null
+                        AttendancePattern = courseRun.AttendancePattern != 0 ? courseRun.AttendancePattern : null,  // Normalize 0 to null
                         National = courseRun.National,
                         RegionIds = courseRun.Regions ?? Array.Empty<string>(),
                         SubRegionIds = courseRun.SubRegions?.Select(r => r.Id) ?? Array.Empty<string>(),

--- a/src/Dfc.CourseDirectory.Functions/NormalizeClassroomBasedCourseRunFields.cs
+++ b/src/Dfc.CourseDirectory.Functions/NormalizeClassroomBasedCourseRunFields.cs
@@ -1,0 +1,32 @@
+﻿using System.Threading.Tasks;
+using Dapper;
+using Dfc.CourseDirectory.Core.DataStore.Sql;
+using Microsoft.Azure.WebJobs;
+
+namespace Dfc.CourseDirectory.Functions
+{
+    public class NormalizeClassroomBasedCourseRunFields
+    {
+        private readonly ISqlQueryDispatcherFactory _sqlQueryDispatcherFactory;
+
+        public NormalizeClassroomBasedCourseRunFields(ISqlQueryDispatcherFactory sqlQueryDispatcherFactory)
+        {
+            _sqlQueryDispatcherFactory = sqlQueryDispatcherFactory;
+        }
+
+        [FunctionName(nameof(NormalizeClassroomBasedCourseRunFields))]
+        [NoAutomaticTrigger]
+        public async Task Execute(string input)
+        {
+            using var dispatcher = _sqlQueryDispatcherFactory.CreateDispatcher();
+
+            var sql = @"
+UPDATE Pttcd.CourseRuns SET AttendancePattern = NULL WHERE AttendancePattern = 0
+UPDATE Pttcd.CourseRuns SET StudyMode = NULL WHERE StudyMode = 0";
+
+            await dispatcher.Transaction.Connection.ExecuteAsync(sql, transaction: dispatcher.Transaction);
+
+            await dispatcher.Commit();
+        }
+    }
+}


### PR DESCRIPTION
The Cosmos model uses 0, the SQL model should be using null. This fixes
the Cosmos->SQL sync to map 0 to null, the one SQL query we have that
uses this field and adds a Function to clear up the data.