### PR TITLE
Fix metching Venue Upload rows to existing Venues with duplicates

### DIFF
--- a/src/Dfc.CourseDirectory.Core/DataManagement/FileUploadProcessor.Venues.cs
+++ b/src/Dfc.CourseDirectory.Core/DataManagement/FileUploadProcessor.Venues.cs
@@ -508,11 +508,14 @@ namespace Dfc.CourseDirectory.Core.DataManagement
         }
 
         // internal for testing
-        internal Guid?[] MatchRowsToExistingVenues(VenueDataUploadRowInfoCollection rows, IEnumerable<Venue> existingVenues)
+        internal Guid?[] MatchRowsToExistingVenues(VenueDataUploadRowInfoCollection rows, IEnumerable<VenueMatchInfo> existingVenues)
         {
             var rowVenueIdMapping = new Guid?[rows.Count];
 
-            var remainingCandidates = existingVenues.ToList();
+            // We have some bad data with duplicates; prefer matching on Venues that have have live offerings
+            var remainingCandidates = existingVenues
+                .OrderByDescending(v => v.HasLiveOfferings ? 1 : 0)
+                .ToList();
 
             // First try to match on ProviderVenueRef..
             MatchOnPredicate((row, venue) =>
@@ -543,7 +546,7 @@ namespace Dfc.CourseDirectory.Core.DataManagement
                         {
                             remainingCandidates.Remove(candidate);
                             rowVenueIdMapping[i] = candidate.VenueId;
-                            continue;
+                            break;
                         }
                     }
                 }

--- a/src/Dfc.CourseDirectory.Core/DataStore/Sql/QueryHandlers/GetVenueMatchInfoForProviderHandler.cs
+++ b/src/Dfc.CourseDirectory.Core/DataStore/Sql/QueryHandlers/GetVenueMatchInfoForProviderHandler.cs
@@ -13,7 +13,7 @@ namespace Dfc.CourseDirectory.Core.DataStore.Sql.QueryHandlers
         public async Task<IReadOnlyCollection<VenueMatchInfo>> Execute(SqlTransaction transaction, GetVenueMatchInfoForProvider query)
         {
             var sql = $@"
-SELECT v.VenueId, v.VenueName, v.ProviderVenueRef, v.AddressLine1, v.AddressLine2, v.Town, v.County, v.Postcode,
+SELECT v.VenueId, p.ProviderId, v.VenueName, v.ProviderVenueRef, v.AddressLine1, v.AddressLine2, v.Town, v.County, v.Postcode,
 v.Telephone, v.Email, v.Website, v.Position.Lat Latitude, v.Position.Long Longitude,
 v.ProviderUkprn,
 CASE WHEN c.VenueId IS NOT NULL OR a.VenueId IS NOT NULL OR t.VenueId IS NOT NULL THEN 1 ELSE 0 END AS HasLiveOfferings

--- a/tests/Dfc.CourseDirectory.Core.Tests/DataManagementTests/FileUploadProcessorTests.Venues.cs
+++ b/tests/Dfc.CourseDirectory.Core.Tests/DataManagementTests/FileUploadProcessorTests.Venues.cs
@@ -16,6 +16,7 @@ using Dfc.CourseDirectory.Core.Models;
 using Dfc.CourseDirectory.Testing;
 using FluentAssertions;
 using FluentAssertions.Execution;
+using Mapster;
 using Moq;
 using Xunit;
 
@@ -176,7 +177,7 @@ namespace Dfc.CourseDirectory.Core.Tests.DataManagementTests
 
             var rows = new[] { new CsvVenueRow() { ProviderVenueRef = "REF", VenueName = "NAME" } }.ToDataUploadRowCollection();
 
-            var existingVenues = new[] { venue1 };
+            var existingVenues = new[] { venue1 }.Select(v => v.Adapt<VenueMatchInfo>());
 
             var uploadProcessor = new TriggerableVenueUploadStatusUpdatesFileUploadProcessor(
                 SqlQueryDispatcherFactory,
@@ -201,7 +202,7 @@ namespace Dfc.CourseDirectory.Core.Tests.DataManagementTests
 
             var rows = new[] { new CsvVenueRow() { VenueName = "NAME" } }.ToDataUploadRowCollection();
 
-            var existingVenues = new[] { venue1 };
+            var existingVenues = new[] { venue1 }.Select(v => v.Adapt<VenueMatchInfo>());
 
             var uploadProcessor = new TriggerableVenueUploadStatusUpdatesFileUploadProcessor(
                 SqlQueryDispatcherFactory,
@@ -230,7 +231,7 @@ namespace Dfc.CourseDirectory.Core.Tests.DataManagementTests
                 new CsvVenueRow() { VenueName = "NAME" },
             }.ToDataUploadRowCollection();
 
-            var existingVenues = new[] { venue1 };
+            var existingVenues = new[] { venue1 }.Select(v => v.Adapt<VenueMatchInfo>());
 
             var uploadProcessor = new TriggerableVenueUploadStatusUpdatesFileUploadProcessor(
                 SqlQueryDispatcherFactory,


### PR DESCRIPTION
We have some existing bad data where a provider has multiple Venues with
the same reference. The matching code had a bug where it wouldn't stop
looking for a match after it had found one. Those two things together
mean we ended up adding supplementary rows at times when we shouldn't.
This fixes that.

Also amended the matching process to prefer matching Venues that have
life offerings attached.

Fixed a query handler that wasn't returning a required field also.