### PR TITLE
Temporarily remove the ProviderId FK on Apprenticeships

### DIFF
--- a/src/Dfc.CourseDirectory.Database/Pttcd/Tables/Apprenticeships.sql
+++ b/src/Dfc.CourseDirectory.Database/Pttcd/Tables/Apprenticeships.sql
@@ -9,7 +9,7 @@
 	[UpdatedOn] DATETIME,
 	[UpdatedBy] NVARCHAR(MAX),
 	[TribalApprenticeshipId] INT,
-	[ProviderId] UNIQUEIDENTIFIER CONSTRAINT [FK_Apprenticeships_Provider] FOREIGN KEY REFERENCES [Pttcd].[Providers] ([ProviderId]),
+	[ProviderId] UNIQUEIDENTIFIER, --CONSTRAINT [FK_Apprenticeships_Provider] FOREIGN KEY REFERENCES [Pttcd].[Providers] ([ProviderId]),
 	[ProviderUkprn] INT,
 	[ApprenticeshipType] TINYINT,
 	[ApprenticeshipTitle] NVARCHAR(MAX),

--- a/src/Dfc.CourseDirectory.Functions/AddMissingProviderIdForeignKeys.cs
+++ b/src/Dfc.CourseDirectory.Functions/AddMissingProviderIdForeignKeys.cs
@@ -31,7 +31,15 @@ UPDATE Pttcd.Venues
 SET ProviderId = p.ProviderId
 FROM Pttcd.Venues v
 JOIN Pttcd.Providers p ON v.ProviderUkprn = p.Ukprn
-WHERE v.ProviderId IS NULL";
+WHERE v.ProviderId IS NULL
+
+UPDATE Pttcd.Apprenticeships
+SET ProviderId = p.ProviderId
+FROM Pttcd.Apprenticeships a
+JOIN Pttcd.Providers p ON a.ProviderUkprn = a.ProviderUkprn
+WHERE a.ProviderId IS NULL OR a.ProviderId = '00000000-0000-0000-0000-000000000000' OR NOT EXISTS (
+    SELECT 1 FROM Pttcd.Providers x WHERE x.ProviderId = a.ProviderId
+)";
 
             await dispatcher.Transaction.Connection.ExecuteAsync(sql, transaction: dispatcher.Transaction);
 


### PR DESCRIPTION
There's some junk data that means the FK is failing. Also amended the FK fixup script to fix this bad data so we can re-apply FK later.