### PR TITLE
Amend TestData.CreateCourse to ensure we're creating valid CourseRuns

### DIFF
--- a/src/Dfc.CourseDirectory.Core/DataStore/Sql/Queries/GetCourse.cs
+++ b/src/Dfc.CourseDirectory.Core/DataStore/Sql/Queries/GetCourse.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using Dfc.CourseDirectory.Core.DataStore.Sql.Models;
+
+namespace Dfc.CourseDirectory.Core.DataStore.Sql.Queries
+{
+    public class GetCourse : ISqlQuery<Course>
+    {
+        public Guid CourseId { get; set; }
+    }
+}

--- a/tests/Dfc.CourseDirectory.Testing/DataStore/CosmosDb/Queries/CreateCourse.cs
+++ b/tests/Dfc.CourseDirectory.Testing/DataStore/CosmosDb/Queries/CreateCourse.cs
@@ -28,12 +28,12 @@ namespace Dfc.CourseDirectory.Testing.DataStore.CosmosDb.Queries
         public IEnumerable<CreateCourseCourseRun> CourseRuns { get; set; }
         public DateTime CreatedDate { get; set; }
         public UserInfo CreatedByUser { get; set; }
-        public CourseStatus CourseStatus { get; set; }
     }
 
     public class CreateCourseCourseRun
     {
         public Guid CourseRunId { get; set; }
+        public CourseStatus CourseRunStatus { get; set; }
         public Guid? VenueId { get; set; }
         public string CourseName { get; set; }
         public CourseDeliveryMode DeliveryMode { get; set; }

--- a/tests/Dfc.CourseDirectory.Testing/DataStore/CosmosDb/QueryHandlers/CreateCourseHandler.cs
+++ b/tests/Dfc.CourseDirectory.Testing/DataStore/CosmosDb/QueryHandlers/CreateCourseHandler.cs
@@ -20,6 +20,8 @@ namespace Dfc.CourseDirectory.Testing.DataStore.CosmosDb.QueryHandlers
         {
             var allRegions = _regionCache.GetAllRegions().GetAwaiter().GetResult();
 
+            var courseStatus = request.CourseRuns.Aggregate((CourseStatus)0, (cur, cr) => cur | cr.CourseRunStatus);
+
             var course = new Course()
             {
                 Id = request.CourseId,
@@ -65,14 +67,14 @@ namespace Dfc.CourseDirectory.Testing.DataStore.CosmosDb.QueryHandlers
                             SubRegionName = r.Name
                         }) :
                         null,
-                    RecordStatus = request.CourseStatus,
+                    RecordStatus = cr.CourseRunStatus,
                     CreatedDate = request.CreatedDate,
                     CreatedBy = request.CreatedByUser.UserId,
                     UpdatedDate = request.CreatedDate,
                     UpdatedBy = request.CreatedByUser.UserId,
                     ProviderCourseID = cr.ProviderCourseId
                 }),
-                CourseStatus = request.CourseStatus,
+                CourseStatus = courseStatus,
                 CreatedBy = request.CreatedByUser.UserId,
                 CreatedDate = request.CreatedDate,
                 UpdatedBy = request.CreatedByUser.UserId,

--- a/tests/Dfc.CourseDirectory.Testing/TestData/TestData.CreateCourse.cs
+++ b/tests/Dfc.CourseDirectory.Testing/TestData/TestData.CreateCourse.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Dfc.CourseDirectory.Core.DataStore.CosmosDb.Models;
+using Dfc.CourseDirectory.Core.DataStore.Sql.Queries;
 using Dfc.CourseDirectory.Core.Models;
 using Dfc.CourseDirectory.Testing.DataStore.CosmosDb.Queries;
 
@@ -9,7 +9,7 @@ namespace Dfc.CourseDirectory.Testing
 {
     public partial class TestData
     {
-        public async Task<Course> CreateCourse(
+        public async Task<Core.DataStore.Sql.Models.Course> CreateCourse(
             Guid providerId,
             UserInfo createdBy,
             string qualificationCourseTitle = "Education assessment in Maths",
@@ -27,8 +27,7 @@ namespace Dfc.CourseDirectory.Testing
             bool adultEducationBudget = false,
             bool advancedLearnerLoan = false,
             DateTime? createdUtc = null,
-            Action<CreateCourseCourseRunBuilder> configureCourseRuns = null,
-            CourseStatus courseStatus = CourseStatus.Live)
+            Action<CreateCourseCourseRunBuilder> configureCourseRuns = null)
         {
             var provider = await _cosmosDbQueryDispatcher.ExecuteQuery(new Core.DataStore.CosmosDb.Queries.GetProviderById()
             {
@@ -45,35 +44,15 @@ namespace Dfc.CourseDirectory.Testing
             IEnumerable<CreateCourseCourseRun> courseRuns;
             var courseRunBuilder = new CreateCourseCourseRunBuilder();
 
-            if (configureCourseRuns != null)
-            {
-                configureCourseRuns.Invoke(courseRunBuilder);
+            configureCourseRuns ??= builder => builder.WithOnlineCourseRun();
+            configureCourseRuns.Invoke(courseRunBuilder);
 
-                if (courseRunBuilder.CourseRuns.Count == 0)
-                {
-                    throw new InvalidOperationException("At least one CourseRun must be specified.");
-                }
-
-                courseRuns = courseRunBuilder.CourseRuns;
-            }
-            else
+            if (courseRunBuilder.CourseRuns.Count == 0)
             {
-                courseRuns = new[]
-                {
-                    new CreateCourseCourseRun()
-                    {
-                        CourseRunId = Guid.NewGuid(),
-                        CourseName = qualificationCourseTitle,
-                        DeliveryMode = CourseDeliveryMode.Online,
-                        FlexibleStartDate = true,
-                        Cost = 69,
-                        DurationUnit = CourseDurationUnit.Months,
-                        DurationValue = 6,
-                        AttendancePattern = CourseAttendancePattern.Evening,
-                        National = true
-                    }
-                };
+                throw new InvalidOperationException("At least one CourseRun must be specified.");
             }
+
+            courseRuns = courseRunBuilder.CourseRuns;
 
             await _cosmosDbQueryDispatcher.ExecuteQuery(
                 new CreateCourse()
@@ -97,12 +76,13 @@ namespace Dfc.CourseDirectory.Testing
                     AdvancedLearnerLoan = advancedLearnerLoan,
                     CourseRuns = courseRuns,
                     CreatedDate = createdUtc ?? _clock.UtcNow,
-                    CreatedByUser = createdBy,
-                    CourseStatus = courseStatus,
+                    CreatedByUser = createdBy
                 });
 
-            var course = await _cosmosDbQueryDispatcher.ExecuteQuery(new GetCourseById() { CourseId = courseId });
-            await _sqlDataSync.SyncCourse(course);
+            var cosmosCourse = await _cosmosDbQueryDispatcher.ExecuteQuery(new GetCourseById() { CourseId = courseId });
+            await _sqlDataSync.SyncCourse(cosmosCourse);
+
+            var course = await WithSqlQueryDispatcher(dispatcher => dispatcher.ExecuteQuery(new GetCourse() { CourseId = courseId }));
 
             return course;
         }
@@ -114,30 +94,41 @@ namespace Dfc.CourseDirectory.Testing
             public IReadOnlyCollection<CreateCourseCourseRun> CourseRuns => _courseRuns;
 
             public CreateCourseCourseRunBuilder WithCourseRun(
-                CourseDeliveryMode deliveryMode,
-                CourseStudyMode? studyMode = null,
-                CourseAttendancePattern? attendancePattern = null,
+                    string courseName = "Education assessment in Maths",
+                    bool? flexibleStartDate = null,
+                    DateTime? startDate = null,
+                    string courseUrl = null,
+                    decimal? cost = 69m,
+                    string costDescription = null,
+                    CourseDurationUnit durationUnit = CourseDurationUnit.Months,
+                    int durationValue = 3,
+                    string providerCourseRef = null,
+                    CourseStatus status = CourseStatus.Live) =>
+                WithOnlineCourseRun(courseName, flexibleStartDate, startDate, courseUrl, cost, costDescription, durationUnit, durationValue, providerCourseRef, status);
+
+            public CreateCourseCourseRunBuilder WithClassroomBasedCourseRun(
+                Guid venueId,
+                CourseAttendancePattern attendancePattern = CourseAttendancePattern.Evening,
+                CourseStudyMode studyMode = CourseStudyMode.PartTime,
                 string courseName = "Education assessment in Maths",
-                bool? national = null,
-                Guid? venueId = null,
-                IEnumerable<string> subRegionIds = null,
                 bool? flexibleStartDate = null,
                 DateTime? startDate = null,
                 string courseUrl = null,
-                decimal? cost = 69,
+                decimal? cost = 69m,
                 string costDescription = null,
                 CourseDurationUnit durationUnit = CourseDurationUnit.Months,
-                int? durationValue = 6,
-                string providerCourseId = null)
+                int durationValue = 3,
+                string providerCourseRef = null,
+                CourseStatus status = CourseStatus.Live)
             {
                 var courseRunId = Guid.NewGuid();
 
                 _courseRuns.Add(new CreateCourseCourseRun()
                 {
                     CourseRunId = courseRunId,
-                    VenueId = venueId,
+                    CourseRunStatus = status,
                     CourseName = courseName,
-                    DeliveryMode = deliveryMode,
+                    DeliveryMode = CourseDeliveryMode.ClassroomBased,
                     FlexibleStartDate = flexibleStartDate ?? !startDate.HasValue,
                     StartDate = startDate,
                     CourseUrl = courseUrl,
@@ -145,11 +136,81 @@ namespace Dfc.CourseDirectory.Testing
                     CostDescription = costDescription,
                     DurationUnit = durationUnit,
                     DurationValue = durationValue,
-                    StudyMode = studyMode,
+                    VenueId = venueId,
                     AttendancePattern = attendancePattern,
+                    StudyMode = studyMode,
+                    ProviderCourseId = providerCourseRef
+                });
+
+                return this;
+            }
+
+            public CreateCourseCourseRunBuilder WithOnlineCourseRun(
+                string courseName = "Education assessment in Maths",
+                bool? flexibleStartDate = null,
+                DateTime? startDate = null,
+                string courseUrl = null,
+                decimal? cost = 69m,
+                string costDescription = null,
+                CourseDurationUnit durationUnit = CourseDurationUnit.Months,
+                int durationValue = 3,
+                string providerCourseRef = null,
+                CourseStatus status = CourseStatus.Live)
+            {
+                var courseRunId = Guid.NewGuid();
+
+                _courseRuns.Add(new CreateCourseCourseRun()
+                {
+                    CourseRunId = courseRunId,
+                    CourseRunStatus = status,
+                    CourseName = courseName,
+                    DeliveryMode = CourseDeliveryMode.Online,
+                    FlexibleStartDate = flexibleStartDate ?? !startDate.HasValue,
+                    StartDate = startDate,
+                    CourseUrl = courseUrl,
+                    Cost = cost,
+                    CostDescription = costDescription,
+                    DurationUnit = durationUnit,
+                    DurationValue = durationValue,
+                    National = true,
+                    ProviderCourseId = providerCourseRef
+                });
+
+                return this;
+            }
+
+            public CreateCourseCourseRunBuilder WithWorkBasedCourseRun(
+                bool national = true,
+                IEnumerable<string> subRegionIds = null,
+                string courseName = "Education assessment in Maths",
+                bool? flexibleStartDate = null,
+                DateTime? startDate = null,
+                string courseUrl = null,
+                decimal? cost = 69m,
+                string costDescription = null,
+                CourseDurationUnit durationUnit = CourseDurationUnit.Months,
+                int durationValue = 3,
+                string providerCourseRef = null,
+                CourseStatus status = CourseStatus.Live)
+            {
+                var courseRunId = Guid.NewGuid();
+
+                _courseRuns.Add(new CreateCourseCourseRun()
+                {
+                    CourseRunId = courseRunId,
+                    CourseRunStatus = status,
+                    CourseName = courseName,
+                    DeliveryMode = CourseDeliveryMode.WorkBased,
+                    FlexibleStartDate = flexibleStartDate ?? !startDate.HasValue,
+                    StartDate = startDate,
+                    CourseUrl = courseUrl,
+                    Cost = cost,
+                    CostDescription = costDescription,
+                    DurationUnit = durationUnit,
+                    DurationValue = durationValue,
                     National = national,
-                    SubRegionIds = subRegionIds,
-                    ProviderCourseId = providerCourseId
+                    SubRegionIds = subRegionIds ?? Array.Empty<string>(),
+                    ProviderCourseId = providerCourseRef
                 });
 
                 return this;

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/BulkUpload/BulkUploadTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/BulkUpload/BulkUploadTests.cs
@@ -14,17 +14,21 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.BulkUpload
         }
 
         [Theory]
-        [InlineData(1,"1 course")]
-        [InlineData(2,"2 courses")]
+        [InlineData(1, "1 course")]
+        [InlineData(2, "2 courses")]
         public async Task Get_PublishYourFile_RendersPendingCount(int courseCount, string expectedCourseCountText)
         {
             // Arrange
             var provider = await TestData.CreateProvider();
             await User.AsTestUser(TestUserType.ProviderUser, provider.ProviderId);
             var providerUser = await TestData.CreateUser(providerId: provider.ProviderId);
+
             for (var i = 0; i < courseCount; i++)
             {
-                await TestData.CreateCourse(provider.ProviderId, createdBy: providerUser, courseStatus: CourseStatus.BulkUploadReadyToGoLive);
+                await TestData.CreateCourse(
+                    provider.ProviderId,
+                    createdBy: providerUser,
+                    configureCourseRuns: builder => builder.WithCourseRun(status: CourseStatus.BulkUploadReadyToGoLive));
             }
 
             // Act

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/DataManagement/Courses/DownloadTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/DataManagement/Courses/DownloadTests.cs
@@ -6,7 +6,6 @@ using System.Net;
 using System.Threading.Tasks;
 using CsvHelper;
 using Dfc.CourseDirectory.Core.DataManagement.Schemas;
-using Dfc.CourseDirectory.Core.Models;
 using FluentAssertions;
 using Xunit;
 
@@ -24,8 +23,10 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.DataManagement.Courses
         {
             // Arrange
             var provider = await TestData.CreateProvider(providerName: "Test Provider");
-            Clock.UtcNow = new DateTime(2021, 4, 9, 13, 0, 0);
+
             await TestData.CreateCourse(provider.ProviderId, createdBy: User.ToUserInfo());
+
+            Clock.UtcNow = new DateTime(2021, 4, 9, 13, 0, 0);
 
             // Act
             var response = await HttpClient.GetAsync($"/data-upload/courses/download?providerId={provider.ProviderId}");
@@ -78,15 +79,12 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.DataManagement.Courses
         {
             // Arrange
             var provider = await TestData.CreateProvider(providerName: "Test Provider");
-            Clock.UtcNow = new DateTime(2021, 4, 9, 13, 0, 0);
 
             // Act
             var response = await HttpClient.GetAsync($"/data-upload/courses/download?providerId={provider.ProviderId}");
 
             // Assert
             response.StatusCode.Should().Be(HttpStatusCode.OK);
-            response.Content.Headers.ContentType.MediaType.Should().Be("text/csv");
-            response.Content.Headers.ContentDisposition.FileName.Should().Be("\"Test Provider_courses_202104091300.csv\"");
 
             using var responseBody = await response.Content.ReadAsStreamAsync();
             using var responseBodyReader = new StreamReader(responseBody);
@@ -95,34 +93,28 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.DataManagement.Courses
             rows.Should().HaveCount(0);
         }
 
-
         [Fact]
         public async Task Get_WorkbasedCourses_ReturnsCorrectResults()
         {
             // Arrange
-            Clock.UtcNow = new DateTime(2021, 4, 9, 13, 0, 0);
             var provider = await TestData.CreateProvider(providerName: "Test Provider");
+
             var course = await TestData.CreateCourse(provider.ProviderId, createdBy: User.ToUserInfo(),
-                configureCourseRuns: b => b.WithCourseRun(
-                    CourseDeliveryMode.WorkBased,
-                    null,
-                    null,
-                    venueId: null,
+                configureCourseRuns: b => b.WithWorkBasedCourseRun(
                     national: false,
                     courseUrl: "https://sometest.com",
                     cost: 61,
                     costDescription: "sixty one",
                     startDate:Clock.UtcNow, 
                     subRegionIds: new[] { "E06000001" }));
-            var crun = course.CourseRuns.FirstOrDefault();
+
+            var courseRun = course.CourseRuns.Single();
 
             // Act
             var response = await HttpClient.GetAsync($"/data-upload/courses/download?providerId={provider.ProviderId}");
 
             // Assert
             response.StatusCode.Should().Be(HttpStatusCode.OK);
-            response.Content.Headers.ContentType.MediaType.Should().Be("text/csv");
-            response.Content.Headers.ContentDisposition.FileName.Should().Be("\"Test Provider_courses_202104091300.csv\"");
 
             using var responseBody = await response.Content.ReadAsStreamAsync();
             using var responseBodyReader = new StreamReader(responseBody);
@@ -144,8 +136,8 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.DataManagement.Courses
                 HowYouWillLearn = course.HowYoullLearn,
                 HowYouWillBeAssessed = course.HowYoullBeAssessed,
                 WhereNext = course.WhereNext,
-                CourseName = crun.CourseName,
-                ProviderCourseRef = crun.ProviderCourseID ?? "",
+                CourseName = courseRun.CourseName,
+                ProviderCourseRef = courseRun.ProviderCourseId ?? "",
                 DeliveryMode = "Work based",
                 StartDate = Clock.UtcNow.ToString("dd/MM/yyyy"),
                 FlexibleStartDate = "No",
@@ -157,7 +149,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.DataManagement.Courses
                 Cost = 61.ToString("0.00"),
                 CostDescription = "sixty one",
                 DurationUnit = "Months",
-                Duration = crun.DurationValue?.ToString(),
+                Duration = courseRun.DurationValue?.ToString(),
                 StudyMode = "",
                 AttendancePattern = "",
             });
@@ -167,28 +159,22 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.DataManagement.Courses
         public async Task Get_Online_ReturnsCorrectResults()
         {
             // Arrange
-            Clock.UtcNow = new DateTime(2021, 4, 9, 13, 0, 0);
             var provider = await TestData.CreateProvider(providerName: "Test Provider");
+
             var course = await TestData.CreateCourse(provider.ProviderId, createdBy: User.ToUserInfo(),
-                configureCourseRuns: b => b.WithCourseRun(
-                    CourseDeliveryMode.Online,
-                    null,
-                    null,
-                    venueId: null,
-                    national: true,
+                configureCourseRuns: b => b.WithOnlineCourseRun(
                     courseUrl: "https://someonlinecourse.com",
                     cost: 61,
                     costDescription: "sixty one",
                     startDate: Clock.UtcNow));
-            var crun = course.CourseRuns.FirstOrDefault();
+
+            var courseRun = course.CourseRuns.Single();
 
             // Act
             var response = await HttpClient.GetAsync($"/data-upload/courses/download?providerId={provider.ProviderId}");
 
             // Assert
             response.StatusCode.Should().Be(HttpStatusCode.OK);
-            response.Content.Headers.ContentType.MediaType.Should().Be("text/csv");
-            response.Content.Headers.ContentDisposition.FileName.Should().Be("\"Test Provider_courses_202104091300.csv\"");
 
             using var responseBody = await response.Content.ReadAsStreamAsync();
             using var responseBodyReader = new StreamReader(responseBody);
@@ -210,8 +196,8 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.DataManagement.Courses
                 HowYouWillLearn = course.HowYoullLearn,
                 HowYouWillBeAssessed = course.HowYoullBeAssessed,
                 WhereNext = course.WhereNext,
-                CourseName = crun.CourseName,
-                ProviderCourseRef = crun.ProviderCourseID ?? "",
+                CourseName = courseRun.CourseName,
+                ProviderCourseRef = courseRun.ProviderCourseId ?? "",
                 DeliveryMode = "Online",
                 StartDate = Clock.UtcNow.ToString("dd/MM/yyyy"),
                 FlexibleStartDate = "No",
@@ -223,54 +209,29 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.DataManagement.Courses
                 Cost = 61.ToString("0.00"),
                 CostDescription = "sixty one",
                 DurationUnit = "Months",
-                Duration = crun.DurationValue?.ToString(),
+                Duration = courseRun.DurationValue?.ToString(),
                 StudyMode = "",
                 AttendancePattern = "",
             });
         }
 
         [Fact]
-        public async Task Get_ClassroomBased_ReturnsCorrectOrder()
+        public async Task Get_ReturnsCoursesOrderByLearnAimRef()
         {
             // Arrange
-            Clock.UtcNow = new DateTime(2021, 4, 9, 13, 0, 0);
             var provider = await TestData.CreateProvider(providerName: "Test Provider");
-            var venue1 = await TestData.CreateVenue(provider.ProviderId, createdBy: User.ToUserInfo(), venueName: Faker.Company.Name(), providerVenueRef: "someRef");
-            var venue2 = await TestData.CreateVenue(provider.ProviderId, createdBy: User.ToUserInfo(), venueName: Faker.Company.Name(), providerVenueRef: "someRef");
-            var course = await TestData.CreateCourse(provider.ProviderId, createdBy: User.ToUserInfo(), learnAimRef:"AAAAAAAA",
-                configureCourseRuns: b => b.WithCourseRun(
-                    CourseDeliveryMode.ClassroomBased,
-                    null,
-                    null,
-                    venueId: venue1.VenueId,
-                    national: false,
-                    courseUrl: "https://someclassroomcourse.com",
-                    cost: 61,
-                    costDescription: "sixty one",
-                    startDate: Clock.UtcNow
-                    ));
-            var course1 = await TestData.CreateCourse(provider.ProviderId, createdBy: User.ToUserInfo(),
-                configureCourseRuns: b => b.WithCourseRun(
-                    CourseDeliveryMode.ClassroomBased,
-                    null,
-                    null,
-                    venueId: venue2.VenueId,
-                    national: false,
-                    courseUrl: "https://someclassroomcourse.com",
-                    cost: 61,
-                    costDescription: "sixty one",
-                    startDate: Clock.UtcNow));
-            var crun = course.CourseRuns.FirstOrDefault();
-            var crun1 = course1.CourseRuns.FirstOrDefault();
 
+            var course1 = await TestData.CreateCourse(provider.ProviderId, createdBy: User.ToUserInfo(), learnAimRef: "BBBBBBBB");
+            var course1CourseRun = course1.CourseRuns.Single();
+
+            var course2 = await TestData.CreateCourse(provider.ProviderId, createdBy: User.ToUserInfo(), learnAimRef: "AAAAAAAA");
+            var course2CourseRun = course2.CourseRuns.Single();
 
             // Act
             var response = await HttpClient.GetAsync($"/data-upload/courses/download?providerId={provider.ProviderId}");
 
             // Assert
             response.StatusCode.Should().Be(HttpStatusCode.OK);
-            response.Content.Headers.ContentType.MediaType.Should().Be("text/csv");
-            response.Content.Headers.ContentDisposition.FileName.Should().Be("\"Test Provider_courses_202104091300.csv\"");
 
             using var responseBody = await response.Content.ReadAsStreamAsync();
             using var responseBodyReader = new StreamReader(responseBody);
@@ -281,61 +242,8 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.DataManagement.Courses
             var rows = csvReader.GetRecords<CsvCourseRow>().ToArray();
             rows.Length.Should().Be(2);
 
-            rows.Should().BeEquivalentTo(
-                new CsvCourseRow()
-                {
-                    LearnAimRef = course1.LearnAimRef,
-                    WhoThisCourseIsFor = course1.CourseDescription,
-                    EntryRequirements = course1.EntryRequirements,
-                    WhatYouWillLearn = course1.WhatYoullLearn,
-                    WhatYouWillNeedToBring = course1.WhatYoullNeed,
-                    HowYouWillLearn = course1.HowYoullLearn,
-                    HowYouWillBeAssessed = course1.HowYoullBeAssessed,
-                    WhereNext = course1.WhereNext,
-                    CourseName = crun1.CourseName,
-                    ProviderCourseRef = crun1.ProviderCourseID ?? "",
-                    DeliveryMode = "Classroom based",
-                    StartDate = Clock.UtcNow.ToString("dd/MM/yyyy"),
-                    FlexibleStartDate = "No",
-                    VenueName = venue2.VenueName,
-                    ProviderVenueRef = "someRef",
-                    NationalDelivery = "No",
-                    SubRegions = "",
-                    CourseWebPage = "https://someclassroomcourse.com",
-                    Cost = 61.ToString("0.00"),
-                    CostDescription = "sixty one",
-                    DurationUnit = "Months",
-                    Duration = crun1.DurationValue?.ToString(),
-                    StudyMode = "",
-                    AttendancePattern = "",
-                },
-                new CsvCourseRow()
-                {
-                    LearnAimRef = course.LearnAimRef,
-                    WhoThisCourseIsFor = course.CourseDescription,
-                    EntryRequirements = course.EntryRequirements,
-                    WhatYouWillLearn = course.WhatYoullLearn,
-                    WhatYouWillNeedToBring = course.WhatYoullNeed,
-                    HowYouWillLearn = course.HowYoullLearn,
-                    HowYouWillBeAssessed = course.HowYoullBeAssessed,
-                    WhereNext = course.WhereNext,
-                    CourseName = crun.CourseName,
-                    ProviderCourseRef = crun.ProviderCourseID ?? "",
-                    DeliveryMode = "Classroom based",
-                    StartDate = Clock.UtcNow.ToString("dd/MM/yyyy"),
-                    FlexibleStartDate = "No",
-                    VenueName = venue1.VenueName,
-                    ProviderVenueRef = "someRef",
-                    NationalDelivery = "No",
-                    SubRegions = "",
-                    CourseWebPage = "https://someclassroomcourse.com",
-                    Cost = 61.ToString("0.00"),
-                    CostDescription = "sixty one",
-                    DurationUnit = "Months",
-                    Duration = crun.DurationValue?.ToString(),
-                    StudyMode = "",
-                    AttendancePattern = "",
-                });
+            rows.First().LearnAimRef.Should().Be(course2.LearnAimRef);
+            rows.Last().LearnAimRef.Should().Be(course1.LearnAimRef);
         }
     }
 }

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/DeleteCourseRunTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/DeleteCourseRunTests.cs
@@ -1,11 +1,11 @@
 ﻿using System;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using Dfc.CourseDirectory.Core.Models;
 using Dfc.CourseDirectory.Testing;
-using Dfc.CourseDirectory.Testing.DataStore.CosmosDb.Queries;
 using Dfc.CourseDirectory.WebV2.Features.DeleteCourseRun;
 using FluentAssertions;
 using FluentAssertions.Execution;
@@ -56,7 +56,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"/courses/{course.Id}/course-runs/{courseRunId}/delete?returnUrl=%2Fcourses");
+                $"/courses/{course.CourseId}/course-runs/{courseRunId}/delete?returnUrl=%2Fcourses");
 
             await User.AsProviderUser(provider.ProviderId, ProviderType.FE);
 
@@ -81,7 +81,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"/courses/{course.Id}/course-runs/{courseRunId}/delete?returnUrl=%2Fcourses");
+                $"/courses/{course.CourseId}/course-runs/{courseRunId}/delete?returnUrl=%2Fcourses");
 
             await User.AsTestUser(userType, anotherProvider.ProviderId);
 
@@ -100,14 +100,14 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
 
             var course = await TestData.CreateCourse(
                 provider.ProviderId,
-                qualificationCourseTitle: "Maths",
-                createdBy: User.ToUserInfo());
+                createdBy: User.ToUserInfo(),
+                configureCourseRuns: builder => builder.WithCourseRun(courseName: "Maths"));
 
-            var courseRunId = await GetCourseRunIdForCourse(course.Id);
+            var courseRunId = course.CourseRuns.Single().CourseRunId;
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"/courses/{course.Id}/course-runs/{courseRunId}/delete?returnUrl=%2Fcourses");
+                $"/courses/{course.CourseId}/course-runs/{courseRunId}/delete?returnUrl=%2Fcourses");
 
             await User.AsProviderUser(provider.ProviderId, ProviderType.FE);
 
@@ -131,19 +131,14 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
 
             var course = await TestData.CreateCourse(
                 provider.ProviderId,
-                qualificationCourseTitle: "Maths",
                 createdBy: User.ToUserInfo(),
-                configureCourseRuns: b => b.WithCourseRun(
-                    CourseDeliveryMode.ClassroomBased,
-                    CourseStudyMode.FullTime,
-                    CourseAttendancePattern.Daytime,
-                    venueId: venueId));
+                configureCourseRuns: b => b.WithClassroomBasedCourseRun(venueId: venueId));
 
-            var courseRunId = await GetCourseRunIdForCourse(course.Id);
+            var courseRunId = course.CourseRuns.Single().CourseRunId;
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"/courses/{course.Id}/course-runs/{courseRunId}/delete?returnUrl=%2Fcourses");
+                $"/courses/{course.CourseId}/course-runs/{courseRunId}/delete?returnUrl=%2Fcourses");
 
             await User.AsProviderUser(provider.ProviderId, ProviderType.FE);
 
@@ -167,20 +162,14 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
 
             var course = await TestData.CreateCourse(
                 provider.ProviderId,
-                qualificationCourseTitle: "Maths",
                 createdBy: User.ToUserInfo(),
-                configureCourseRuns: b => b.WithCourseRun(
-                    CourseDeliveryMode.Online,
-                    CourseStudyMode.PartTime,
-                    CourseAttendancePattern.Evening,
-                    venueId: null,
-                    national: true));
+                configureCourseRuns: b => b.WithWorkBasedCourseRun());
 
-            var courseRunId = await GetCourseRunIdForCourse(course.Id);
+            var courseRunId = course.CourseRuns.Single().CourseRunId;
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"/courses/{course.Id}/course-runs/{courseRunId}/delete?returnUrl=%2Fcourses");
+                $"/courses/{course.CourseId}/course-runs/{courseRunId}/delete?returnUrl=%2Fcourses");
 
             await User.AsProviderUser(provider.ProviderId, ProviderType.FE);
 
@@ -204,20 +193,14 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
 
             var course = await TestData.CreateCourse(
                 provider.ProviderId,
-                qualificationCourseTitle: "Maths",
                 createdBy: User.ToUserInfo(),
-                configureCourseRuns: b => b.WithCourseRun(
-                    CourseDeliveryMode.Online,
-                    CourseStudyMode.PartTime,
-                    CourseAttendancePattern.Evening,
-                    national: true,
-                    providerCourseId: "My course"));
+                configureCourseRuns: b => b.WithCourseRun(providerCourseRef: "My course"));
 
-            var courseRunId = await GetCourseRunIdForCourse(course.Id);
+            var courseRunId = course.CourseRuns.Single().CourseRunId;
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"/courses/{course.Id}/course-runs/{courseRunId}/delete?returnUrl=%2Fcourses");
+                $"/courses/{course.CourseId}/course-runs/{courseRunId}/delete?returnUrl=%2Fcourses");
 
             await User.AsProviderUser(provider.ProviderId, ProviderType.FE);
 
@@ -241,20 +224,14 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
 
             var course = await TestData.CreateCourse(
                 provider.ProviderId,
-                qualificationCourseTitle: "Maths",
                 createdBy: User.ToUserInfo(),
-                configureCourseRuns: b => b.WithCourseRun(
-                    CourseDeliveryMode.Online,
-                    CourseStudyMode.PartTime,
-                    CourseAttendancePattern.Evening,
-                    national: true,
-                    providerCourseId: null));
+                configureCourseRuns: b => b.WithCourseRun(providerCourseRef: null));
 
-            var courseRunId = await GetCourseRunIdForCourse(course.Id);
+            var courseRunId = course.CourseRuns.Single().CourseRunId;
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"/courses/{course.Id}/course-runs/{courseRunId}/delete?returnUrl=%2Fcourses");
+                $"/courses/{course.CourseId}/course-runs/{courseRunId}/delete?returnUrl=%2Fcourses");
 
             await User.AsProviderUser(provider.ProviderId, ProviderType.FE);
 
@@ -278,20 +255,14 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
 
             var course = await TestData.CreateCourse(
                 provider.ProviderId,
-                qualificationCourseTitle: "Maths",
                 createdBy: User.ToUserInfo(),
-                configureCourseRuns: b => b.WithCourseRun(
-                    CourseDeliveryMode.Online,
-                    CourseStudyMode.PartTime,
-                    CourseAttendancePattern.Evening,
-                    national: true,
-                    flexibleStartDate: true));
+                configureCourseRuns: b => b.WithCourseRun(flexibleStartDate: true));
 
-            var courseRunId = await GetCourseRunIdForCourse(course.Id);
+            var courseRunId = course.CourseRuns.Single().CourseRunId;
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"/courses/{course.Id}/course-runs/{courseRunId}/delete?returnUrl=%2Fcourses");
+                $"/courses/{course.CourseId}/course-runs/{courseRunId}/delete?returnUrl=%2Fcourses");
 
             await User.AsProviderUser(provider.ProviderId, ProviderType.FE);
 
@@ -315,20 +286,14 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
 
             var course = await TestData.CreateCourse(
                 provider.ProviderId,
-                qualificationCourseTitle: "Maths",
                 createdBy: User.ToUserInfo(),
-                configureCourseRuns: b => b.WithCourseRun(
-                    CourseDeliveryMode.Online,
-                    CourseStudyMode.PartTime,
-                    CourseAttendancePattern.Evening,
-                    national: true,
-                    startDate: new DateTime(2020, 4, 1)));
+                configureCourseRuns: b => b.WithOnlineCourseRun(startDate: new DateTime(2020, 4, 1)));
 
-            var courseRunId = await GetCourseRunIdForCourse(course.Id);
+            var courseRunId = course.CourseRuns.Single().CourseRunId;
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"/courses/{course.Id}/course-runs/{courseRunId}/delete?returnUrl=%2Fcourses");
+                $"/courses/{course.CourseId}/course-runs/{courseRunId}/delete?returnUrl=%2Fcourses");
 
             await User.AsProviderUser(provider.ProviderId, ProviderType.FE);
 
@@ -348,13 +313,13 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
             // Arrange
             var provider = await TestData.CreateProvider();
             var course = await TestData.CreateCourse(provider.ProviderId, createdBy: User.ToUserInfo());
-            var courseRunId = await GetCourseRunIdForCourse(course.Id);
+            var courseRunId = course.CourseRuns.Single().CourseRunId;
 
             var returnUrl = "/courses";
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"/courses/{course.Id}/course-runs/{courseRunId}/delete?returnUrl={UrlEncoder.Default.Encode(returnUrl)}");
+                $"/courses/{course.CourseId}/course-runs/{courseRunId}/delete?returnUrl={UrlEncoder.Default.Encode(returnUrl)}");
 
             await User.AsProviderUser(provider.ProviderId, ProviderType.FE);
 
@@ -412,14 +377,14 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
 
             var request = new HttpRequestMessage(
                 HttpMethod.Post,
-                $"/courses/{course.Id}/course-runs/{courseRunId}/delete?returnUrl=%2fcourses")
+                $"/courses/{course.CourseId}/course-runs/{courseRunId}/delete?returnUrl=%2fcourses")
             {
                 Content = requestContent
             };
 
             await User.AsProviderUser(provider.ProviderId, ProviderType.FE);
 
-            CreateJourneyInstance(course.Id, courseRunId);
+            CreateJourneyInstance(course.CourseId, courseRunId);
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -438,7 +403,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
 
             var provider = await TestData.CreateProvider();
             var course = await TestData.CreateCourse(provider.ProviderId, createdBy: User.ToUserInfo());
-            var courseRunId = await GetCourseRunIdForCourse(course.Id);
+            var courseRunId = course.CourseRuns.Single().CourseRunId;
 
             var requestContent = new FormUrlEncodedContentBuilder()
                 .Add("Confirm", "true")
@@ -446,14 +411,14 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
 
             var request = new HttpRequestMessage(
                 HttpMethod.Post,
-                $"/courses/{course.Id}/course-runs/{courseRunId}/delete?returnUrl=%2fcourses")
+                $"/courses/{course.CourseId}/course-runs/{courseRunId}/delete?returnUrl=%2fcourses")
             {
                 Content = requestContent
             };
 
             await User.AsTestUser(userType, anotherProvider.ProviderId);
 
-            CreateJourneyInstance(course.Id, courseRunId);
+            CreateJourneyInstance(course.CourseId, courseRunId);
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -468,21 +433,21 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
             // Arrange
             var provider = await TestData.CreateProvider();
             var course = await TestData.CreateCourse(provider.ProviderId, createdBy: User.ToUserInfo());
-            var courseRunId = await GetCourseRunIdForCourse(course.Id);
+            var courseRunId = course.CourseRuns.Single().CourseRunId;
 
             var requestContent = new FormUrlEncodedContentBuilder()
                 .ToContent();
 
             var request = new HttpRequestMessage(
                 HttpMethod.Post,
-                $"/courses/{course.Id}/course-runs/{courseRunId}/delete?returnUrl=%2fcourses")
+                $"/courses/{course.CourseId}/course-runs/{courseRunId}/delete?returnUrl=%2fcourses")
             {
                 Content = requestContent
             };
 
             await User.AsProviderUser(provider.ProviderId, ProviderType.FE);
 
-            CreateJourneyInstance(course.Id, courseRunId);
+            CreateJourneyInstance(course.CourseId, courseRunId);
 
             // Act
             var response = await HttpClient.SendAsync(request);
@@ -503,7 +468,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
                 qualificationCourseTitle: "Maths",
                 createdBy: User.ToUserInfo());
 
-            var courseRunId = await GetCourseRunIdForCourse(course.Id);
+            var courseRunId = course.CourseRuns.Single().CourseRunId;
 
             var requestContent = new FormUrlEncodedContentBuilder()
                 .Add("Confirm", "true")
@@ -511,14 +476,14 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
 
             var request = new HttpRequestMessage(
                 HttpMethod.Post,
-                $"/courses/{course.Id}/course-runs/{courseRunId}/delete?returnUrl=%2fcourses")
+                $"/courses/{course.CourseId}/course-runs/{courseRunId}/delete?returnUrl=%2fcourses")
             {
                 Content = requestContent
             };
 
             await User.AsProviderUser(provider.ProviderId, ProviderType.FE);
 
-            CreateJourneyInstance(course.Id, courseRunId);
+            CreateJourneyInstance(course.CourseId, courseRunId);
 
             DeleteCourseRunQuery capturedDeleteCourseRunQuery = null;
             CosmosDbQueryDispatcher.Callback<DeleteCourseRunQuery, OneOf<NotFound, Success>>(q => capturedDeleteCourseRunQuery = q);
@@ -530,14 +495,14 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
             Assert.Equal(HttpStatusCode.Found, response.StatusCode);
 
             Assert.Equal(
-                $"/courses/{course.Id}/course-runs/{courseRunId}/delete/confirmed",
+                $"/courses/{course.CourseId}/course-runs/{courseRunId}/delete/confirmed",
                 response.Headers.Location.OriginalString);
 
             CosmosDbQueryDispatcher.Verify(d => d.ExecuteQuery(It.IsAny<DeleteCourseRunQuery>()), Times.Once);
             using (new AssertionScope())
             {
                 capturedDeleteCourseRunQuery.Should().NotBeNull();
-                capturedDeleteCourseRunQuery.CourseId.Should().Be(course.Id);
+                capturedDeleteCourseRunQuery.CourseId.Should().Be(course.CourseId);
                 capturedDeleteCourseRunQuery.CourseRunId.Should().Be(courseRunId);
                 capturedDeleteCourseRunQuery.ProviderUkprn.Should().Be(provider.Ukprn);
                 capturedDeleteCourseRunQuery.UpdatedBy.Should().Be(TestUserInfo.DefaultUserId);
@@ -556,23 +521,23 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
                 qualificationCourseTitle: "Maths",
                 createdBy: User.ToUserInfo());
 
-            var courseRunId = await GetCourseRunIdForCourse(course.Id);
+            var courseRunId = course.CourseRuns.Single().CourseRunId;
 
             await CosmosDbQueryDispatcher.Object.ExecuteQuery(new DeleteCourseRunQuery()
             {
-                CourseId = course.Id,
+                CourseId = course.CourseId,
                 CourseRunId = courseRunId,
                 ProviderUkprn = provider.Ukprn
             });
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"/courses/{course.Id}/course-runs/{courseRunId}/delete/confirmed");
+                $"/courses/{course.CourseId}/course-runs/{courseRunId}/delete/confirmed");
 
             await User.AsProviderUser(provider.ProviderId, ProviderType.FE);
 
             CreateJourneyInstance(
-                course.Id,
+                course.CourseId,
                 courseRunId,
                 new JourneyModel()
                 {
@@ -602,23 +567,23 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
                 qualificationCourseTitle: "Maths",
                 createdBy: User.ToUserInfo());
 
-            var courseRunId = await GetCourseRunIdForCourse(course.Id);
+            var courseRunId = course.CourseRuns.Single().CourseRunId;
 
             await CosmosDbQueryDispatcher.Object.ExecuteQuery(new DeleteCourseRunQuery()
             {
-                CourseId = course.Id,
+                CourseId = course.CourseId,
                 CourseRunId = courseRunId,
                 ProviderUkprn = provider.Ukprn
             });
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"/courses/{course.Id}/course-runs/{courseRunId}/delete/confirmed");
+                $"/courses/{course.CourseId}/course-runs/{courseRunId}/delete/confirmed");
 
             await User.AsProviderUser(provider.ProviderId, ProviderType.FE);
 
             CreateJourneyInstance(
-                course.Id,
+                course.CourseId,
                 courseRunId,
                 new JourneyModel()
                 {
@@ -648,26 +613,26 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
                 qualificationCourseTitle: "Maths",
                 createdBy: User.ToUserInfo());
 
-            var courseRunId = await GetCourseRunIdForCourse(course.Id);
+            var courseRunId = course.CourseRuns.Single().CourseRunId;
 
             // Create another live course
             await TestData.CreateCourse(provider.ProviderId, createdBy: User.ToUserInfo());
 
             await CosmosDbQueryDispatcher.Object.ExecuteQuery(new DeleteCourseRunQuery()
             {
-                CourseId = course.Id,
+                CourseId = course.CourseId,
                 CourseRunId = courseRunId,
                 ProviderUkprn = provider.Ukprn
             });
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"/courses/{course.Id}/course-runs/{courseRunId}/delete/confirmed");
+                $"/courses/{course.CourseId}/course-runs/{courseRunId}/delete/confirmed");
 
             await User.AsProviderUser(provider.ProviderId, ProviderType.FE);
 
             CreateJourneyInstance(
-                course.Id,
+                course.CourseId,
                 courseRunId,
                 new JourneyModel()
                 {
@@ -697,19 +662,6 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests
                     .With("courseId", courseId)
                     .With("courseRunId", courseRunId),
                 flowModel ?? new JourneyModel());
-        }
-
-        private async Task<Guid> GetCourseRunIdForCourse(Guid courseId)
-        {
-            var course = await CosmosDbQueryDispatcher.Object.ExecuteQuery(
-                new GetCourseById()
-                {
-                    CourseId = courseId
-                });
-
-            var courseRun = Assert.Single(course.CourseRuns);
-
-            return courseRun.Id;
         }
     }
 }

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/ProviderDashboard/DashboardTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/ProviderDashboard/DashboardTests.cs
@@ -267,12 +267,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ProviderDashboard
             await TestData.CreateCourse(
                 provider.ProviderId,
                 createdBy: User.ToUserInfo(),
-                configureCourseRuns: courseRunBuilder =>
-                    courseRunBuilder.WithCourseRun(
-                        CourseDeliveryMode.ClassroomBased,
-                        CourseStudyMode.FullTime,
-                        CourseAttendancePattern.Daytime,
-                        startDate: Clock.UtcNow.AddMonths(-1).Date));
+                configureCourseRuns: builder => builder.WithCourseRun(startDate: Clock.UtcNow.AddMonths(-1).Date));
 
             var request = new HttpRequestMessage(HttpMethod.Get, $"/dashboard?providerId={provider.ProviderId}");
 
@@ -298,12 +293,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ProviderDashboard
             await TestData.CreateCourse(
                 provider.ProviderId,
                 createdBy: User.ToUserInfo(),
-                courseStatus: courseStatus,
-                configureCourseRuns: courseRunBuilder =>
-                    courseRunBuilder.WithCourseRun(
-                        CourseDeliveryMode.ClassroomBased,
-                        CourseStudyMode.FullTime,
-                        CourseAttendancePattern.Daytime));
+                configureCourseRuns: builder => builder.WithCourseRun(status: courseStatus));
 
             var request = new HttpRequestMessage(HttpMethod.Get, $"/dashboard?providerId={provider.ProviderId}");
 
@@ -347,12 +337,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ProviderDashboard
             await TestData.CreateCourse(
                 provider.ProviderId,
                 createdBy: User.ToUserInfo(),
-                courseStatus: CourseStatus.BulkUploadPending,
-                configureCourseRuns: courseRunBuilder =>
-                    courseRunBuilder.WithCourseRun(
-                        CourseDeliveryMode.ClassroomBased,
-                        CourseStudyMode.FullTime,
-                        CourseAttendancePattern.Daytime));
+                configureCourseRuns: builder => builder.WithCourseRun(status: CourseStatus.BulkUploadPending));
 
             var request = new HttpRequestMessage(HttpMethod.Get, $"/dashboard?providerId={provider.ProviderId}");
 
@@ -376,12 +361,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.ProviderDashboard
             await TestData.CreateCourse(
                 provider.ProviderId,
                 createdBy: User.ToUserInfo(),
-                courseStatus: CourseStatus.BulkUploadReadyToGoLive,
-                configureCourseRuns: courseRunBuilder =>
-                    courseRunBuilder.WithCourseRun(
-                        CourseDeliveryMode.ClassroomBased,
-                        CourseStudyMode.FullTime,
-                        CourseAttendancePattern.Daytime));
+                configureCourseRuns: builder => builder.WithCourseRun(status: CourseStatus.BulkUploadReadyToGoLive));
 
             var request = new HttpRequestMessage(HttpMethod.Get, $"/dashboard?providerId={provider.ProviderId}");
 

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/Providers/Reporting/ProviderMissingPrimaryContactReportTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/Providers/Reporting/ProviderMissingPrimaryContactReportTests.cs
@@ -476,7 +476,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers.Reporting
             {
                 CreateContact("CV4 1AA", "some Street", null, null)
             });
-            await TestData.CreateCourse(provider.ProviderId, createdBy: User.ToUserInfo(), courseStatus: courseStatus);
+            await TestData.CreateCourse(provider.ProviderId, createdBy: User.ToUserInfo(), configureCourseRuns: builder => builder.WithCourseRun(status: courseStatus));
 
             await User.AsHelpdesk();
             var request = new HttpRequestMessage(

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/Providers/Reporting/ProviderTypeReportTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/Providers/Reporting/ProviderTypeReportTests.cs
@@ -123,10 +123,17 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Providers.Reporting
             var provider = await CreateProvider(12345678, ProviderType.FE | ProviderType.Apprenticeships | ProviderType.TLevels, ProviderStatus.Onboarded, "Active");
             var venue = await TestData.CreateVenue(provider.ProviderId, createdBy: User.ToUserInfo(), venueName: "TestVenue1");
 
-            var liveCourseIds = await Task.WhenAll(Enumerable.Range(0, 3).Select(_ => TestData.CreateCourse(provider.ProviderId, User.ToUserInfo())));
-            var pendingCourseIds = await Task.WhenAll(Enumerable.Range(0, 1).Select(_ => TestData.CreateCourse(provider.ProviderId, User.ToUserInfo(), courseStatus: CourseStatus.Pending)));
-            var archivedCourseIds = await Task.WhenAll(Enumerable.Range(0, 1).Select(_ => TestData.CreateCourse(provider.ProviderId, User.ToUserInfo(), courseStatus: CourseStatus.Archived)));
-            var deletedCourseIds = await Task.WhenAll(Enumerable.Range(0, 1).Select(_ => TestData.CreateCourse(provider.ProviderId, User.ToUserInfo(), courseStatus: CourseStatus.Deleted)));
+            var liveCourseIds = await Task.WhenAll(
+                Enumerable.Range(0, 3).Select(_ => TestData.CreateCourse(provider.ProviderId, User.ToUserInfo())));
+
+            var pendingCourseIds = await Task.WhenAll(
+                Enumerable.Range(0, 1).Select(_ => TestData.CreateCourse(provider.ProviderId, User.ToUserInfo(), configureCourseRuns: builder => builder.WithCourseRun(status: CourseStatus.Pending))));
+
+            var archivedCourseIds = await Task.WhenAll(
+                Enumerable.Range(0, 1).Select(_ => TestData.CreateCourse(provider.ProviderId, User.ToUserInfo(), configureCourseRuns: builder => builder.WithCourseRun(status: CourseStatus.Archived))));
+
+            var deletedCourseIds = await Task.WhenAll(
+                Enumerable.Range(0, 1).Select(_ => TestData.CreateCourse(provider.ProviderId, User.ToUserInfo(), configureCourseRuns: builder => builder.WithCourseRun(status: CourseStatus.Deleted))));
 
             var standard = await TestData.CreateStandard(123, 456, "TestStandard1");
             var liveApprenticeships = await Task.WhenAll(Enumerable.Range(0, 3).Select(_ => TestData.CreateApprenticeship(provider.ProviderId, standard, User.ToUserInfo())));

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/Venues/DeleteVenue/DeleteVenueTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/Venues/DeleteVenue/DeleteVenueTests.cs
@@ -72,8 +72,10 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.DeleteVenue
 
             var venue = await TestData.CreateVenue(provider.ProviderId, createdBy: User.ToUserInfo());
 
-            var course = await TestData.CreateCourse(provider.ProviderId, User.ToUserInfo(), configureCourseRuns: builder =>
-                builder.WithCourseRun(CourseDeliveryMode.ClassroomBased, CourseStudyMode.FullTime, CourseAttendancePattern.Daytime, venueId: venue.VenueId));
+            var course = await TestData.CreateCourse(
+                provider.ProviderId,
+                createdBy: User.ToUserInfo(),
+                configureCourseRuns: builder => builder.WithClassroomBasedCourseRun(venueId: venue.VenueId));
 
             var request = new HttpRequestMessage(HttpMethod.Get, $"/venues/{venue.VenueId}/delete");
 
@@ -86,7 +88,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.DeleteVenue
             var doc = await response.GetDocument();
 
             Assert.Null(doc.GetElementByTestId("delete-location-button"));
-            Assert.NotNull(doc.GetElementByTestId($"affected-course-{course.Id}"));
+            Assert.NotNull(doc.GetElementByTestId($"affected-course-{course.CourseId}"));
         }
 
         [Fact]
@@ -303,8 +305,10 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.DeleteVenue
 
             var venue = await TestData.CreateVenue(provider.ProviderId, createdBy: User.ToUserInfo());
 
-            var course = await TestData.CreateCourse(provider.ProviderId, User.ToUserInfo(), configureCourseRuns: builder =>
-                builder.WithCourseRun(CourseDeliveryMode.ClassroomBased, CourseStudyMode.FullTime, CourseAttendancePattern.Daytime, venueId: venue.VenueId));
+            var course = await TestData.CreateCourse(
+                provider.ProviderId,
+                createdBy: User.ToUserInfo(),
+                configureCourseRuns: builder => builder.WithClassroomBasedCourseRun(venueId: venue.VenueId));
 
             var requestContent = new FormUrlEncodedContentBuilder()
                 .Add(nameof(Command.Confirm), true)
@@ -325,7 +329,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.Venues.DeleteVenue
             var doc = await response.GetDocument();
 
             Assert.Null(doc.GetElementByTestId("delete-location-button"));
-            Assert.NotNull(doc.GetElementByTestId($"affected-course-{course.Id}"));
+            Assert.NotNull(doc.GetElementByTestId($"affected-course-{course.CourseId}"));
             doc.GetElementByTestId("affected-courses-error-message").TextContent.Should().Be("The affected courses have changed");
         }
 

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FilterTests/AuthorizeCourseAttributeTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FilterTests/AuthorizeCourseAttributeTests.cs
@@ -27,7 +27,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FilterTests
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"/AuthorizeCourseAttributeTests/{course.Id}");
+                $"/AuthorizeCourseAttributeTests/{course.CourseId}");
 
             await User.AsTestUser(userType);
 
@@ -50,7 +50,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FilterTests
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"/AuthorizeCourseAttributeTests/{course.Id}");
+                $"/AuthorizeCourseAttributeTests/{course.CourseId}");
 
             await User.AsTestUser(userType, provider.ProviderId);
 
@@ -75,7 +75,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FilterTests
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"/AuthorizeCourseAttributeTests/{course.Id}");
+                $"/AuthorizeCourseAttributeTests/{course.CourseId}");
 
             await User.AsTestUser(userType, anotherProvider.ProviderId);
 
@@ -96,7 +96,7 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FilterTests
 
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"/AuthorizeCourseAttributeTests/{course.Id}");
+                $"/AuthorizeCourseAttributeTests/{course.CourseId}");
 
             User.SetNotAuthenticated();
 


### PR DESCRIPTION
There's now a method on CreateCourseCourseRun for each delivery type that accepts only the relevant/allowed parameters for that delivery type.

Also amended the method to return the Course SQL model instead of the Cosmos one.