### PR TITLE
Rationalize HTML encoded course data

### DIFF
--- a/src/Dfc.CourseDirectory.Core/DataStore/Sql/QueryHandlers/CourseMappingHelper.cs
+++ b/src/Dfc.CourseDirectory.Core/DataStore/Sql/QueryHandlers/CourseMappingHelper.cs
@@ -1,0 +1,132 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Dapper;
+using Dfc.CourseDirectory.Core.DataStore.Sql.Models;
+using Dfc.CourseDirectory.Core.Models;
+using static System.Net.WebUtility;
+
+namespace Dfc.CourseDirectory.Core.DataStore.Sql.QueryHandlers
+{
+    internal static class CourseMappingHelper
+    {
+        public static async Task<IReadOnlyCollection<Course>> MapCourses(SqlMapper.GridReader reader)
+        {
+            var courses = await reader.ReadAsync<CourseResult>();
+
+            var courseRuns = (await reader.ReadAsync<CourseRunResult>())
+                .GroupBy(r => r.CourseId)
+                .ToDictionary(g => g.Key, g => g.AsEnumerable());
+
+            var courseRunSubRegions = (await reader.ReadAsync<CourseRunSubRegionResult>())
+                .GroupBy(r => r.CourseRunId)
+                .ToDictionary(g => g.Key, g => g.Select(r => r.RegionId).AsEnumerable());
+
+            // N.B. We need to normalize HTML-encoded data here. The legacy projects HTML-encoded everything before
+            // persisting it in Cosmos. We want to move the HTML encoding to the edge, where it should be done.
+            // The existing data synced from Cosmos has a DataIsHtmlEncoded column set to true; read that here and
+            // decode the relevant fields if it's set.
+
+            return courses.Select(MapCourse).ToArray();
+
+            Course MapCourse(CourseResult row)
+            {
+                return new Course()
+                {
+                    CourseId = row.CourseId,
+                    CourseStatus = row.CourseStatus,
+                    ProviderId = row.ProviderId,
+                    LearnAimRef = row.LearnAimRef,
+                    CourseDescription = DecodeIfNecessary(row.CourseDescription),
+                    EntryRequirements = DecodeIfNecessary(row.EntryRequirements),
+                    WhatYoullLearn = DecodeIfNecessary(row.WhatYoullLearn),
+                    HowYoullLearn = DecodeIfNecessary(row.HowYoullLearn),
+                    WhatYoullNeed = DecodeIfNecessary(row.WhatYoullNeed),
+                    HowYoullBeAssessed = DecodeIfNecessary(row.HowYoullBeAssessed),
+                    WhereNext = DecodeIfNecessary(row.WhereNext),
+                    CourseRuns = courseRuns
+                        .GetValueOrDefault(row.CourseId, Enumerable.Empty<CourseRunResult>())
+                        .Select(MapCourseRun)
+                        .ToArray()
+                };
+
+                string DecodeIfNecessary(string field) => row.DataIsHtmlEncoded ? HtmlDecode(field) : field;
+            }
+
+            CourseRun MapCourseRun(CourseRunResult row)
+            {
+                return new CourseRun()
+                {
+                    CourseRunId = row.CourseRunId,
+                    CourseRunStatus = row.CourseRunStatus,
+                    CourseName = DecodeIfNecessary(row.CourseName),
+                    VenueId = row.VenueId,
+                    ProviderCourseId = DecodeIfNecessary(row.ProviderCourseId),
+                    DeliveryMode = row.DeliveryMode,
+                    FlexibleStartDate = row.FlexibleStartDate,
+                    StartDate = row.StartDate,
+                    CourseWebsite = row.CourseWebsite,
+                    Cost = row.Cost,
+                    CostDescription = DecodeIfNecessary(row.CostDescription),
+                    DurationUnit = row.DurationUnit,
+                    DurationValue = row.DurationValue,
+                    StudyMode = row.StudyMode != 0 ? row.StudyMode : null,  // Normalize 0 to null
+                    AttendancePattern = row.AttendancePattern != 0 ? row.AttendancePattern : null,  // Normalize 0 to null
+                    National = row.National,
+                    SubRegionIds = courseRunSubRegions.GetValueOrDefault(row.CourseRunId, Enumerable.Empty<string>()).ToArray(),
+                    VenueName = row.VenueName,
+                    ProviderVenueRef = row.ProviderVenueRef
+                };
+
+                string DecodeIfNecessary(string field) => row.DataIsHtmlEncoded ? HtmlDecode(field) : field;
+            }
+        }
+
+        private class CourseResult
+        {
+            public Guid CourseId { get; set; }
+            public CourseStatus CourseStatus { get; set; }
+            public Guid ProviderId { get; set; }
+            public string LearnAimRef { get; set; }
+            public string CourseDescription { get; set; }
+            public string EntryRequirements { get; set; }
+            public string WhatYoullLearn { get; set; }
+            public string HowYoullLearn { get; set; }
+            public string WhatYoullNeed { get; set; }
+            public string HowYoullBeAssessed { get; set; }
+            public string WhereNext { get; set; }
+            public bool DataIsHtmlEncoded { get; set; }
+        }
+
+        private class CourseRunResult
+        {
+            public Guid CourseId { get; set; }
+            public Guid CourseRunId { get; set; }
+            public CourseStatus CourseRunStatus { get; set; }
+            public string CourseName { get; set; }
+            public Guid? VenueId { get; set; }
+            public string ProviderCourseId { get; set; }
+            public CourseDeliveryMode DeliveryMode { get; set; }
+            public bool FlexibleStartDate { get; set; }
+            public DateTime? StartDate { get; set; }
+            public string CourseWebsite { get; set; }
+            public decimal? Cost { get; set; }
+            public string CostDescription { get; set; }
+            public CourseDurationUnit DurationUnit { get; set; }
+            public int? DurationValue { get; set; }
+            public CourseStudyMode? StudyMode { get; set; }
+            public CourseAttendancePattern? AttendancePattern { get; set; }
+            public bool? National { get; set; }
+            public string VenueName { get; set; }
+            public string ProviderVenueRef { get; set; }
+            public bool DataIsHtmlEncoded { get; set; }
+        }
+
+        private class CourseRunSubRegionResult
+        {
+            public Guid CourseRunId { get; set; }
+            public string RegionId { get; set; }
+        }
+    }
+}

--- a/src/Dfc.CourseDirectory.Core/DataStore/Sql/QueryHandlers/GetCourseHandler.cs
+++ b/src/Dfc.CourseDirectory.Core/DataStore/Sql/QueryHandlers/GetCourseHandler.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Data.SqlClient;
+﻿using System.Data.SqlClient;
 using System.Linq;
 using System.Threading.Tasks;
 using Dapper;
@@ -18,7 +16,7 @@ namespace Dfc.CourseDirectory.Core.DataStore.Sql.QueryHandlers
 SELECT
     c.CourseId, c.CourseStatus, p.ProviderId, c.LearnAimRef,
     c.CourseDescription, c.EntryRequirements, c.WhatYoullLearn, c.HowYoullLearn, c.WhatYoullNeed, c.HowYoullBeAssessed,
-    c.WhereNext
+    c.WhereNext, c.DataIsHtmlEncoded
 FROM Pttcd.Courses c
 JOIN Pttcd.Providers p ON c.ProviderUkprn = p.Ukprn
 WHERE c.CourseId = @CourseId
@@ -43,6 +41,7 @@ SELECT
     cr.StudyMode,
     cr.AttendancePattern,
     cr.[National],
+    cr.DataIsHtmlEncoded,
     v.VenueName,
     v.ProviderVenueRef
 FROM Pttcd.CourseRuns cr
@@ -63,101 +62,7 @@ WHERE cr.CourseId = @CourseId
 
             using var reader = await transaction.Connection.QueryMultipleAsync(sql, paramz, transaction);
 
-            var course = await reader.ReadSingleOrDefaultAsync<CourseResult>();
-
-            if (course == null)
-            {
-                return null;
-            }
-
-            var courseRuns = await reader.ReadAsync<CourseRunResult>();
-
-            var courseRunSubRegions = (await reader.ReadAsync<CourseRunSubRegionResult>())
-                .GroupBy(r => r.CourseRunId)
-                .ToDictionary(g => g.Key, g => g.Select(r => r.RegionId).AsEnumerable());
-
-            return new Course()
-            {
-                CourseId = course.CourseId,
-                CourseStatus = course.CourseStatus,
-                ProviderId = course.ProviderId,
-                LearnAimRef = course.LearnAimRef,
-                CourseDescription = course.CourseDescription,
-                EntryRequirements = course.EntryRequirements,
-                WhatYoullLearn = course.WhatYoullLearn,
-                HowYoullLearn = course.HowYoullLearn,
-                WhatYoullNeed = course.WhatYoullNeed,
-                HowYoullBeAssessed = course.HowYoullBeAssessed,
-                WhereNext = course.WhereNext,
-                CourseRuns = courseRuns
-                    .Select(cr => new CourseRun()
-                    {
-                        CourseRunId = cr.CourseRunId,
-                        CourseRunStatus = cr.CourseRunStatus,
-                        CourseName = cr.CourseName,
-                        VenueId = cr.VenueId,
-                        ProviderCourseId = cr.ProviderCourseId,
-                        DeliveryMode = cr.DeliveryMode,
-                        FlexibleStartDate = cr.FlexibleStartDate,
-                        StartDate = cr.StartDate,
-                        CourseWebsite = cr.CourseWebsite,
-                        Cost = cr.Cost,
-                        CostDescription = cr.CostDescription,
-                        DurationUnit = cr.DurationUnit,
-                        DurationValue = cr.DurationValue,
-                        StudyMode = cr.StudyMode != 0 ? cr.StudyMode : null,  // Normalize 0 to null
-                        AttendancePattern = cr.AttendancePattern != 0 ? cr.AttendancePattern : null,  // Normalize 0 to null
-                        National = cr.National,
-                        SubRegionIds = courseRunSubRegions.GetValueOrDefault(cr.CourseRunId, Enumerable.Empty<string>()).ToArray(),
-                        VenueName = cr.VenueName,
-                        ProviderVenueRef = cr.ProviderVenueRef
-                    })
-                    .ToArray()
-            };
-        }
-
-        private class CourseResult
-        {
-            public Guid CourseId { get; set; }
-            public CourseStatus CourseStatus { get; set; }
-            public Guid ProviderId { get; set; }
-            public string LearnAimRef { get; set; }
-            public string CourseDescription { get; set; }
-            public string EntryRequirements { get; set; }
-            public string WhatYoullLearn { get; set; }
-            public string HowYoullLearn { get; set; }
-            public string WhatYoullNeed { get; set; }
-            public string HowYoullBeAssessed { get; set; }
-            public string WhereNext { get; set; }
-        }
-
-        private class CourseRunResult
-        {
-            public Guid CourseId { get; set; }
-            public Guid CourseRunId { get; set; }
-            public CourseStatus CourseRunStatus { get; set; }
-            public string CourseName { get; set; }
-            public Guid? VenueId { get; set; }
-            public string ProviderCourseId { get; set; }
-            public CourseDeliveryMode DeliveryMode { get; set; }
-            public bool FlexibleStartDate { get; set; }
-            public DateTime? StartDate { get; set; }
-            public string CourseWebsite { get; set; }
-            public decimal? Cost { get; set; }
-            public string CostDescription { get; set; }
-            public CourseDurationUnit DurationUnit { get; set; }
-            public int? DurationValue { get; set; }
-            public CourseStudyMode? StudyMode { get; set; }
-            public CourseAttendancePattern? AttendancePattern { get; set; }
-            public bool? National { get; set; }
-            public string VenueName { get; set; }
-            public string ProviderVenueRef { get; set; }
-        }
-
-        private class CourseRunSubRegionResult
-        {
-            public Guid CourseRunId { get; set; }
-            public string RegionId { get; set; }
+            return (await CourseMappingHelper.MapCourses(reader)).SingleOrDefault();
         }
     }
 }

--- a/src/Dfc.CourseDirectory.Core/DataStore/Sql/QueryHandlers/GetCoursesForProviderHandler.cs
+++ b/src/Dfc.CourseDirectory.Core/DataStore/Sql/QueryHandlers/GetCoursesForProviderHandler.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Data.SqlClient;
 using System.Linq;
 using System.Threading.Tasks;
@@ -27,7 +26,7 @@ AND (c.CourseStatus & @CourseStatusMask) <> 0
 SELECT
     c.CourseId, c.CourseStatus, @ProviderId ProviderId, c.LearnAimRef,
     c.CourseDescription, c.EntryRequirements, c.WhatYoullLearn, c.HowYoullLearn, c.WhatYoullNeed, c.HowYoullBeAssessed,
-    c.WhereNext
+    c.WhereNext, c.DataIsHtmlEncoded
 FROM Pttcd.Courses c
 JOIN @CourseIds x ON c.CourseId = x.Id
 
@@ -50,6 +49,7 @@ SELECT
     cr.StudyMode,
     cr.AttendancePattern,
     cr.[National],
+    cr.DataIsHtmlEncoded,
     v.VenueName,
     v.ProviderVenueRef
 FROM Pttcd.CourseRuns cr
@@ -72,102 +72,7 @@ JOIN @CourseIds x ON cr.CourseId = x.Id
             };
 
             using var reader = await transaction.Connection.QueryMultipleAsync(sql, paramz, transaction);
-
-            var courses = await reader.ReadAsync<CourseResult>();
-
-            var courseRuns = (await reader.ReadAsync<CourseRunResult>())
-                .GroupBy(r => r.CourseId)
-                .ToDictionary(g => g.Key, g => g.AsEnumerable());
-
-            var courseRunSubRegions = (await reader.ReadAsync<CourseRunSubRegionResult>())
-                .GroupBy(r => r.CourseRunId)
-                .ToDictionary(g => g.Key, g => g.Select(r => r.RegionId).AsEnumerable());
-
-            return courses
-                .Select(c => new Course()
-                {
-                    CourseId = c.CourseId,
-                    CourseStatus = c.CourseStatus,
-                    ProviderId = c.ProviderId,
-                    LearnAimRef = c.LearnAimRef,
-                    CourseDescription = c.CourseDescription,
-                    EntryRequirements = c.EntryRequirements,
-                    WhatYoullLearn = c.WhatYoullLearn,
-                    HowYoullLearn = c.HowYoullLearn,
-                    WhatYoullNeed = c.WhatYoullNeed,
-                    HowYoullBeAssessed = c.HowYoullBeAssessed,
-                    WhereNext = c.WhereNext,
-                    CourseRuns = courseRuns
-                        .GetValueOrDefault(c.CourseId, Enumerable.Empty<CourseRunResult>())
-                        .Select(cr => new CourseRun()
-                        {
-                            CourseRunId = cr.CourseRunId,
-                            CourseRunStatus = cr.CourseRunStatus,
-                            CourseName = cr.CourseName,
-                            VenueId = cr.VenueId,
-                            ProviderCourseId = cr.ProviderCourseId,
-                            DeliveryMode = cr.DeliveryMode,
-                            FlexibleStartDate = cr.FlexibleStartDate,
-                            StartDate = cr.StartDate,
-                            CourseWebsite = cr.CourseWebsite,
-                            Cost = cr.Cost,
-                            CostDescription = cr.CostDescription,
-                            DurationUnit = cr.DurationUnit,
-                            DurationValue = cr.DurationValue,
-                            StudyMode = cr.StudyMode != 0 ? cr.StudyMode : null,  // Normalize 0 to null
-                            AttendancePattern = cr.AttendancePattern != 0 ? cr.AttendancePattern : null,  // Normalize 0 to null
-                            National = cr.National,
-                            SubRegionIds = courseRunSubRegions.GetValueOrDefault(cr.CourseRunId, Enumerable.Empty<string>()).ToArray(),
-                            VenueName = cr.VenueName,
-                            ProviderVenueRef = cr.ProviderVenueRef
-                        })
-                        .ToArray()
-                })
-                .ToArray();
-        }
-
-        private class CourseResult
-        {
-            public Guid CourseId { get; set; }
-            public CourseStatus CourseStatus { get; set; }
-            public Guid ProviderId { get; set; }
-            public string LearnAimRef { get; set; }
-            public string CourseDescription { get; set; }
-            public string EntryRequirements { get; set; }
-            public string WhatYoullLearn { get; set; }
-            public string HowYoullLearn { get; set; }
-            public string WhatYoullNeed { get; set; }
-            public string HowYoullBeAssessed { get; set; }
-            public string WhereNext { get; set; }
-        }
-
-        private class CourseRunResult
-        {
-            public Guid CourseId { get; set; }
-            public Guid CourseRunId { get; set; }
-            public CourseStatus CourseRunStatus { get; set; }
-            public string CourseName { get; set; }
-            public Guid? VenueId { get; set; }
-            public string ProviderCourseId { get; set; }
-            public CourseDeliveryMode DeliveryMode { get; set; }
-            public bool FlexibleStartDate { get; set; }
-            public DateTime? StartDate { get; set; }
-            public string CourseWebsite { get; set; }
-            public decimal? Cost { get; set; }
-            public string CostDescription { get; set; }
-            public CourseDurationUnit DurationUnit { get; set; }
-            public int? DurationValue { get; set; }
-            public CourseStudyMode? StudyMode { get; set; }
-            public CourseAttendancePattern? AttendancePattern { get; set; }
-            public bool? National { get; set; }
-            public string VenueName { get; set; }
-            public string ProviderVenueRef { get; set; }
-        }
-
-        private class CourseRunSubRegionResult
-        {
-            public Guid CourseRunId { get; set; }
-            public string RegionId { get; set; }
+            return await CourseMappingHelper.MapCourses(reader);
         }
     }
 }

--- a/src/Dfc.CourseDirectory.Core/DataStore/Sql/QueryHandlers/PublishCourseUploadHandler.cs
+++ b/src/Dfc.CourseDirectory.Core/DataStore/Sql/QueryHandlers/PublishCourseUploadHandler.cs
@@ -89,7 +89,8 @@ INSERT INTO Pttcd.Courses (
     HowYoullLearn,
     WhatYoullNeed,
     HowYoullBeAssessed,
-    WhereNext
+    WhereNext,
+    DataIsHtmlEncoded
 )
 SELECT
     CourseId,
@@ -106,7 +107,8 @@ SELECT
     HowYouWillLearn,
     WhatYouWillNeedToBring,
     HowYouWillBeAssessed,
-    WhereNext
+    WhereNext,
+    0  -- DataIsHtmlEncoded
 FROM CoursesCte
 WHERE GroupRowNumber = 1
 
@@ -131,7 +133,8 @@ INSERT INTO Pttcd.CourseRuns (
     DurationValue,
     StudyMode,
     AttendancePattern,
-    [National]
+    [National],
+    DataIsHtmlEncoded
 )
 SELECT
     CourseRunId,
@@ -154,7 +157,8 @@ SELECT
     ResolvedDuration,
     ResolvedStudyMode,
     ResolvedAttendancePattern,
-    ResolvedNationalDelivery
+    ResolvedNationalDelivery,
+    0  -- DataIsHtmlEncoded
 FROM Pttcd.CourseUploadRows
 WHERE CourseUploadId = @CourseUploadId
 AND CourseUploadRowStatus = {(int)UploadRowStatus.Default}

--- a/src/Dfc.CourseDirectory.Core/DataStore/Sql/QueryHandlers/UpsertCoursesFromCosmosHandler.cs
+++ b/src/Dfc.CourseDirectory.Core/DataStore/Sql/QueryHandlers/UpsertCoursesFromCosmosHandler.cs
@@ -114,7 +114,8 @@ WHEN NOT MATCHED THEN
         WhatYoullNeed,
         HowYoullBeAssessed,
         WhereNext,
-        BulkUploadErrorCount
+        BulkUploadErrorCount,
+        DataIsHtmlEncoded
     ) VALUES (
         source.CourseId,
         source.ProviderId,
@@ -134,7 +135,8 @@ WHEN NOT MATCHED THEN
         source.WhatYoullNeed,
         source.HowYoullBeAssessed,
         source.WhereNext,
-        source.BulkUploadErrorCount
+        source.BulkUploadErrorCount,
+        1
     )
 WHEN MATCHED THEN
     UPDATE SET
@@ -314,7 +316,8 @@ WHEN NOT MATCHED THEN
         StudyMode,
         AttendancePattern,
         [National],
-        BulkUploadErrorCount
+        BulkUploadErrorCount,
+        DataIsHtmlEncoded
     ) VALUES (
         source.CourseRunId,
         source.CourseId,
@@ -337,7 +340,8 @@ WHEN NOT MATCHED THEN
         source.StudyMode,
         source.AttendancePattern,
         source.[National],
-        source.BulkUploadErrorCount
+        source.BulkUploadErrorCount,
+        1
     )
 WHEN MATCHED THEN
     UPDATE SET

--- a/src/Dfc.CourseDirectory.Database/Pttcd/Tables/CourseRuns.sql
+++ b/src/Dfc.CourseDirectory.Database/Pttcd/Tables/CourseRuns.sql
@@ -21,5 +21,6 @@
 	[StudyMode] TINYINT,
 	[AttendancePattern] TINYINT,
 	[National] BIT,
-	[BulkUploadErrorCount] INT
+	[BulkUploadErrorCount] INT,
+	[DataIsHtmlEncoded] BIT NOT NULL CONSTRAINT [DF_CourseRuns_DataIsHtmlEncoded] DEFAULT (1)
 )

--- a/src/Dfc.CourseDirectory.Database/Pttcd/Tables/Courses.sql
+++ b/src/Dfc.CourseDirectory.Database/Pttcd/Tables/Courses.sql
@@ -19,5 +19,6 @@
 	[WhatYoullNeed] NVARCHAR(MAX),
 	[HowYoullBeAssessed] NVARCHAR(MAX),
 	[WhereNext] NVARCHAR(MAX),
-	[BulkUploadErrorCount] INT
+	[BulkUploadErrorCount] INT,
+	[DataIsHtmlEncoded] BIT NOT NULL CONSTRAINT [DF_Courses_DataIsHtmlEncoded] DEFAULT (1)
 )


### PR DESCRIPTION
The legacy UI stores string fields HTML-encoded in Cosmos. As part of the move away from Cosmos we want to move away from encoding data at rest and encoding it 'on the edge' as appropriate. 

This PR adds an additional field to the `Courses` and `CourseRuns` SQL tables indicating whether that row has its strings encoded or not.

All existing data will have the flag set to `1` since it's currently all synced from Cosmos. As we move the UI to using SQL directly we will store things unencoded and the flag will be set to `0`. The new Course Data Management features store fields unencoded also.

The mapping to `Course` and `CourseRun` models is updated here to handle both cases; where the data is encoded and where it's not.