### PR TITLE
HTML encode free text fields on FAC API

### DIFF
--- a/src/Dfc.CourseDirectory.FindACourseApi/Features/CourseRunDetail/CourseRunDetail.cs
+++ b/src/Dfc.CourseDirectory.FindACourseApi/Features/CourseRunDetail/CourseRunDetail.cs
@@ -13,6 +13,7 @@ using Dfc.CourseDirectory.Core.Search;
 using MediatR;
 using OneOf;
 using OneOf.Types;
+using static System.Net.WebUtility;
 
 namespace Dfc.CourseDirectory.FindACourseApi.Features.CourseRunDetail
 {
@@ -94,8 +95,8 @@ namespace Dfc.CourseDirectory.FindACourseApi.Features.CourseRunDetail
                 OfferingType = Core.Search.Models.FindACourseOfferingType.Course,
                 AttendancePattern = courseRun.DeliveryMode == CourseDeliveryMode.ClassroomBased ? (CourseAttendancePattern?)courseRun.AttendancePattern : null,
                 Cost = courseRun.Cost,
-                CostDescription = courseRun.CostDescription,
-                CourseName = courseRun.CourseName,
+                CostDescription = HtmlEncode(courseRun.CostDescription),
+                CourseName = HtmlEncode(courseRun.CourseName),
                 CourseURL = ViewModelFormatting.EnsureHttpPrefixed(courseRun.CourseWebsite),
                 CreatedDate = courseRun.CreatedOn,
                 DeliveryMode = courseRun.DeliveryMode,
@@ -108,28 +109,28 @@ namespace Dfc.CourseDirectory.FindACourseApi.Features.CourseRunDetail
                 Course = new CourseViewModel
                 {
                     AwardOrgCode = qualification.Record.AwardOrgCode,
-                    CourseDescription = course.CourseDescription,
+                    CourseDescription = HtmlEncode(course.CourseDescription),
                     CourseId = course.CourseId,
-                    EntryRequirements = course.EntryRequirements,
-                    HowYoullBeAssessed = course.HowYoullBeAssessed,
-                    HowYoullLearn = course.HowYoullLearn,
+                    EntryRequirements = HtmlEncode(course.EntryRequirements),
+                    HowYoullBeAssessed = HtmlEncode(course.HowYoullBeAssessed),
+                    HowYoullLearn = HtmlEncode(course.HowYoullLearn),
                     LearnAimRef = course.LearnAimRef,
                     QualificationLevel = qualification.Record.NotionalNVQLevelv2,
-                    WhatYoullLearn = course.WhatYoullLearn,
-                    WhatYoullNeed = course.WhatYoullNeed,
-                    WhereNext = course.WhereNext
+                    WhatYoullLearn = HtmlEncode(course.WhatYoullLearn),
+                    WhatYoullNeed = HtmlEncode(course.WhatYoullNeed),
+                    WhereNext = HtmlEncode(course.WhereNext)
                 },
                 Venue = venue != null
                     ? new VenueViewModel
                     {
-                        AddressLine1 = venue.AddressLine1,
-                        AddressLine2 = venue.AddressLine2,
-                        County = venue.County,
+                        AddressLine1 = HtmlEncode(venue.AddressLine1),
+                        AddressLine2 = HtmlEncode(venue.AddressLine2),
+                        County = HtmlEncode(venue.County),
                         Email = venue.Email,
                         Postcode = venue.Postcode,
                         Telephone = venue.Telephone,
-                        Town = venue.Town,
-                        VenueName = venue.VenueName,
+                        Town = HtmlEncode(venue.Town),
+                        VenueName = HtmlEncode(venue.VenueName),
                         Website = ViewModelFormatting.EnsureHttpPrefixed(venue.Website),
                         Latitude = Convert.ToDecimal(venue.Latitude),
                         Longitude = Convert.ToDecimal(venue.Longitude)
@@ -137,16 +138,16 @@ namespace Dfc.CourseDirectory.FindACourseApi.Features.CourseRunDetail
                     : null,
                 Provider = new ProviderViewModel
                 {
-                    ProviderName = sqlProvider.DisplayName,
-                    TradingName = sqlProvider.DisplayName,
-                    CourseDirectoryName = provider.CourseDirectoryName,
-                    Alias = provider.Alias,
+                    ProviderName = HtmlEncode(sqlProvider.DisplayName),
+                    TradingName = HtmlEncode(sqlProvider.DisplayName),
+                    CourseDirectoryName = HtmlEncode(provider.CourseDirectoryName),
+                    Alias = HtmlEncode(provider.Alias),
                     Ukprn = provider.UnitedKingdomProviderReferenceNumber,
-                    AddressLine1 = providerAddressLines.AddressLine1,
-                    AddressLine2 = providerAddressLines.AddressLine2,
-                    Town = providerContact?.ContactAddress?.PostTown ?? providerContact?.ContactAddress?.Items?.FirstOrDefault()?.ToString(),
+                    AddressLine1 = HtmlEncode(providerAddressLines.AddressLine1),
+                    AddressLine2 = HtmlEncode(providerAddressLines.AddressLine2),
+                    Town = HtmlEncode(providerContact?.ContactAddress?.PostTown ?? providerContact?.ContactAddress?.Items?.FirstOrDefault()?.ToString()),
                     Postcode = providerContact?.ContactAddress?.PostCode,
-                    County = providerContact?.ContactAddress?.County ?? providerContact?.ContactAddress?.Locality,
+                    County = HtmlEncode(providerContact?.ContactAddress?.County ?? providerContact?.ContactAddress?.Locality),
                     Telephone = providerContact?.ContactTelephone1,
                     Fax = providerContact?.ContactFax,
                     Website = ViewModelFormatting.EnsureHttpPrefixed(providerContact?.ContactWebsiteAddress),
@@ -157,21 +158,21 @@ namespace Dfc.CourseDirectory.FindACourseApi.Features.CourseRunDetail
                 Qualification = new QualificationViewModel
                 {
                     AwardOrgCode = qualification.Record.AwardOrgCode,
-                    AwardOrgName = qualification.Record.AwardOrgName,
+                    AwardOrgName = HtmlEncode(qualification.Record.AwardOrgName),
                     LearnAimRef = qualification.Record.LearnAimRef,
-                    LearnAimRefTitle = qualification.Record.LearnAimRefTitle,
-                    LearnAimRefTypeDesc = qualification.Record.LearnAimRefTypeDesc,
+                    LearnAimRefTitle = HtmlEncode(qualification.Record.LearnAimRefTitle),
+                    LearnAimRefTypeDesc = HtmlEncode(qualification.Record.LearnAimRefTypeDesc),
                     QualificationLevel = qualification.Record.NotionalNVQLevelv2,
-                    SectorSubjectAreaTier1Desc = qualification.Record.SectorSubjectAreaTier1Desc,
-                    SectorSubjectAreaTier2Desc = qualification.Record.SectorSubjectAreaTier2Desc
+                    SectorSubjectAreaTier1Desc = HtmlEncode(qualification.Record.SectorSubjectAreaTier1Desc),
+                    SectorSubjectAreaTier2Desc = HtmlEncode(qualification.Record.SectorSubjectAreaTier2Desc)
                 },
                 AlternativeCourseRuns = alternativeCourseRuns.Select(c => new AlternativeCourseRunViewModel
                 {
                     CourseRunId = c.CourseRun.CourseRunId,
                     AttendancePattern = c.CourseRun.DeliveryMode == CourseDeliveryMode.ClassroomBased ? (CourseAttendancePattern?)c.CourseRun.AttendancePattern : null,
                     Cost = c.CourseRun.Cost,
-                    CostDescription = c.CourseRun.CostDescription,
-                    CourseName = c.CourseRun.CourseName,
+                    CostDescription = HtmlEncode(c.CourseRun.CostDescription),
+                    CourseName = HtmlEncode(c.CourseRun.CourseName),
                     CourseURL = ViewModelFormatting.EnsureHttpPrefixed(c.CourseRun.CourseWebsite),
                     CreatedDate = c.CourseRun.CreatedOn,
                     DeliveryMode = c.CourseRun.DeliveryMode,
@@ -183,14 +184,14 @@ namespace Dfc.CourseDirectory.FindACourseApi.Features.CourseRunDetail
                     Venue = c.Venue != null
                         ? new VenueViewModel
                         {
-                            AddressLine1 = c.Venue.AddressLine1,
-                            AddressLine2 = c.Venue.AddressLine2,
-                            County = c.Venue.County,
+                            AddressLine1 = HtmlEncode(c.Venue.AddressLine1),
+                            AddressLine2 = HtmlEncode(c.Venue.AddressLine2),
+                            County = HtmlEncode(c.Venue.County),
                             Email = c.Venue.Email,
                             Postcode = c.Venue.Postcode,
                             Telephone = c.Venue.Telephone,
-                            Town = c.Venue.Town,
-                            VenueName = c.Venue.VenueName,
+                            Town = HtmlEncode(c.Venue.Town),
+                            VenueName = HtmlEncode(c.Venue.VenueName),
                             Website = ViewModelFormatting.EnsureHttpPrefixed(c.Venue.Website),
                             Latitude = Convert.ToDecimal(c.Venue.Latitude),
                             Longitude = Convert.ToDecimal(c.Venue.Longitude)

--- a/src/Dfc.CourseDirectory.FindACourseApi/Features/Search/Search.cs
+++ b/src/Dfc.CourseDirectory.FindACourseApi/Features/Search/Search.cs
@@ -14,6 +14,7 @@ using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using OneOf;
 using FindACourseOffering = Dfc.CourseDirectory.Core.Search.Models.FindACourseOffering;
+using static System.Net.WebUtility;
 
 namespace Dfc.CourseDirectory.FindACourseApi.Features.Search
 {
@@ -240,12 +241,12 @@ namespace Dfc.CourseDirectory.FindACourseApi.Features.Search
                         Cost = !string.IsNullOrEmpty(i.Record.Cost) ?
                             Convert.ToInt32(decimal.Parse(i.Record.Cost)) :
                             (int?)null,
-                        CostDescription = i.Record.CostDescription,
-                        CourseDescription = NormalizeCourseDataEncodedString(i.Record.CourseDescription),
-                        CourseName = NormalizeCourseRunDataEncodedString(i.Record.CourseName),
+                        CostDescription = HtmlEncode(i.Record.CostDescription),
+                        CourseDescription = HtmlEncode(NormalizeCourseDataEncodedString(i.Record.CourseDescription)),
+                        CourseName = HtmlEncode(NormalizeCourseRunDataEncodedString(i.Record.CourseName)),
                         CourseId = i.Record.CourseId,
                         CourseRunId = i.Record.CourseRunId,
-                        CourseText = NormalizeCourseDataEncodedString(i.Record.CourseDescription),
+                        CourseText = HtmlEncode(NormalizeCourseDataEncodedString(i.Record.CourseDescription)),
                         DeliveryMode = ((int)i.Record.DeliveryMode).ToString(),
                         DeliveryModeDescription = i.Record.DeliveryMode.ToDescription(),
                         Distance = GetDistanceFromLatLngForResult(i),
@@ -256,16 +257,16 @@ namespace Dfc.CourseDirectory.FindACourseApi.Features.Search
                         National = i.Record.National,
                         QualificationLevel = i.Record.NotionalNVQLevelv2,
                         OfferingType = i.Record.OfferingType,
-                        ProviderName = i.Record.ProviderDisplayName,
-                        QualificationCourseTitle = i.Record.QualificationCourseTitle,
-                        Region = i.Record.RegionName,
+                        ProviderName = HtmlEncode(i.Record.ProviderDisplayName),
+                        QualificationCourseTitle = HtmlEncode(i.Record.QualificationCourseTitle),
+                        Region = HtmlEncode(i.Record.RegionName),
                         SearchScore = i.Score.Value,
                         StartDate = !i.Record.FlexibleStartDate.GetValueOrDefault() ? i.Record.StartDate : null,
                         TLevelId = i.Record.TLevelId,
                         TLevelLocationId = i.Record.TLevelLocationId,
                         Ukprn = i.Record.ProviderUkprn.ToString(),
                         UpdatedOn = i.Record.UpdatedOn,
-                        VenueAddress = i.Record.VenueAddress,
+                        VenueAddress = HtmlEncode(i.Record.VenueAddress),
                         VenueAttendancePattern = ((int?)i.Record.AttendancePattern)?.ToString(),
                         VenueAttendancePatternDescription = i.Record.DeliveryMode == CourseDeliveryMode.ClassroomBased ?
                             i.Record.AttendancePattern?.ToDescription() :
@@ -277,7 +278,7 @@ namespace Dfc.CourseDirectory.FindACourseApi.Features.Search
                                 Longitude = i.Record.Position.Longitude
                             } :
                             null,
-                        VenueName = i.Record.VenueName,
+                        VenueName = HtmlEncode(i.Record.VenueName),
                         VenueStudyMode = ((int?)i.Record.StudyMode)?.ToString(),
                         VenueStudyModeDescription = i.Record.DeliveryMode == CourseDeliveryMode.ClassroomBased ? 
                             i.Record.StudyMode?.ToDescription() :
@@ -289,12 +290,12 @@ namespace Dfc.CourseDirectory.FindACourseApi.Features.Search
 
                     string NormalizeCourseDataEncodedString(string value) =>
                         value != null && i.Record.CourseDataIsHtmlEncoded != false ?
-                        System.Net.WebUtility.HtmlDecode(value) :
+                        HtmlDecode(value) :
                         value;
 
                     string NormalizeCourseRunDataEncodedString(string value) =>
                         value != null && i.Record.CourseRunDataIsHtmlEncoded != false ?
-                        System.Net.WebUtility.HtmlDecode(value) :
+                        HtmlDecode(value) :
                         value;
                 }).ToList()
             };

--- a/src/Dfc.CourseDirectory.FindACourseApi/Features/TLevels/TLevelDetail.cs
+++ b/src/Dfc.CourseDirectory.FindACourseApi/Features/TLevels/TLevelDetail.cs
@@ -9,6 +9,7 @@ using Dfc.CourseDirectory.Core.DataStore.Sql.Queries;
 using MediatR;
 using OneOf;
 using OneOf.Types;
+using static System.Net.WebUtility;
 
 namespace Dfc.CourseDirectory.FindACourseApi.Features.TLevels.TLevelDetail
 {
@@ -53,7 +54,7 @@ namespace Dfc.CourseDirectory.FindACourseApi.Features.TLevels.TLevelDetail
             var venues = await getVenues;
 
             var feChoice = await _cosmosDbQueryDispatcher.ExecuteQuery(
-                new Core.DataStore.CosmosDb.Queries.GetFeChoiceForProvider() { ProviderUkprn = provider.Ukprn });
+                new GetFeChoiceForProvider() { ProviderUkprn = provider.Ukprn });
 
             var providerContact = provider.ProviderContact
                 .SingleOrDefault(c => c.ContactType == "P");
@@ -67,17 +68,17 @@ namespace Dfc.CourseDirectory.FindACourseApi.Features.TLevels.TLevelDetail
                     FrameworkCode = tLevel.TLevelDefinition.FrameworkCode,
                     ProgType = tLevel.TLevelDefinition.ProgType,
                     QualificationLevel = tLevel.TLevelDefinition.QualificationLevel.ToString(),
-                    TLevelName = tLevel.TLevelDefinition.Name
+                    TLevelName = HtmlEncode(tLevel.TLevelDefinition.Name)
                 },
                 Provider = new ProviderViewModel()
                 {
-                    ProviderName = sqlProvider.DisplayName,
+                    ProviderName = HtmlEncode(sqlProvider.DisplayName),
                     Ukprn = provider.UnitedKingdomProviderReferenceNumber,
-                    AddressLine1 = ViewModelFormatting.ConcatAddressLines(providerContact?.ContactAddress?.SAON?.Description, providerContact?.ContactAddress?.PAON?.Description, providerContact?.ContactAddress?.StreetDescription),
-                    AddressLine2 = providerContact?.ContactAddress?.Locality,
-                    Town = providerContact?.ContactAddress?.PostTown ?? providerContact?.ContactAddress?.Items?.ElementAtOrDefault(0),
+                    AddressLine1 = HtmlEncode(ViewModelFormatting.ConcatAddressLines(providerContact?.ContactAddress?.SAON?.Description, providerContact?.ContactAddress?.PAON?.Description, providerContact?.ContactAddress?.StreetDescription)),
+                    AddressLine2 = HtmlEncode(providerContact?.ContactAddress?.Locality),
+                    Town = HtmlEncode(providerContact?.ContactAddress?.PostTown ?? providerContact?.ContactAddress?.Items?.ElementAtOrDefault(0)),
                     Postcode = providerContact?.ContactAddress?.PostCode,
-                    County = providerContact?.ContactAddress?.County ?? providerContact?.ContactAddress?.Items?.ElementAtOrDefault(1),
+                    County = HtmlEncode(providerContact?.ContactAddress?.County ?? providerContact?.ContactAddress?.Items?.ElementAtOrDefault(1)),
                     Email = providerContact?.ContactEmail,
                     Telephone = providerContact?.ContactTelephone1,
                     Fax = providerContact?.ContactFax,
@@ -85,12 +86,12 @@ namespace Dfc.CourseDirectory.FindACourseApi.Features.TLevels.TLevelDetail
                     LearnerSatisfaction = feChoice?.LearnerSatisfaction,
                     EmployerSatisfaction = feChoice?.EmployerSatisfaction
                 },
-                WhoFor = tLevel.WhoFor,
-                EntryRequirements = tLevel.EntryRequirements,
-                WhatYoullLearn = tLevel.WhatYoullLearn,
-                HowYoullLearn = tLevel.HowYoullLearn,
-                HowYoullBeAssessed = tLevel.HowYoullBeAssessed,
-                WhatYouCanDoNext = tLevel.WhatYouCanDoNext,
+                WhoFor = HtmlEncode(tLevel.WhoFor),
+                EntryRequirements = HtmlEncode(tLevel.EntryRequirements),
+                WhatYoullLearn = HtmlEncode(tLevel.WhatYoullLearn),
+                HowYoullLearn = HtmlEncode(tLevel.HowYoullLearn),
+                HowYoullBeAssessed = HtmlEncode(tLevel.HowYoullBeAssessed),
+                WhatYouCanDoNext = HtmlEncode(tLevel.WhatYouCanDoNext),
                 Website = ViewModelFormatting.EnsureHttpPrefixed(tLevel.Website),
                 StartDate = tLevel.StartDate,
                 Locations = tLevel.Locations
@@ -98,11 +99,11 @@ namespace Dfc.CourseDirectory.FindACourseApi.Features.TLevels.TLevelDetail
                     .Select(t => new TLevelLocationViewModel()
                     {
                         TLevelLocationId = t.Location.TLevelLocationId,
-                        VenueName = t.Venue.VenueName,
-                        AddressLine1 = t.Venue.AddressLine1,
-                        AddressLine2 = t.Venue.AddressLine2,
-                        Town = t.Venue.Town,
-                        County = t.Venue.County,
+                        VenueName = HtmlEncode(t.Venue.VenueName),
+                        AddressLine1 = HtmlEncode(t.Venue.AddressLine1),
+                        AddressLine2 = HtmlEncode(t.Venue.AddressLine2),
+                        Town = HtmlEncode(t.Venue.Town),
+                        County = HtmlEncode(t.Venue.County),
                         Postcode = t.Venue.Postcode,
                         Telephone = t.Venue.Telephone,
                         Email = t.Venue.Email,

--- a/tests/Dfc.CourseDirectory.FindACourseApi.Tests/FeatureTests/TLevelDetailTests.cs
+++ b/tests/Dfc.CourseDirectory.FindACourseApi.Tests/FeatureTests/TLevelDetailTests.cs
@@ -11,6 +11,7 @@ using FluentAssertions.Execution;
 using Moq;
 using Newtonsoft.Json.Linq;
 using Xunit;
+using static System.Net.WebUtility;
 
 namespace Dfc.CourseDirectory.FindACourseApi.Tests.FeatureTests
 {
@@ -197,18 +198,18 @@ namespace Dfc.CourseDirectory.FindACourseApi.Tests.FeatureTests
                 json["qualification"]["frameworkCode"].ToObject<int>().Should().Be(tLevelDefinitionFrameworkCode);
                 json["qualification"]["progType"].ToObject<int>().Should().Be(tLevelDefinitionProgType);
                 json["qualification"]["qualificationLevel"].ToObject<string>().Should().Be(tLevelDefinitionQualificationLevel.ToString());
-                json["qualification"]["tLevelName"].ToObject<string>().Should().Be(tLevelDefinitionName);
-                json["provider"]["providerName"].ToObject<string>().Should().Be(providerName);
+                json["qualification"]["tLevelName"].ToObject<string>().Should().Be(HtmlEncode(tLevelDefinitionName));
+                json["provider"]["providerName"].ToObject<string>().Should().Be(HtmlEncode(providerName));
                 json["provider"]["ukprn"].ToObject<int>().Should().Be(providerUkprn);
                 json["provider"]["email"].ToObject<string>().Should().Be(providerContactEmail);
                 json["provider"]["employerSatisfaction"].ToObject<decimal?>().Should().Be(providerEmployerSatisfaction);
                 json["provider"]["learnerSatisfaction"].ToObject<decimal?>().Should().Be(providerLearnerSatisfaction);
-                json["whoFor"].ToObject<string>().Should().Be(whoFor);
-                json["entryRequirements"].ToObject<string>().Should().Be(entryRequirements);
-                json["whatYoullLearn"].ToObject<string>().Should().Be(whatYoullLearn);
-                json["howYoullLearn"].ToObject<string>().Should().Be(howYoullLearn);
-                json["howYoullBeAssessed"].ToObject<string>().Should().Be(howYoullBeAssessed);
-                json["whatYouCanDoNext"].ToObject<string>().Should().Be(whatYouCanDoNext);
+                json["whoFor"].ToObject<string>().Should().Be(HtmlEncode(whoFor));
+                json["entryRequirements"].ToObject<string>().Should().Be(HtmlEncode(entryRequirements));
+                json["whatYoullLearn"].ToObject<string>().Should().Be(HtmlEncode(whatYoullLearn));
+                json["howYoullLearn"].ToObject<string>().Should().Be(HtmlEncode(howYoullLearn));
+                json["howYoullBeAssessed"].ToObject<string>().Should().Be(HtmlEncode(howYoullBeAssessed));
+                json["whatYouCanDoNext"].ToObject<string>().Should().Be(HtmlEncode(whatYouCanDoNext));
                 json["website"].ToObject<string>().Should().Be(website);
                 json["startDate"].ToObject<DateTime>().Should().Be(startDate);
                 json["deliveryMode"].ToObject<string>().Should().Be("ClassroomBased");
@@ -221,11 +222,11 @@ namespace Dfc.CourseDirectory.FindACourseApi.Tests.FeatureTests
 
                 var location = json["locations"].ToArray().Should().ContainSingle().Subject;
                 location["tLevelLocationId"].ToObject<string>().Should().Be(tLevelLocationId.ToString());
-                location["venueName"].ToObject<string>().Should().Be(venueName);
-                location["addressLine1"].ToObject<string>().Should().Be(venueAddressLine1);
-                location["addressLine2"].ToObject<string>().Should().Be(venueAddressLine2);
-                location["town"].ToObject<string>().Should().Be(venueTown);
-                location["county"].ToObject<string>().Should().Be(venueCounty);
+                location["venueName"].ToObject<string>().Should().Be(HtmlEncode(venueName));
+                location["addressLine1"].ToObject<string>().Should().Be(HtmlEncode(venueAddressLine1));
+                location["addressLine2"].ToObject<string>().Should().Be(HtmlEncode(venueAddressLine2));
+                location["town"].ToObject<string>().Should().Be(HtmlEncode(venueTown));
+                location["county"].ToObject<string>().Should().Be(HtmlEncode(venueCounty));
                 location["postcode"].ToObject<string>().Should().Be(venuePostcode);
                 location["telephone"].ToObject<string>().Should().Be(venueTelephone);
                 location["email"].ToObject<string>().Should().Be(venueEmail);


### PR DESCRIPTION
The front-end is expecting these fields to be HTML encoded. Originally
they were encoded before entry into Cosmos but now we're moving away
from that we need to encode 'on the edge'.