### PR TITLE
Exclude just-created courses from FAC index update job

### DIFF
--- a/src/Dfc.CourseDirectory.Core/DataStore/Sql/Queries/UpdateFindACourseIndexFromMissingCourses.cs
+++ b/src/Dfc.CourseDirectory.Core/DataStore/Sql/Queries/UpdateFindACourseIndexFromMissingCourses.cs
@@ -5,6 +5,7 @@ namespace Dfc.CourseDirectory.Core.DataStore.Sql.Queries
     public class UpdateFindACourseIndexFromMissingCourses : ISqlQuery<int>
     {
         public int MaxCourseRunCount { get; set; }
+        public DateTime CreatedBefore { get; set; }
         public DateTime Now { get; set; }
     }
 }

--- a/src/Dfc.CourseDirectory.Core/DataStore/Sql/QueryHandlers/UpdateFindACourseIndexFromMissingCoursesHandler.cs
+++ b/src/Dfc.CourseDirectory.Core/DataStore/Sql/QueryHandlers/UpdateFindACourseIndexFromMissingCoursesHandler.cs
@@ -18,13 +18,14 @@ SELECT TOP {query.MaxCourseRunCount} cr.CourseRunId FROM Pttcd.CourseRuns cr
 LEFT JOIN Pttcd.FindACourseIndex i ON cr.CourseRunId = i.CourseRunId
 WHERE cr.CourseRunStatus = {(int)CourseStatus.Live}
 AND i.CourseRunId IS NULL
+AND cr.CreatedOn < @CreatedBefore
 
 EXEC Pttcd.RefreshFindACourseIndex @CourseRunIds, @Now
 
 SELECT COUNT(*) FROM @CourseRunIds
 ";
 
-            return transaction.Connection.QuerySingleAsync<int>(sql, new { query.Now }, transaction: transaction);
+            return transaction.Connection.QuerySingleAsync<int>(sql, new { query.Now, query.CreatedBefore }, transaction: transaction);
         }
     }
 }

--- a/src/Dfc.CourseDirectory.Functions/RefreshFindACourseIndex.cs
+++ b/src/Dfc.CourseDirectory.Functions/RefreshFindACourseIndex.cs
@@ -26,6 +26,9 @@ namespace Dfc.CourseDirectory.Functions
 
             const int batchSize = 100;
 
+            // Exclude course runs that have only just been created so we don't race with the background worker
+            var createdBefore = _clock.UtcNow.AddHours(-1);
+
             int updated;
 
             do
@@ -35,6 +38,7 @@ namespace Dfc.CourseDirectory.Functions
                 updated = await dispatcher.ExecuteQuery(new UpdateFindACourseIndexFromMissingCourses()
                 {
                     MaxCourseRunCount = batchSize,
+                    CreatedBefore = createdBefore,
                     Now = _clock.UtcNow
                 });
 


### PR DESCRIPTION
We're seeing duplicate key exceptions from this job that I think are due
to this process racing with the background task that's indexing
just-published courses. Exclude courses that have been created in the
past hour to allow time for the background task to complete.