### PR TITLE
SDD-990 - Stop Rendering apprenticeship data management card

### DIFF
--- a/src/Dfc.CourseDirectory.WebV2/Features/DataManagement/Venues/Dashboard.cs
+++ b/src/Dfc.CourseDirectory.WebV2/Features/DataManagement/Venues/Dashboard.cs
@@ -53,6 +53,12 @@ namespace Dfc.CourseDirectory.WebV2.Features.DataManagement.Venues.Dashboard
                 Date = _clock.UtcNow.Date
             });
 
+            var qaStatus = await _sqlQueryDispatcher.ExecuteQuery(
+                new GetProviderApprenticeshipQAStatus()
+                {
+                    ProviderId = providerContext.ProviderInfo.ProviderId,
+                });
+
             var providerType = providerContext.ProviderInfo.ProviderType;
 
             var venueUploadStatus = await _sqlQueryDispatcher.ExecuteQuery(
@@ -78,7 +84,7 @@ namespace Dfc.CourseDirectory.WebV2.Features.DataManagement.Venues.Dashboard
                 PublishedApprenticeshipsCount = counts.ApprenticeshipCounts.GetValueOrDefault(ApprenticeshipStatus.Live, 0),
                 PublishedCourseCount = counts.CourseRunCounts.GetValueOrDefault(CourseStatus.Live, 0),
                 PublishedVenueCount = counts.VenueCount,
-                ShowApprenticeships = providerType.HasFlag(ProviderType.Apprenticeships),
+                ShowApprenticeships = providerType.HasFlag(ProviderType.Apprenticeships) && qaStatus == ApprenticeshipQAStatus.Passed,
                 ShowCourses = providerType.HasFlag(ProviderType.FE),
                 VenueUploadInProgress = venueUploadStatus != null && (venueUploadStatus.UploadStatus == UploadStatus.Processing || venueUploadStatus.UploadStatus == UploadStatus.Created),
                 UnpublishedVenueCount = counts.UnpublishedVenueCount,

--- a/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/DataManagement/DashboardTests.cs
+++ b/tests/Dfc.CourseDirectory.WebV2.Tests/FeatureTests/DataManagement/DashboardTests.cs
@@ -314,5 +314,35 @@ namespace Dfc.CourseDirectory.WebV2.Tests.FeatureTests.DataManagement
                 doc.GetElementByTestId("apprenticeship-in-progress-link").TextContent.Should().Be("Upload in progress");
             }
         }
+
+        [Fact]
+        public async Task Get_ApprenticeshipQAInProcess_DoesNotRenderApprenticeshipCard()
+        {
+            // Arrange
+            var provider = await TestData.CreateProvider(
+                apprenticeshipQAStatus: ApprenticeshipQAStatus.InProgress,
+                providerType: ProviderType.Apprenticeships);
+
+            //Create some venue upload rows to test new data in UI
+            var (apprenticeshipUpload, _) = await TestData.CreateApprenticeshipUpload(providerId: provider.ProviderId, createdBy: User.ToUserInfo(), uploadStatus: UploadStatus.Processing,
+                rowBuilder =>
+                {
+                    rowBuilder.AddValidRow();
+                });
+
+            var request = new HttpRequestMessage(HttpMethod.Get, $"/data-upload?providerId={provider.ProviderId}");
+
+            // Act
+            var response = await HttpClient.SendAsync(request);
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+            var doc = await response.GetDocument();
+            using (new AssertionScope())
+            {
+                doc.GetElementByTestId("ApprenticeshipsCard").Should().BeNull();
+            }
+        }
     }
 }


### PR DESCRIPTION
- Updated data management dashboard to stop rendering apprenticeships card until QA passed. Like provider dashboard does.
- Added unit test.