### PR TITLE
SDD-1063 - Refactor Muliple Standard code validation for apprenticeships

### DIFF
--- a/src/Dfc.CourseDirectory.Core/DataManagement/FileUploadProcessor.Apprenticeships.cs
+++ b/src/Dfc.CourseDirectory.Core/DataManagement/FileUploadProcessor.Apprenticeships.cs
@@ -656,7 +656,7 @@ namespace Dfc.CourseDirectory.Core.DataManagement
                 Guid? matchedVenueId,
                 IList<ParsedCsvApprenticeshipRow> allRows)
             {
-                RuleFor(c => c.StandardCode).Transform(x => int.TryParse(x, out int standardCode) ? (int?)standardCode : null).StandardCode(allRows, x=>x.DeliveryMethod);
+                RuleFor(c => c.StandardCode).Transform(x => int.TryParse(x, out int standardCode) ? (int?)standardCode : null).StandardCode(allRows, x=>x.ResolvedDeliveryMethod);
                 RuleFor(c => c.StandardVersion).Transform(x => int.TryParse(x, out int standardVersion) ? (int?)standardVersion : null).StandardVersion();
                 RuleFor(c => c.ApprenticeshipInformation).MarketingInformation();
                 RuleFor(c => c.ApprenticeshipWebpage).Website();

--- a/src/Dfc.CourseDirectory.Core/Validation/ApprenticeshipValidation/RuleBuilderExtensions.cs
+++ b/src/Dfc.CourseDirectory.Core/Validation/ApprenticeshipValidation/RuleBuilderExtensions.cs
@@ -44,7 +44,7 @@ namespace Dfc.CourseDirectory.Core.Validation.ApprenticeshipValidation
                 .Apply(Rules.Website)
                     .WithMessageFromErrorCode("APPRENTICESHIP_WEBSITE_FORMAT");
 
-        public static void StandardCode<T>(this IRuleBuilderInitial<T, int?> field, IList<ParsedCsvApprenticeshipRow> allRows, Func<T, string> getDeliveryMethod) =>
+        public static void StandardCode<T>(this IRuleBuilderInitial<T, int?> field, IList<ParsedCsvApprenticeshipRow> allRows, Func<T, ApprenticeshipLocationType?> getDeliveryMethod) =>
             field
             .NotNull()
             .WithMessageFromErrorCode("APPRENTICESHIP_STANDARD_CODE_REQUIRED")
@@ -52,7 +52,7 @@ namespace Dfc.CourseDirectory.Core.Validation.ApprenticeshipValidation
              {
                  var obj = (T)ctx.InstanceToValidate;
                  var deliveryMethod = getDeliveryMethod(obj);
-                 var count = allRows.Count(c => c.StandardCode == v?.ToString() && c.DeliveryMethod == deliveryMethod);
+                 var count = allRows.Count(c => c.StandardCode == v?.ToString() && c.ResolvedDeliveryMethod == deliveryMethod && (deliveryMethod == ApprenticeshipLocationType.EmployerBased || deliveryMethod == ApprenticeshipLocationType.ClassroomBasedAndEmployerBased));
                  if (count > 1)
                  {
                      ctx.AddFailure(CreateFailure("APPRENTICESHIP_DUPLICATE_STANDARDCODE"));

--- a/tests/Dfc.CourseDirectory.Core.Tests/DataManagementTests/ApprenticeshipUploadRowValidatorTests.cs
+++ b/tests/Dfc.CourseDirectory.Core.Tests/DataManagementTests/ApprenticeshipUploadRowValidatorTests.cs
@@ -661,7 +661,7 @@ namespace Dfc.CourseDirectory.Core.Tests.DataManagementTests
             var validator = new ApprenticeshipUploadRowValidator(Clock, matchedVenueId: null, new List<ParsedCsvApprenticeshipRow>() { parsedRow1, parsedRow2 });
 
             // Act
-            var validationResult1 = validator.Validate(ParsedCsvApprenticeshipRow.FromCsvApprenticeshipRow(row2, allRegions));
+            var validationResult1 = validator.Validate(ParsedCsvApprenticeshipRow.FromCsvApprenticeshipRow(row1, allRegions));
             var validationResult2 = validator.Validate(ParsedCsvApprenticeshipRow.FromCsvApprenticeshipRow(row2, allRegions));
 
             // Assert
@@ -670,6 +670,176 @@ namespace Dfc.CourseDirectory.Core.Tests.DataManagementTests
                 error => error.ErrorCode == "APPRENTICESHIP_DUPLICATE_STANDARDCODE");
             Assert.DoesNotContain(
                 validationResult2.Errors,
+                error => error.ErrorCode == "APPRENTICESHIP_DUPLICATE_STANDARDCODE");
+        }
+
+        [Fact]
+        public async Task ApprenticeshipEmployerAndTwoClassroomWithDuplicateStandardCode_DoesNotReturnsValidationError()
+        {
+            // Arrange
+            var provider = await TestData.CreateProvider(providerType: Models.ProviderType.Apprenticeships);
+            var user = await TestData.CreateUser();
+            var venue = await TestData.CreateVenue(
+                providerId: provider.ProviderId,
+                createdBy: user,
+                venueName: "My Venue",
+                providerVenueRef: "VENUE1");
+            var allRegions = await new RegionCache(SqlQueryDispatcherFactory).GetAllRegions();
+
+            var row1 = new CsvApprenticeshipRow()
+            {
+                StandardCode = "1",
+                StandardVersion = "1",
+                ApprenticeshipInformation = "Some info",
+                ApprenticeshipWebpage = "https://someapprenticeship.com",
+                DeliveryModes = "day release",
+                DeliveryMethod = "classroom based",
+                ContactEmail = "someemail@invalid.com",
+                ContactPhone = "0121 111 1111",
+                ContactUrl = "https://someapprenticeship.com",
+                YourVenueReference = "VENUE2"
+            };
+
+            var row2 = new CsvApprenticeshipRow()
+            {
+                StandardCode = "1",
+                StandardVersion = "1",
+                ApprenticeshipInformation = "Some info",
+                ApprenticeshipWebpage = "https://someapprenticeship.com",
+                DeliveryMethod = "employer based",
+                ContactEmail = "someemail@invalid.com",
+                ContactPhone = "0121 111 1111",
+                ContactUrl = "https://someapprenticeship.com",
+                YourVenueReference = "VENUE2"
+            };
+
+            var row3 = new CsvApprenticeshipRow()
+            {
+                StandardCode = "1",
+                StandardVersion = "1",
+                ApprenticeshipInformation = "Some info",
+                ApprenticeshipWebpage = "https://someapprenticeship.com",
+                DeliveryModes = "day release",
+                DeliveryMethod = "classroom based",
+                ContactEmail = "someemail@invalid.com",
+                ContactPhone = "0121 111 1111",
+                ContactUrl = "https://someapprenticeship.com",
+                YourVenueReference = "VENUE2"
+            };
+
+            var parsedRow1 = ParsedCsvApprenticeshipRow.FromCsvApprenticeshipRow(row1, allRegions);
+            var parsedRow2 = ParsedCsvApprenticeshipRow.FromCsvApprenticeshipRow(row2, allRegions);
+            var parsedRow3 = ParsedCsvApprenticeshipRow.FromCsvApprenticeshipRow(row3, allRegions);
+            var validator = new ApprenticeshipUploadRowValidator(Clock, matchedVenueId: null, new List<ParsedCsvApprenticeshipRow>() { parsedRow1, parsedRow2, parsedRow3 });
+
+            // Act
+            var validationResult1 = validator.Validate(ParsedCsvApprenticeshipRow.FromCsvApprenticeshipRow(row1, allRegions));
+            var validationResult2 = validator.Validate(ParsedCsvApprenticeshipRow.FromCsvApprenticeshipRow(row2, allRegions));
+            var validationResult3 = validator.Validate(ParsedCsvApprenticeshipRow.FromCsvApprenticeshipRow(row3, allRegions));
+
+            // Assert
+            Assert.DoesNotContain(
+                validationResult1.Errors,
+                error => error.ErrorCode == "APPRENTICESHIP_DUPLICATE_STANDARDCODE");
+            Assert.DoesNotContain(
+                validationResult2.Errors,
+                error => error.ErrorCode == "APPRENTICESHIP_DUPLICATE_STANDARDCODE");
+            Assert.DoesNotContain(
+                validationResult3.Errors,
+                error => error.ErrorCode == "APPRENTICESHIP_DUPLICATE_STANDARDCODE");
+        }
+
+        [Fact]
+        public async Task ApprenticeshipMultipleEmployerAndMultipleClassroomWithDuplicateStandardCode_DoesNotReturnsValidationError()
+        {
+            // Arrange
+            var provider = await TestData.CreateProvider(providerType: Models.ProviderType.Apprenticeships);
+            var user = await TestData.CreateUser();
+            var venue = await TestData.CreateVenue(
+                providerId: provider.ProviderId,
+                createdBy: user,
+                venueName: "My Venue",
+                providerVenueRef: "VENUE1");
+            var allRegions = await new RegionCache(SqlQueryDispatcherFactory).GetAllRegions();
+
+            var row1 = new CsvApprenticeshipRow()
+            {
+                StandardCode = "1",
+                StandardVersion = "1",
+                ApprenticeshipInformation = "Some info",
+                ApprenticeshipWebpage = "https://someapprenticeship.com",
+                DeliveryModes = "day release",
+                DeliveryMethod = "classroom based",
+                ContactEmail = "someemail@invalid.com",
+                ContactPhone = "0121 111 1111",
+                ContactUrl = "https://someapprenticeship.com",
+                YourVenueReference = "VENUE2"
+            };
+
+            var row2 = new CsvApprenticeshipRow()
+            {
+                StandardCode = "1",
+                StandardVersion = "1",
+                ApprenticeshipInformation = "Some info",
+                ApprenticeshipWebpage = "https://someapprenticeship.com",
+                DeliveryMethod = "employer based",
+                ContactEmail = "someemail@invalid.com",
+                ContactPhone = "0121 111 1111",
+                ContactUrl = "https://someapprenticeship.com",
+                YourVenueReference = "VENUE2"
+            };
+
+            var row3 = new CsvApprenticeshipRow()
+            {
+                StandardCode = "1",
+                StandardVersion = "1",
+                ApprenticeshipInformation = "Some info",
+                ApprenticeshipWebpage = "https://someapprenticeship.com",
+                DeliveryModes = "day release",
+                DeliveryMethod = "classroom based",
+                ContactEmail = "someemail@invalid.com",
+                ContactPhone = "0121 111 1111",
+                ContactUrl = "https://someapprenticeship.com",
+                YourVenueReference = "VENUE2"
+            };
+
+            var row4 = new CsvApprenticeshipRow()
+            {
+                StandardCode = "1",
+                StandardVersion = "1",
+                ApprenticeshipInformation = "Some info",
+                ApprenticeshipWebpage = "https://someapprenticeship.com",
+                DeliveryMethod = "employer based",
+                ContactEmail = "someemail@invalid.com",
+                ContactPhone = "0121 111 1111",
+                ContactUrl = "https://someapprenticeship.com",
+                YourVenueReference = "VENUE2"
+            };
+
+            var parsedRow1 = ParsedCsvApprenticeshipRow.FromCsvApprenticeshipRow(row1, allRegions);
+            var parsedRow2 = ParsedCsvApprenticeshipRow.FromCsvApprenticeshipRow(row2, allRegions);
+            var parsedRow3 = ParsedCsvApprenticeshipRow.FromCsvApprenticeshipRow(row3, allRegions);
+            var parsedRow4 = ParsedCsvApprenticeshipRow.FromCsvApprenticeshipRow(row4, allRegions);
+            var validator = new ApprenticeshipUploadRowValidator(Clock, matchedVenueId: null, new List<ParsedCsvApprenticeshipRow>() { parsedRow1, parsedRow2, parsedRow3, parsedRow4 });
+
+            // Act
+            var validationResult1 = validator.Validate(ParsedCsvApprenticeshipRow.FromCsvApprenticeshipRow(row1, allRegions));
+            var validationResult2 = validator.Validate(ParsedCsvApprenticeshipRow.FromCsvApprenticeshipRow(row2, allRegions));
+            var validationResult3 = validator.Validate(ParsedCsvApprenticeshipRow.FromCsvApprenticeshipRow(row3, allRegions));
+            var validationResult4 = validator.Validate(ParsedCsvApprenticeshipRow.FromCsvApprenticeshipRow(row4, allRegions));
+
+            // Assert
+            Assert.DoesNotContain(
+                validationResult1.Errors,
+                error => error.ErrorCode == "APPRENTICESHIP_DUPLICATE_STANDARDCODE");
+            Assert.Contains(
+                validationResult2.Errors,
+                error => error.ErrorCode == "APPRENTICESHIP_DUPLICATE_STANDARDCODE");
+            Assert.DoesNotContain(
+                validationResult3.Errors,
+                error => error.ErrorCode == "APPRENTICESHIP_DUPLICATE_STANDARDCODE");
+            Assert.Contains(
+                validationResult4.Errors,
                 error => error.ErrorCode == "APPRENTICESHIP_DUPLICATE_STANDARDCODE");
         }
 


### PR DESCRIPTION
Refactor of standardcode validation rule, so that it allows an apprenticeship classroom/employer to share a standard code. 

# Rules are now :
- 2 Employer, 2 classroom with same standardcode will error on both employer apprenticeships but not classroom.
- 2 Employer with same standard will error against both employer apprenticeships
- 1 Employer, 1 Classroom with same standardcode will not error
- 1 Employer, 2 classroom with same standardcode will not error