### PR TITLE
SDD-857 - Validation fixes for national or radius

### DIFF
--- a/src/Dfc.CourseDirectory.Core/Content.Designer.cs
+++ b/src/Dfc.CourseDirectory.Core/Content.Designer.cs
@@ -151,6 +151,15 @@ namespace Dfc.CourseDirectory.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Enter national or a radius.
+        /// </summary>
+        public static string ERROR_APPRENTICESHIP_NATIONALDELIVERY_REQUIRED {
+            get {
+                return ResourceManager.GetString("ERROR_APPRENTICESHIP_NATIONALDELIVERY_REQUIRED", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Enter a Venue reference.
         /// </summary>
         public static string ERROR_APPRENTICESHIP_PROVIDER_VENUE_REF_INVALID {
@@ -187,7 +196,7 @@ namespace Dfc.CourseDirectory.Core {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Enter a Radius.
+        ///   Looks up a localized string similar to Enter national or a radius.
         /// </summary>
         public static string ERROR_APPRENTICESHIP_RADIUS_REQUIRED {
             get {

--- a/src/Dfc.CourseDirectory.Core/Content.resx
+++ b/src/Dfc.CourseDirectory.Core/Content.resx
@@ -147,6 +147,9 @@
   <data name="ERROR_APPRENTICESHIP_NATIONALDELIVERY_NOT_ALLOWED" xml:space="preserve">
     <value>You must remove National Delivery</value>
   </data>
+  <data name="ERROR_APPRENTICESHIP_NATIONALDELIVERY_REQUIRED" xml:space="preserve">
+    <value>Enter national or a radius</value>
+  </data>
   <data name="ERROR_APPRENTICESHIP_PROVIDER_VENUE_REF_INVALID" xml:space="preserve">
     <value>Enter a Venue reference</value>
   </data>
@@ -160,7 +163,7 @@
     <value>You must remove Radius</value>
   </data>
   <data name="ERROR_APPRENTICESHIP_RADIUS_REQUIRED" xml:space="preserve">
-    <value>Enter a Radius</value>
+    <value>Enter national or a radius</value>
   </data>
   <data name="ERROR_APPRENTICESHIP_STANDARD_CODE_REQUIRED" xml:space="preserve">
     <value>Enter standard code</value>

--- a/src/Dfc.CourseDirectory.Core/DataManagement/Errors.cs
+++ b/src/Dfc.CourseDirectory.Core/DataManagement/Errors.cs
@@ -64,6 +64,7 @@ namespace Dfc.CourseDirectory.Core.DataManagement
                 case "APPRENTICESHIP_INFORMATION_MAXLENGTH":
                 case "APPRENTICESHIP_INFORMATION_REQUIRED":
                     return "Apprenticeship information";
+                case "APPRENTICESHIP_NATIONALDELIVERY_REQUIRED":
                 case "APPRENTICESHIP_NATIONALDELIVERY_NOT_ALLOWED":
                     return "National delivery";
                 case "APPRENTICESHIP_RADIUS_INVALID":

--- a/src/Dfc.CourseDirectory.Core/DataManagement/FileUploadProcessor.Apprenticeships.cs
+++ b/src/Dfc.CourseDirectory.Core/DataManagement/FileUploadProcessor.Apprenticeships.cs
@@ -656,7 +656,7 @@ namespace Dfc.CourseDirectory.Core.DataManagement
                 Guid? matchedVenueId,
                 IList<ParsedCsvApprenticeshipRow> allRows)
             {
-                RuleFor(c => c.StandardCode).Transform(x => int.TryParse(x, out int standardCode) ? (int?)standardCode : null).StandardCode(allRows, x=>x.ResolvedDeliveryMethod);
+                RuleFor(c => c.StandardCode).Transform(x => int.TryParse(x, out int standardCode) ? (int?)standardCode : null).StandardCode(allRows, x => x.ResolvedDeliveryMethod);
                 RuleFor(c => c.StandardVersion).Transform(x => int.TryParse(x, out int standardVersion) ? (int?)standardVersion : null).StandardVersion();
                 RuleFor(c => c.ApprenticeshipInformation).MarketingInformation();
                 RuleFor(c => c.ApprenticeshipWebpage).Website();
@@ -666,9 +666,9 @@ namespace Dfc.CourseDirectory.Core.DataManagement
                 RuleFor(c => c.ResolvedDeliveryModes).DeliveryMode(c => c.ResolvedDeliveryMethod);
                 RuleFor(c => c.ResolvedDeliveryMethod).DeliveryMethod();
                 RuleFor(c => c.YourVenueReference).YourVenueReference(c => c.ResolvedDeliveryMethod, c => c.VenueName, matchedVenueId);
-                RuleFor(c => c.ResolvedRadius).Radius(c => c.ResolvedDeliveryMethod);
+                RuleFor(c => c.ResolvedRadius).Radius(c => c.ResolvedDeliveryMethod, r => r.ResolvedNationalDelivery);
                 RuleFor(c => c.ResolvedNationalDelivery).NationalDelivery(
-                    c => c.ResolvedDeliveryMethod);
+                    c => c.ResolvedDeliveryMethod, r => r.ResolvedRadius);
                 RuleFor(c => c.ResolvedSubRegions).SubRegions(
                     subRegionsWereSpecified: c => !string.IsNullOrEmpty(c.SubRegion),
                     c => c.ResolvedDeliveryMethod,

--- a/src/Dfc.CourseDirectory.Core/DataManagement/Schemas/CsvApprenticeshipRowWithErrors.cs
+++ b/src/Dfc.CourseDirectory.Core/DataManagement/Schemas/CsvApprenticeshipRowWithErrors.cs
@@ -29,7 +29,7 @@ namespace Dfc.CourseDirectory.Core.DataManagement.Schemas
             SubRegion = row.SubRegions,
             Errors = string.Join(
                 "\n",
-                row.Errors.Select(errorCode => ErrorRegistry.All[errorCode].GetMessage()))
+                row.Errors.Select(errorCode => ErrorRegistry.All[errorCode].GetMessage()).Distinct())
         };
     }
 }

--- a/src/Dfc.CourseDirectory.Core/Validation/ApprenticeshipValidation/RuleBuilderExtensions.cs
+++ b/src/Dfc.CourseDirectory.Core/Validation/ApprenticeshipValidation/RuleBuilderExtensions.cs
@@ -157,7 +157,7 @@ namespace Dfc.CourseDirectory.Core.Validation.ApprenticeshipValidation
                          if (deliveryMethod == ApprenticeshipLocationType.ClassroomBasedAndEmployerBased)
                          {
                              //both
-                             if ((v.HasValue && nationalDelivery.HasValue || !v.HasValue && !nationalDelivery.HasValue))
+                             if ((v.HasValue && nationalDelivery == true || !v.HasValue && !nationalDelivery.HasValue))
                                  ctx.AddFailure(CreateFailure("APPRENTICESHIP_RADIUS_REQUIRED"));
                          }
                          else
@@ -226,7 +226,7 @@ namespace Dfc.CourseDirectory.Core.Validation.ApprenticeshipValidation
                      var radius = getRadius(obj);
 
                      if ((deliveryMethod == ApprenticeshipLocationType.ClassroomBasedAndEmployerBased && !radius.HasValue && !v.HasValue) ||
-                          (deliveryMethod == ApprenticeshipLocationType.ClassroomBasedAndEmployerBased && radius.HasValue && v.HasValue))
+                          (deliveryMethod == ApprenticeshipLocationType.ClassroomBasedAndEmployerBased && radius.HasValue && v == true))
                      {
                          ctx.AddFailure(CreateFailure("APPRENTICESHIP_NATIONALDELIVERY_REQUIRED"));
                          return;

--- a/src/Dfc.CourseDirectory.Core/Validation/ErrorRegistry.cs
+++ b/src/Dfc.CourseDirectory.Core/Validation/ErrorRegistry.cs
@@ -105,7 +105,8 @@ namespace Dfc.CourseDirectory.Core.Validation
             new Error("APPRENTICESHIP_TELEPHONE_FORMAT"),
             new Error("APPRENTICESHIP_INFORMATION_MAXLENGTH", ApprenticeshipConstants.MarketingInformationStrippedMaxLength),
             new Error("APPRENTICESHIP_RADIUS_INVALID", ApprenticeshipConstants.RadiusRangeMin,ApprenticeshipConstants.RadiusRangeMax),
-            new Error("APPRENTICESHIP_DUPLICATE_STANDARDCODE")
+            new Error("APPRENTICESHIP_DUPLICATE_STANDARDCODE"),
+            new Error("APPRENTICESHIP_NATIONALDELIVERY_REQUIRED")
 
         }.ToDictionary(e => e.ErrorCode, e => e);
     }

--- a/tests/Dfc.CourseDirectory.Core.Tests/DataManagementTests/ApprenticeshipUploadRowValidatorTests.cs
+++ b/tests/Dfc.CourseDirectory.Core.Tests/DataManagementTests/ApprenticeshipUploadRowValidatorTests.cs
@@ -561,6 +561,50 @@ namespace Dfc.CourseDirectory.Core.Tests.DataManagementTests
 
         #region both tests
         [Fact]
+        public async Task ApprenticeshipClassroomAndEmployerSetsRadiusAndNationalFalse_DoesNotReturnValidationError()
+        {
+            // Arrange
+            var provider = await TestData.CreateProvider(providerType: Models.ProviderType.Apprenticeships);
+            var user = await TestData.CreateUser();
+            var venue = await TestData.CreateVenue(
+                providerId: provider.ProviderId,
+                createdBy: user,
+                venueName: "My Venue",
+                providerVenueRef: "VENUE1");
+            var allRegions = await new RegionCache(SqlQueryDispatcherFactory).GetAllRegions();
+
+            var row1 = new CsvApprenticeshipRow()
+            {
+                StandardCode = "1",
+                StandardVersion = "1",
+                ApprenticeshipInformation = "Some info",
+                ApprenticeshipWebpage = "https://someapprenticeship.com",
+                DeliveryMethod = "Classroom based",
+                DeliveryModes = "Employer Address;Day Release",
+                ContactEmail = "someemail@invalid.com",
+                ContactPhone = "0121 111 1111",
+                ContactUrl = "https://someapprenticeship.com",
+                YourVenueReference = "VENUE2",
+                Radius = "100",
+                NationalDelivery = "false"
+            };
+
+            var parsedRow1 = ParsedCsvApprenticeshipRow.FromCsvApprenticeshipRow(row1, allRegions);
+            var validator = new ApprenticeshipUploadRowValidator(Clock, matchedVenueId: null, new List<ParsedCsvApprenticeshipRow>() { parsedRow1, parsedRow1 });
+
+            // Act
+            var validationResult1 = validator.Validate(ParsedCsvApprenticeshipRow.FromCsvApprenticeshipRow(row1, allRegions));
+
+            // Assert
+            Assert.DoesNotContain(
+                validationResult1.Errors,
+                error => error.ErrorCode == "APPRENTICESHIP_NATIONALDELIVERY_REQUIRED");
+            Assert.DoesNotContain(
+                validationResult1.Errors,
+                error => error.ErrorCode == "APPRENTICESHIP_RADIUS_REQUIRED");
+        }
+
+        [Fact]
         public async Task ApprenticeshipClassroomAndEmployerProvidesBothRadiusAndNational_ReturnsValidationError()
         {
             // Arrange

--- a/tests/Dfc.CourseDirectory.Core.Tests/DataManagementTests/ApprenticeshipUploadRowValidatorTests.cs
+++ b/tests/Dfc.CourseDirectory.Core.Tests/DataManagementTests/ApprenticeshipUploadRowValidatorTests.cs
@@ -559,6 +559,180 @@ namespace Dfc.CourseDirectory.Core.Tests.DataManagementTests
         }
         #endregion
 
+        #region both tests
+        [Fact]
+        public async Task ApprenticeshipClassroomAndEmployerProvidesBothRadiusAndNational_ReturnsValidationError()
+        {
+            // Arrange
+            var provider = await TestData.CreateProvider(providerType: Models.ProviderType.Apprenticeships);
+            var user = await TestData.CreateUser();
+            var venue = await TestData.CreateVenue(
+                providerId: provider.ProviderId,
+                createdBy: user,
+                venueName: "My Venue",
+                providerVenueRef: "VENUE1");
+            var allRegions = await new RegionCache(SqlQueryDispatcherFactory).GetAllRegions();
+
+            var row1 = new CsvApprenticeshipRow()
+            {
+                StandardCode = "1",
+                StandardVersion = "1",
+                ApprenticeshipInformation = "Some info",
+                ApprenticeshipWebpage = "https://someapprenticeship.com",
+                DeliveryMethod = "Classroom based",
+                DeliveryModes = "Employer Address;Day Release",
+                ContactEmail = "someemail@invalid.com",
+                ContactPhone = "0121 111 1111",
+                ContactUrl = "https://someapprenticeship.com",
+                YourVenueReference = "VENUE2",
+                Radius = "100",
+                NationalDelivery = "yes"
+            };
+
+            var parsedRow1 = ParsedCsvApprenticeshipRow.FromCsvApprenticeshipRow(row1, allRegions);
+            var validator = new ApprenticeshipUploadRowValidator(Clock, matchedVenueId: null, new List<ParsedCsvApprenticeshipRow>() { parsedRow1, parsedRow1 });
+
+            // Act
+            var validationResult1 = validator.Validate(ParsedCsvApprenticeshipRow.FromCsvApprenticeshipRow(row1, allRegions));
+
+            // Assert
+            Assert.Contains(
+                validationResult1.Errors,
+                error => error.ErrorCode == "APPRENTICESHIP_NATIONALDELIVERY_REQUIRED");
+            Assert.Contains(
+                validationResult1.Errors,
+                error => error.ErrorCode == "APPRENTICESHIP_RADIUS_REQUIRED");
+        }
+
+        [Fact]
+        public async Task ApprenticeshipClassroomAndEmployerWithoutRadiusAndNational_ReturnsValidationError()
+        {
+            // Arrange
+            var provider = await TestData.CreateProvider(providerType: Models.ProviderType.Apprenticeships);
+            var user = await TestData.CreateUser();
+            var venue = await TestData.CreateVenue(
+                providerId: provider.ProviderId,
+                createdBy: user,
+                venueName: "My Venue",
+                providerVenueRef: "VENUE1");
+            var allRegions = await new RegionCache(SqlQueryDispatcherFactory).GetAllRegions();
+
+            var row1 = new CsvApprenticeshipRow()
+            {
+                StandardCode = "1",
+                StandardVersion = "1",
+                ApprenticeshipInformation = "Some info",
+                ApprenticeshipWebpage = "https://someapprenticeship.com",
+                DeliveryMethod = "Classroom based",
+                DeliveryModes = "Employer Address;Day Release",
+                ContactEmail = "someemail@invalid.com",
+                ContactPhone = "0121 111 1111",
+                ContactUrl = "https://someapprenticeship.com",
+                YourVenueReference = "VENUE2",
+            };
+
+            var parsedRow1 = ParsedCsvApprenticeshipRow.FromCsvApprenticeshipRow(row1, allRegions);
+            var validator = new ApprenticeshipUploadRowValidator(Clock, matchedVenueId: null, new List<ParsedCsvApprenticeshipRow>() { parsedRow1, parsedRow1 });
+
+            // Act
+            var validationResult1 = validator.Validate(ParsedCsvApprenticeshipRow.FromCsvApprenticeshipRow(row1, allRegions));
+
+            // Assert
+            Assert.Contains(
+                validationResult1.Errors,
+                error => error.ErrorCode == "APPRENTICESHIP_NATIONALDELIVERY_REQUIRED");
+            Assert.Contains(
+                validationResult1.Errors,
+                error => error.ErrorCode == "APPRENTICESHIP_RADIUS_REQUIRED");
+        }
+
+        [Fact]
+        public async Task ApprenticeshipClassroomAndEmployerWithOnlyRadiusSet_DoesNotReturnValidationError()
+        {
+            // Arrange
+            var provider = await TestData.CreateProvider(providerType: Models.ProviderType.Apprenticeships);
+            var user = await TestData.CreateUser();
+            var venue = await TestData.CreateVenue(
+                providerId: provider.ProviderId,
+                createdBy: user,
+                venueName: "My Venue",
+                providerVenueRef: "VENUE1");
+            var allRegions = await new RegionCache(SqlQueryDispatcherFactory).GetAllRegions();
+
+            var row1 = new CsvApprenticeshipRow()
+            {
+                StandardCode = "1",
+                StandardVersion = "1",
+                ApprenticeshipInformation = "Some info",
+                ApprenticeshipWebpage = "https://someapprenticeship.com",
+                DeliveryMethod = "Classroom based",
+                DeliveryModes = "Employer Address;Day Release",
+                ContactEmail = "someemail@invalid.com",
+                ContactPhone = "0121 111 1111",
+                ContactUrl = "https://someapprenticeship.com",
+                YourVenueReference = "VENUE2",
+                Radius = "100"
+            };
+
+            var parsedRow1 = ParsedCsvApprenticeshipRow.FromCsvApprenticeshipRow(row1, allRegions);
+            var validator = new ApprenticeshipUploadRowValidator(Clock, matchedVenueId: null, new List<ParsedCsvApprenticeshipRow>() { parsedRow1, parsedRow1 });
+
+            // Act
+            var validationResult1 = validator.Validate(ParsedCsvApprenticeshipRow.FromCsvApprenticeshipRow(row1, allRegions));
+
+            // Assert
+            Assert.DoesNotContain(
+                validationResult1.Errors,
+                error => error.ErrorCode == "APPRENTICESHIP_NATIONALDELIVERY_REQUIRED");
+            Assert.DoesNotContain(
+                validationResult1.Errors,
+                error => error.ErrorCode == "APPRENTICESHIP_RADIUS_REQUIRED");
+        }
+
+        [Fact]
+        public async Task ApprenticeshipClassroomAndEmployerWithOnlyNationalSet_DoesNotReturnValidationError()
+        {
+            // Arrange
+            var provider = await TestData.CreateProvider(providerType: Models.ProviderType.Apprenticeships);
+            var user = await TestData.CreateUser();
+            var venue = await TestData.CreateVenue(
+                providerId: provider.ProviderId,
+                createdBy: user,
+                venueName: "My Venue",
+                providerVenueRef: "VENUE1");
+            var allRegions = await new RegionCache(SqlQueryDispatcherFactory).GetAllRegions();
+
+            var row1 = new CsvApprenticeshipRow()
+            {
+                StandardCode = "1",
+                StandardVersion = "1",
+                ApprenticeshipInformation = "Some info",
+                ApprenticeshipWebpage = "https://someapprenticeship.com",
+                DeliveryMethod = "Classroom based",
+                DeliveryModes = "Employer Address;Day Release",
+                ContactEmail = "someemail@invalid.com",
+                ContactPhone = "0121 111 1111",
+                ContactUrl = "https://someapprenticeship.com",
+                YourVenueReference = "VENUE2",
+                NationalDelivery = "yes"
+            };
+
+            var parsedRow1 = ParsedCsvApprenticeshipRow.FromCsvApprenticeshipRow(row1, allRegions);
+            var validator = new ApprenticeshipUploadRowValidator(Clock, matchedVenueId: null, new List<ParsedCsvApprenticeshipRow>() { parsedRow1, parsedRow1 });
+
+            // Act
+            var validationResult1 = validator.Validate(ParsedCsvApprenticeshipRow.FromCsvApprenticeshipRow(row1, allRegions));
+
+            // Assert
+            Assert.DoesNotContain(
+                validationResult1.Errors,
+                error => error.ErrorCode == "APPRENTICESHIP_NATIONALDELIVERY_REQUIRED");
+            Assert.DoesNotContain(
+                validationResult1.Errors,
+                error => error.ErrorCode == "APPRENTICESHIP_RADIUS_REQUIRED");
+        }
+        #endregion
+
         #region Employer based tests
         [Fact]
         public async Task ApprenticeshipWhenEmployerWithDuplicateStandardCode_ReturnsValidationError()
@@ -604,7 +778,7 @@ namespace Dfc.CourseDirectory.Core.Tests.DataManagementTests
             var validator = new ApprenticeshipUploadRowValidator(Clock, matchedVenueId: null, new List<ParsedCsvApprenticeshipRow>() { parsedRow1, parsedRow2 });
 
             // Act
-            var validationResult1 = validator.Validate(ParsedCsvApprenticeshipRow.FromCsvApprenticeshipRow(row2, allRegions));
+            var validationResult1 = validator.Validate(ParsedCsvApprenticeshipRow.FromCsvApprenticeshipRow(row1, allRegions));
             var validationResult2 = validator.Validate(ParsedCsvApprenticeshipRow.FromCsvApprenticeshipRow(row2, allRegions));
 
             // Assert


### PR DESCRIPTION
- Added changes to support either radius or national validation rules when Apprenticeship Both.
- Added tests around providing both, none, either.