### PR TITLE
Merge Release 24 into Master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -354,3 +354,5 @@ MigrationBackup/
 
 !lib/*.nupkg
 /.vscode
+/utils/Cosmos/**/appsettings.json
+utils/Cosmos/Dfc.CosmosBulkUtils/Properties/launchSettings.json

--- a/utils/Cosmos/Dfc.Cosmos.Utils.sln
+++ b/utils/Cosmos/Dfc.Cosmos.Utils.sln
@@ -1,0 +1,37 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.2.32526.322
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Dfc.CosmosToCsv", "Dfc.CosmosToCsv\Dfc.CosmosToCsv.csproj", "{CE96502A-351D-4982-8B00-64A917A1F989}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Dfc.CosmosBulkUtils", "Dfc.CosmosBulkUtils\Dfc.CosmosBulkUtils.csproj", "{CA558365-A4A0-45EA-BEA6-C345501738C8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dfc.CosmosToSQLScript", "Dfc.CosmosToSQLScript\Dfc.CosmosToSQLScript.csproj", "{2511FD75-B8F1-4C08-B74D-C5C33788C927}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{CE96502A-351D-4982-8B00-64A917A1F989}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CE96502A-351D-4982-8B00-64A917A1F989}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CE96502A-351D-4982-8B00-64A917A1F989}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CE96502A-351D-4982-8B00-64A917A1F989}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CA558365-A4A0-45EA-BEA6-C345501738C8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CA558365-A4A0-45EA-BEA6-C345501738C8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CA558365-A4A0-45EA-BEA6-C345501738C8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CA558365-A4A0-45EA-BEA6-C345501738C8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2511FD75-B8F1-4C08-B74D-C5C33788C927}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2511FD75-B8F1-4C08-B74D-C5C33788C927}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2511FD75-B8F1-4C08-B74D-C5C33788C927}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2511FD75-B8F1-4C08-B74D-C5C33788C927}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {FA18A626-C44C-491D-A580-B93C843D88B7}
+	EndGlobalSection
+EndGlobal

--- a/utils/Cosmos/Dfc.CosmosBulkUtils/Application.cs
+++ b/utils/Cosmos/Dfc.CosmosBulkUtils/Application.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Threading.Tasks;
+using CommandLine;
+using Dfc.CosmosBulkUtils.Config;
+using Dfc.CosmosBulkUtils.Features.Add;
+using Dfc.CosmosBulkUtils.Features.Delete;
+using Dfc.CosmosBulkUtils.Features.Patch;
+using Dfc.CosmosBulkUtils.Features.Touch;
+using Microsoft.Extensions.Logging;
+
+namespace Dfc.CosmosBulkUtils
+{
+    public class Application
+    {
+        private readonly ILogger<Application> _logger;
+        private readonly ITouchService _touchService;
+        private readonly IDeleteService _deleteService;
+        private readonly IPatchService _patchService;
+        private readonly IAddService _addService;
+
+        public Application(ILogger<Application> logger, ITouchService touchService, IDeleteService deleteService, IPatchService patchService, IAddService addService)
+        {
+            _logger = logger;
+            _touchService = touchService;
+            _deleteService = deleteService;
+            _patchService = patchService;
+            _addService = addService;
+        }
+
+        public async Task<int> Run(CmdOptions cmdOption)
+        {
+            _logger.LogInformation("Running");
+
+            switch (cmdOption)
+            {
+                case TouchOptions touchOptions:
+                    return await _touchService.Execute(touchOptions.Filename);
+                case DeleteOptions deleteOptions:
+                    return await _deleteService.Execute(deleteOptions.Filename);
+                case PatchOptions patchOptions:
+                    return await _patchService.Execute(patchOptions);
+                case AddOptions addOptions:
+                    return await _addService.Execute(addOptions.Path, addOptions.PartitionKey);
+                    default:
+                    return 1;
+
+            }
+
+
+
+            //_logger.LogInformation("Complete");
+            //    return 0;
+
+        }
+
+    }
+}

--- a/utils/Cosmos/Dfc.CosmosBulkUtils/Config/CmdOptions.cs
+++ b/utils/Cosmos/Dfc.CosmosBulkUtils/Config/CmdOptions.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using CommandLine;
+
+namespace Dfc.CosmosBulkUtils.Config
+{
+    public class CmdOptions
+    {
+        [Option('u', "url", Required = true, HelpText = "Azure Cosmosdb URL")]
+        public string EndpointUrl { get; set; }
+        [Option('k', "key", Required = true, HelpText = "Azure Cosmosdb Access Key")]
+        public string AccessKey { get; set; }
+        [Option('c', "container", Required = true, HelpText = "Azure Container Id")]
+        public string ContainerId { get; set; }
+        [Option('d', "database", Required = true, HelpText = "Azure Database Id")]
+        public string DatabaseId { get; set; }
+
+    }
+}

--- a/utils/Cosmos/Dfc.CosmosBulkUtils/Config/CosmosDbSettings.cs
+++ b/utils/Cosmos/Dfc.CosmosBulkUtils/Config/CosmosDbSettings.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Dfc.CosmosBulkUtils.Config
+{
+    public class CosmosDbSettings
+    {
+        public static string SectionName => "CosmosDb";
+        public string EndpointUrl { get; set; }
+        public string AccessKey { get; set; }
+
+        public string ContainerId { get; set; }
+        public string DatabaseId { get; set; }
+    }
+}

--- a/utils/Cosmos/Dfc.CosmosBulkUtils/Config/CosmosRecord.cs
+++ b/utils/Cosmos/Dfc.CosmosBulkUtils/Config/CosmosRecord.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Dfc.CosmosBulkUtils.Config
+{
+    public class CosmosRecord
+    {
+        public string Id { get; set; }
+    }
+}

--- a/utils/Cosmos/Dfc.CosmosBulkUtils/Config/PatchCommand.cs
+++ b/utils/Cosmos/Dfc.CosmosBulkUtils/Config/PatchCommand.cs
@@ -1,0 +1,8 @@
+﻿namespace Dfc.CosmosBulkUtils.Config
+{
+    public class PatchCommand
+    {
+        public string Field { get; set; }
+        public object Value { get; set; }
+    }
+}

--- a/utils/Cosmos/Dfc.CosmosBulkUtils/Config/PatchConfig.cs
+++ b/utils/Cosmos/Dfc.CosmosBulkUtils/Config/PatchConfig.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Dfc.CosmosBulkUtils.Config
+{
+    public class PatchConfig
+    {
+        public string PartitionKeyValue { get; set; }
+        public string FilterPredicate { get; set; }
+        public List<string> FilterIds { get; set; }
+        public IEnumerable<PatchCommand> Operations { get; set; }
+
+    }
+}

--- a/utils/Cosmos/Dfc.CosmosBulkUtils/Dfc.CosmosBulkUtils.csproj
+++ b/utils/Cosmos/Dfc.CosmosBulkUtils/Dfc.CosmosBulkUtils.csproj
@@ -1,0 +1,37 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>false</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Remove="C:\Users\Amand\.nuget\packages\microsoft.azure.cosmos\3.28.0\contentFiles\any\netstandard2.0\ThirdPartyNotice.txt" />
+    <Content Remove="C:\Users\asandhu2\.nuget\packages\microsoft.azure.cosmos\3.27.2\contentFiles\any\netstandard2.0\ThirdPartyNotice.txt" />
+    <Content Remove="C:\Users\asandhu2\.nuget\packages\microsoft.azure.cosmos\3.28.0\contentFiles\any\netstandard2.0\ThirdPartyNotice.txt" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CommandLineParser" Version="2.9.1" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.28.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
+    <PackageReference Include="Serilog.Extensions.Hosting" Version="4.2.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="patch-config-example.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/utils/Cosmos/Dfc.CosmosBulkUtils/Features/Add/AddOptions.cs
+++ b/utils/Cosmos/Dfc.CosmosBulkUtils/Features/Add/AddOptions.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using CommandLine;
+using Dfc.CosmosBulkUtils.Config;
+
+namespace Dfc.CosmosBulkUtils.Features.Add
+{
+    [Verb("add", HelpText = "Add documents to the collection")]
+    public class AddOptions : CmdOptions
+    {
+        [Option('p', "path", Required = true, HelpText = "folder containing the documents to add")]
+        public string Path { get; set; }
+
+        [Option("pkey", Required = false, HelpText = "Optional partition key to be used when inserting document")]
+        public string PartitionKey { get; set; }
+    }
+}

--- a/utils/Cosmos/Dfc.CosmosBulkUtils/Features/Add/AddService.cs
+++ b/utils/Cosmos/Dfc.CosmosBulkUtils/Features/Add/AddService.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Dfc.CosmosBulkUtils.Services;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+namespace Dfc.CosmosBulkUtils.Features.Add
+{
+    public class AddService : IAddService
+    {
+        private readonly ILogger<AddService> _logger;
+        private readonly IFileService _fileService;
+        private readonly IContainerService _containerService;
+
+        public AddService(ILogger<AddService> logger, IFileService fileService, IContainerService containerService)
+        {
+            _logger = logger;
+            _fileService = fileService;
+            _containerService = containerService;
+        }
+        public async Task<int> Execute(string path, string partitionKey)
+        {
+            var success = new List<string>();
+            var failed = new List<string>();
+
+            foreach (string file in Directory.EnumerateFiles(path, "*.json"))
+            {
+                var document = JsonConvert.DeserializeObject<Dictionary<string, object>>(File.ReadAllText(file));
+                _logger.LogInformation("Attempting to add {0}", file);
+                var result = await _containerService.Add(file, document, partitionKey);
+
+                if (result)
+                {
+                    success.Add(file);
+                } else
+                {
+                    failed.Add(file);
+                }
+
+            }
+
+            if (failed.Count > 0)
+            {
+                _logger.LogError("The following failed to upsert");
+                failed.ForEach(x => _logger.LogError(x));
+                return 1;
+            } else
+            {
+                _logger.LogInformation("Complete");
+                return 0;
+            }
+        }
+    }
+}

--- a/utils/Cosmos/Dfc.CosmosBulkUtils/Features/Add/IAddService.cs
+++ b/utils/Cosmos/Dfc.CosmosBulkUtils/Features/Add/IAddService.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Dfc.CosmosBulkUtils.Features.Add
+{
+    public interface IAddService
+    {
+        Task<int> Execute(string path, string partitionKey);
+    }
+}

--- a/utils/Cosmos/Dfc.CosmosBulkUtils/Features/Delete/DeleteOptions.cs
+++ b/utils/Cosmos/Dfc.CosmosBulkUtils/Features/Delete/DeleteOptions.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using CommandLine;
+using Dfc.CosmosBulkUtils.Config;
+
+namespace Dfc.CosmosBulkUtils.Features.Delete
+{
+    [Verb("delete", HelpText = "Remove the list of id's from the cosmosdb collection")]
+    public class DeleteOptions : CmdOptions
+    {
+        [Option('f', "file", Required = true, HelpText = "text file containing document ids")]
+        public string Filename { get; set; }
+    }
+}

--- a/utils/Cosmos/Dfc.CosmosBulkUtils/Features/Delete/DeleteService.cs
+++ b/utils/Cosmos/Dfc.CosmosBulkUtils/Features/Delete/DeleteService.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Dfc.CosmosBulkUtils.Services;
+using Microsoft.Extensions.Logging;
+using Serilog;
+using ILogger = Serilog.ILogger;
+
+namespace Dfc.CosmosBulkUtils.Features.Delete
+{
+    public class DeleteService : IDeleteService
+    {
+        private readonly ILogger<DeleteService> _logger;
+        private readonly IFileService _fileService;
+        private readonly IContainerService _containerService;
+
+        public DeleteService(ILogger<DeleteService> logger, IFileService fileService, IContainerService containerService)
+        {
+            _logger = logger;
+            _fileService = fileService;
+            _containerService = containerService;
+        }
+
+        public async Task<int> Execute(string filename)
+        {
+            var ids = _fileService.LoadRecordIds(filename);
+
+            if (!this.Confirm(ids.Count))
+            {
+                Log.Information("Aborting");
+                return 1;
+            }
+
+            int successful = 0, failed = 0;
+
+            foreach (var id in ids)
+            {
+                if (await _containerService.Delete(id))
+                {
+                    successful++;
+                }
+                else
+                {
+                    failed++;
+                }
+                _logger.LogInformation("Progress {total}", successful + failed);
+            }
+
+            _logger.LogInformation("Summary Successful={successful} Failed={failed}", successful, failed);
+            return 0;
+        }
+
+        private bool Confirm(int totalRecords)
+        {
+            var settings = _containerService.GetSettings();
+            Console.WriteLine("A total of {0} will be deleted from {1} {2} {3}", totalRecords, settings.EndpointUrl, settings.DatabaseId, settings.ContainerId );
+            Console.WriteLine("Press Y to proceed - or any other key to quit");
+
+            return Console.ReadKey().KeyChar.ToString().Equals("y", StringComparison.InvariantCultureIgnoreCase);
+        }
+    }
+}

--- a/utils/Cosmos/Dfc.CosmosBulkUtils/Features/Delete/IDeleteService.cs
+++ b/utils/Cosmos/Dfc.CosmosBulkUtils/Features/Delete/IDeleteService.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace Dfc.CosmosBulkUtils.Features.Delete
+{
+    public interface IDeleteService
+    {
+        Task<int> Execute(string filename);
+    }
+}

--- a/utils/Cosmos/Dfc.CosmosBulkUtils/Features/Patch/IPatchService.cs
+++ b/utils/Cosmos/Dfc.CosmosBulkUtils/Features/Patch/IPatchService.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Dfc.CosmosBulkUtils.Features.Patch
+{
+    public interface IPatchService
+    {
+        Task<int> Execute(PatchOptions options);
+    }
+}

--- a/utils/Cosmos/Dfc.CosmosBulkUtils/Features/Patch/PatchOptions.cs
+++ b/utils/Cosmos/Dfc.CosmosBulkUtils/Features/Patch/PatchOptions.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using CommandLine;
+using Dfc.CosmosBulkUtils.Config;
+
+namespace Dfc.CosmosBulkUtils.Features.Patch
+{
+    [Verb("patch", HelpText = "Patch list of items based on query")]
+    public class PatchOptions : CmdOptions
+    {
+        [Option('f', "file", Required = true, HelpText = "text file containing JSON config for patch operation")]
+        public string Filename { get; set; }
+    }
+}

--- a/utils/Cosmos/Dfc.CosmosBulkUtils/Features/Patch/PatchService.cs
+++ b/utils/Cosmos/Dfc.CosmosBulkUtils/Features/Patch/PatchService.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Dfc.CosmosBulkUtils.Services;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Logging;
+
+namespace Dfc.CosmosBulkUtils.Features.Patch
+{
+    public class PatchService : IPatchService
+    {
+        private readonly ILogger<PatchService> _logger;
+        private readonly IFileService _fileService;
+        private readonly IContainerService _containerService;
+
+        public PatchService(ILogger<PatchService> logger, IFileService fileService, IContainerService containerService)
+        {
+            _logger = logger;
+            _fileService = fileService;
+            _containerService = containerService;
+        }
+        public async Task<int> Execute(PatchOptions options)
+        {
+            _logger.LogInformation("Loading patch config {0}", options.Filename);
+            var config = _fileService.LoadPatchConfig(options.Filename);
+
+            await _containerService.Patch(config);
+
+
+
+
+
+            return 0;
+        }
+    }
+}

--- a/utils/Cosmos/Dfc.CosmosBulkUtils/Features/Touch/ITouchService.cs
+++ b/utils/Cosmos/Dfc.CosmosBulkUtils/Features/Touch/ITouchService.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace Dfc.CosmosBulkUtils.Features.Touch
+{
+    public interface ITouchService
+    {
+        Task<int> Execute(string filename);
+    }
+}

--- a/utils/Cosmos/Dfc.CosmosBulkUtils/Features/Touch/TouchOptions.cs
+++ b/utils/Cosmos/Dfc.CosmosBulkUtils/Features/Touch/TouchOptions.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using CommandLine;
+using Dfc.CosmosBulkUtils.Config;
+
+namespace Dfc.CosmosBulkUtils.Features.Touch
+{
+    [Verb("touch", HelpText = "Touch the list of id's from the cosmosdb collection to force a sync to SQL")]
+    public class TouchOptions :CmdOptions
+    {
+        [Option('f', "file", Required = true, HelpText = "text file containing document ids")]
+        public string Filename { get; set; }
+    }
+}

--- a/utils/Cosmos/Dfc.CosmosBulkUtils/Features/Touch/TouchService.cs
+++ b/utils/Cosmos/Dfc.CosmosBulkUtils/Features/Touch/TouchService.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Threading.Tasks;
+using Dfc.CosmosBulkUtils.Services;
+using Dfc.CosmosBulkUtils.Utils;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Linq;
+
+namespace Dfc.CosmosBulkUtils.Features.Touch
+{
+    public class TouchService :  ITouchService
+    {
+        private readonly IFileService _fileService;
+        private readonly IContainerService _containerService;
+        private readonly ILogger<TouchService> _logger;
+
+        public TouchService(ILogger<TouchService> logger, IFileService fileService, IContainerService containerService) 
+        {
+            _logger = logger;
+            _fileService = fileService;
+            _containerService = containerService;
+        }
+
+        public async Task<int> Execute(string filename)
+        {
+            
+            
+                var ids = _fileService.LoadRecordIds(filename);
+
+                foreach (var id in ids)
+                {
+                    _logger.LogInformation("Attempting touch on {id}", id);
+                    var item = await _containerService.Get(id);
+                    await _containerService.Update(id, item);
+                    _logger.LogInformation("Touch done for {id}", id);
+                }
+
+                return 0;
+            
+        }
+    }
+}

--- a/utils/Cosmos/Dfc.CosmosBulkUtils/Program.cs
+++ b/utils/Cosmos/Dfc.CosmosBulkUtils/Program.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using CommandLine;
+using CommandLine.Text;
+using Dfc.CosmosBulkUtils.Config;
+using Dfc.CosmosBulkUtils.Features.Add;
+using Dfc.CosmosBulkUtils.Features.Delete;
+using Dfc.CosmosBulkUtils.Features.Patch;
+using Dfc.CosmosBulkUtils.Features.Touch;
+using Dfc.CosmosBulkUtils.Services;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Newtonsoft.Json.Linq;
+using Serilog;
+using Serilog.Core;
+
+namespace Dfc.CosmosBulkUtils
+{
+    internal class Program
+    {
+        private static async Task<int> Main(string[] args)
+        {
+            var builder = new ConfigurationBuilder();
+            BuildConfig(builder);
+            Log.Logger = new LoggerConfiguration().ReadFrom
+                .Configuration(builder.Build())
+                .CreateLogger();
+
+            try
+            {
+                Log.Logger.Information("Initialise...");
+
+                var result = await CommandLine.Parser.Default.ParseArguments<TouchOptions, DeleteOptions, PatchOptions, AddOptions>(args)
+                    .MapResult(
+                    (TouchOptions opts) =>  Execute(opts), 
+                    (DeleteOptions opts) => Execute(opts), 
+                    (PatchOptions opts) => Execute(opts), 
+                    (AddOptions opts) => Execute(opts),
+                    error => Task.FromResult(1)
+                    );
+
+
+                return result;
+
+            }
+            catch (Exception e)
+            {
+                Log.Logger.Error("Failed", e);
+                throw;
+            }
+
+
+        }
+
+        private async static Task<int> Execute(CmdOptions options)
+        {
+            var host = CreateHost(options);
+            var app = ActivatorUtilities.CreateInstance<Application>(host.Services);
+            return await app.Run(options);
+
+        }
+
+        private static IHost CreateHost(CmdOptions options)
+        {
+            var host = Host.CreateDefaultBuilder()
+                    .ConfigureServices((context, services) =>
+                    {
+                            services.Configure<CosmosDbSettings>(p =>
+                            {
+                                p.EndpointUrl = options.EndpointUrl;
+                                p.AccessKey = options.AccessKey;
+                                p.ContainerId = options.ContainerId;
+                                p.DatabaseId = options.DatabaseId;
+
+                            });
+
+                        services.AddTransient<IContainerService, ContainerService>();
+                        services.AddTransient<ITouchService, TouchService>();
+                        services.AddTransient<IDeleteService, DeleteService>();
+                        services.AddTransient<IPatchService, PatchService>();
+                        services.AddTransient<IAddService, AddService>();
+                        services.AddTransient<IFileService, FileService>();
+                        services.AddTransient<Application>();
+                    })
+                    .UseSerilog()
+                    .Build();
+
+            return host;
+        }
+
+        private static void BuildConfig(IConfigurationBuilder builder)
+        {
+            builder.SetBasePath(Directory.GetCurrentDirectory())
+                .AddJsonFile("appsettings.json", false);
+        }
+    }
+}

--- a/utils/Cosmos/Dfc.CosmosBulkUtils/Properties/launchSettings.json
+++ b/utils/Cosmos/Dfc.CosmosBulkUtils/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "Dfc.CosmosBulkUtils": {
+      "commandName": "Project",
+      "commandLineArgs": "add -u https://localhost:8081 -k C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw== -c Areas -d backup --pkey \"none_required\" -p c:\\git\\Areas"
+    }
+  }
+}

--- a/utils/Cosmos/Dfc.CosmosBulkUtils/Services/ContainerService.cs
+++ b/utils/Cosmos/Dfc.CosmosBulkUtils/Services/ContainerService.cs
@@ -1,0 +1,191 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Dfc.CosmosBulkUtils.Config;
+using Dfc.CosmosBulkUtils.Utils;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json.Linq;
+
+namespace Dfc.CosmosBulkUtils.Services
+{
+    public class ContainerService : IContainerService
+    {
+        private readonly Container _container;
+        private readonly ILogger<ContainerService> _logger;
+        private readonly CosmosDbSettings _settings;
+
+        public ContainerService(ILogger<ContainerService> logger, IOptions<CosmosDbSettings> settings)
+        {
+            _settings = settings.Value;
+            _logger = logger;
+            _container =
+                new CosmosClient(_settings.EndpointUrl, _settings.AccessKey,
+                        new CosmosClientOptions
+                        {
+                            ConnectionMode = ConnectionMode.Gateway, 
+                            AllowBulkExecution = false, 
+                            MaxRetryAttemptsOnRateLimitedRequests = 200, 
+                            MaxRetryWaitTimeOnRateLimitedRequests = new TimeSpan(0, 10, 0)
+                        })
+                    .GetDatabase(_settings.DatabaseId).GetContainer(_settings.ContainerId);
+        }
+
+        public async Task Update(Guid id,object item)
+        {
+            _logger.LogInformation("Updating {id}", id);
+            var response = await _container.UpsertItemAsync(item, PartitionKey.None);
+
+            if (!response.StatusCode.IsSuccessStatusCode())
+            {
+                throw new ApplicationException($"Failed to update record {response.StatusCode.ToString()}");
+
+            }
+        }
+
+        public async Task<bool> Delete(Guid id)
+        {
+            _logger.LogInformation("Deleting {id}", id);
+
+
+            if (!await Exists(id))
+            {
+                _logger.LogWarning("Skipping {id} not found", id);
+                return false;
+            }
+
+            var response = await _container.DeleteItemAsync<object>(id.ToString(), PartitionKey.None);
+
+            if (response.StatusCode.IsSuccessStatusCode())
+            {
+                _logger.LogInformation("Deleted {id}", id);
+                return true;
+            }
+
+            return false;
+        }
+
+        public async Task<bool> Add(string filename, IDictionary<string, object> document, string partitionKey)
+        {
+            var response = await _container.CreateItemAsync<IDictionary<string,object>>(document);
+
+            if (response.StatusCode.IsSuccessStatusCode())
+            {
+                _logger.LogInformation("Added {filename}", filename);
+                return true;
+            }
+
+            return false;
+        }
+
+        public async Task<object> Get(Guid id)
+        {
+            _logger.LogInformation("Getting {id}", id);
+            var response = await _container.ReadItemAsync<object>(id.ToString(), PartitionKey.None);
+            return response.StatusCode.IsSuccessStatusCode()
+                ? response.Resource
+                : throw new ApplicationException($"Failed to get record {response.StatusCode.ToString()}");
+        }
+
+        public async Task<bool> Exists(Guid id)
+        {
+            var response = await _container.ReadItemStreamAsync(id.ToString(), PartitionKey.None);
+
+
+            switch (response.StatusCode)
+            {
+                case HttpStatusCode.NotFound:
+                    return false;
+                default:
+                    return response.IsSuccessStatusCode;
+            }
+
+        }
+
+        public async Task<bool> Patch(PatchConfig config)
+        {          
+            var stopWatch = Stopwatch.StartNew();
+            var results = await GetCosmosRecordIds(config);
+
+
+            var patchOperations = (from o in config.Operations
+                                  select PatchOperation.Replace(o.Field, o.Value)).ToList();
+
+            var tasks = new List<Task<(ItemResponse<object>?, Exception?)>>();
+
+            _logger.LogInformation("Processing....");
+            var success = 0;
+            var failed = new Dictionary<string,string>();
+
+            for (int i = 0; i < results.Count; i++)
+            {
+                var item = results[i];
+
+                var result = await _container.PatchItemAsync<object>(
+                    id: item.Id,
+                    partitionKey: String.IsNullOrEmpty(config.PartitionKeyValue) ? PartitionKey.None : new PartitionKey(config.PartitionKeyValue),
+                    patchOperations: patchOperations
+                );
+
+                if (result.StatusCode.IsSuccessStatusCode())
+                {
+                    success++;
+                }
+                else
+                {
+                    failed.Add(item.Id, result.StatusCode.ToString());
+                }
+
+            }
+
+            foreach (var key in failed.Keys)
+            {
+                _logger.LogError("{0} - {1}", key, failed[key]);
+            }
+
+
+            _logger.LogInformation("Complete Elapsed = {0}", stopWatch.Elapsed);
+
+            return true;
+        }
+
+        private async Task<List<CosmosRecord>> GetCosmosRecordIds(PatchConfig config)
+        {
+            var results = new List<CosmosRecord>();
+
+            if (config.FilterIds.Any())
+            {
+                results.AddRange(config.FilterIds.Select(id => new CosmosRecord { Id = id.ToLower() }));
+                return results;
+            }
+
+            var queryResults = _container.GetItemQueryIterator<CosmosRecord>(config.FilterPredicate);
+            while (queryResults.HasMoreResults)
+            {
+                var currentResults = await queryResults.ReadNextAsync();
+                results.AddRange(currentResults);
+                _logger.LogInformation("Found {0}", results.Count);
+            }
+
+            _logger.LogInformation("Total of {0} records found", results.Count);
+
+            return results;
+        }
+
+        public CosmosDbSettings GetSettings()
+        {
+            return new CosmosDbSettings
+            {
+                DatabaseId = _settings.DatabaseId,
+                ContainerId = _settings.ContainerId,
+                EndpointUrl = _settings.EndpointUrl,
+                AccessKey = "XXXXXXXXXX"
+
+            };
+        }
+    }
+}

--- a/utils/Cosmos/Dfc.CosmosBulkUtils/Services/FileService.cs
+++ b/utils/Cosmos/Dfc.CosmosBulkUtils/Services/FileService.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Dfc.CosmosBulkUtils.Config;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+namespace Dfc.CosmosBulkUtils.Services
+{
+    public class FileService : IFileService
+    {
+        private readonly ILogger<FileService> _logger;
+
+        public FileService(ILogger<FileService> logger)
+        {
+            _logger = logger;
+        }
+
+        public IList<Guid> LoadRecordIds(string filename)
+        {
+            if (string.IsNullOrEmpty(filename) || !File.Exists(filename))
+                throw new ArgumentException("Filename not defined or not found", nameof(filename));
+
+            var listOfLines = File.ReadAllLines(filename)
+                .Where(x => !string.IsNullOrWhiteSpace(x));
+
+            var results = new List<Guid>();
+            foreach (var line in listOfLines)
+            {
+                if (Guid.TryParse(line, out var result))
+                {
+                    results.Add(result);
+                    _logger.LogInformation("Parsed {guid}", result);
+                }
+                else
+                {
+                    _logger.LogWarning("Failed to parse line {line}", line);
+                }
+            }
+
+            if (results.Count == 0) throw new ApplicationException("Files does not contain any valid guids, aborting");
+
+            return results;
+        }
+
+        public PatchConfig LoadPatchConfig(string filename)
+        {
+            var result  = JsonConvert.DeserializeObject<PatchConfig>(File.ReadAllText(filename));
+
+            if (!String.IsNullOrEmpty(result.FilterPredicate) && result.FilterIds.Count > 0)
+            {
+                throw new ApplicationException(
+                    "Invalid Patch file, you can't specify FilterPredicate and FilterIds only one can be used at a time");
+            }
+            return result;
+        }
+    }
+}

--- a/utils/Cosmos/Dfc.CosmosBulkUtils/Services/IContainerService.cs
+++ b/utils/Cosmos/Dfc.CosmosBulkUtils/Services/IContainerService.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Dfc.CosmosBulkUtils.Config;
+
+namespace Dfc.CosmosBulkUtils.Services
+{
+    public interface IContainerService
+    {
+        Task Update(Guid id, object payload);
+        Task<bool> Delete(Guid id);
+        Task<object> Get(Guid id);
+
+        Task<bool> Exists(Guid id);
+
+        Task<bool> Patch(PatchConfig config);
+
+        Task<bool> Add(string id, IDictionary<string, object> document, string partitionKey);
+
+        CosmosDbSettings GetSettings();
+    }
+}

--- a/utils/Cosmos/Dfc.CosmosBulkUtils/Services/IFileService.cs
+++ b/utils/Cosmos/Dfc.CosmosBulkUtils/Services/IFileService.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using Dfc.CosmosBulkUtils.Config;
+
+namespace Dfc.CosmosBulkUtils.Services
+{
+    public interface IFileService
+    {
+        IList<Guid> LoadRecordIds(string filename);
+        PatchConfig LoadPatchConfig(string filename);
+    }
+}

--- a/utils/Cosmos/Dfc.CosmosBulkUtils/Utils/Extensions.cs
+++ b/utils/Cosmos/Dfc.CosmosBulkUtils/Utils/Extensions.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Dfc.CosmosBulkUtils.Utils
+{
+    public static class Extensions
+    {
+        public static bool IsSuccessStatusCode(this HttpStatusCode statusCode)
+            => (int)statusCode >= 200 && (int)statusCode <= 299;
+    }
+}

--- a/utils/Cosmos/Dfc.CosmosBulkUtils/Utils/TaskHandlers.cs
+++ b/utils/Cosmos/Dfc.CosmosBulkUtils/Utils/TaskHandlers.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Azure.Cosmos;
+
+namespace Dfc.CosmosBulkUtils.Utils
+{
+    public static class TaskHandlers
+    {
+        public static async Task<(ItemResponse<object>?, Exception?)> CosmosExecuteAndCaptureErrorsAsync(Task<ItemResponse<object>> task)
+        {
+            try
+            {
+                return (await task, null);
+            }
+            catch (Exception ex)
+            {
+
+                return (null, ex);
+            }
+        }
+    }
+}

--- a/utils/Cosmos/Dfc.CosmosBulkUtils/appsettings.json
+++ b/utils/Cosmos/Dfc.CosmosBulkUtils/appsettings.json
@@ -1,0 +1,23 @@
+{
+  "Serilog": {
+    "Using": [],
+    "MinimumLevel": {
+      "Default": "Debug",
+      "Override": {
+        "Microsoft": "Debug",
+        "System": "Warning"
+      }
+    },
+    "Enrich": [ "FromLogContext" ],
+    "WriteTo": [
+      { "Name": "Console" },
+      {
+        "Name": "File",
+        "Args": {
+          "path": ".\\Log.txt"
+        }
+      }
+    ]
+
+  }
+}

--- a/utils/Cosmos/Dfc.CosmosBulkUtils/patch-config-example.json
+++ b/utils/Cosmos/Dfc.CosmosBulkUtils/patch-config-example.json
@@ -1,0 +1,10 @@
+{
+  "FilterPredicate": "SELECT c.id FROM c where c.X = \"0000000201\"",
+  "PartitionKeyValue": "not_required",
+  "Operations": [
+    {
+      "Field": "/TouchpointID",
+      "Value": "0000000101"
+    }
+  ]
+}

--- a/utils/Cosmos/Dfc.CosmosToCsv/Config/CosmosDbSettings.cs
+++ b/utils/Cosmos/Dfc.CosmosToCsv/Config/CosmosDbSettings.cs
@@ -1,0 +1,17 @@
+﻿namespace Dfc.CosmosToCsv.Config
+{
+    internal class CosmosDbSettings
+    {
+        public static string SectionName => "CosmosDb";
+        public string EndpointUrl { get; set; }
+        public string AccessKey { get; set; }
+
+        public string ContainerId { get; set; }
+        public string DatabaseId { get; set; }
+
+        public string Query { get; set; }
+        public string Filename { get; set; }
+
+        public string Key { get; set; }
+    }
+}

--- a/utils/Cosmos/Dfc.CosmosToCsv/Data/ExportRequest.cs
+++ b/utils/Cosmos/Dfc.CosmosToCsv/Data/ExportRequest.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.Azure.Cosmos;
+
+namespace Dfc.CosmosToCsv.Data
+{
+    public class ExportRequest
+    {
+        public string DatabaseId { get; set; }
+        public string ContainerId { get; set; }
+        public QueryDefinition Query { get; set; }
+
+        public string FileName { get; set; }
+    }
+}

--- a/utils/Cosmos/Dfc.CosmosToCsv/Dfc.CosmosToCsv.csproj
+++ b/utils/Cosmos/Dfc.CosmosToCsv/Dfc.CosmosToCsv.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+   
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Remove="C:\Users\asandhu2\.nuget\packages\microsoft.azure.cosmos\3.27.2\contentFiles\any\netstandard2.0\ThirdPartyNotice.txt" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CsvHelper" Version="27.2.1" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.27.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/utils/Cosmos/Dfc.CosmosToCsv/Program.cs
+++ b/utils/Cosmos/Dfc.CosmosToCsv/Program.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Dfc.CosmosToCsv.Config;
+using Dfc.CosmosToCsv.Data;
+using Dfc.CosmosToCsv.Services;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Configuration;
+
+namespace Dfc.CosmosToCsv
+{
+    internal class Program
+    {
+        private static async Task Main(string[] args)
+        {
+            var configs = GetConfig();
+
+            foreach (var config in configs)
+            {
+                var exportService = new ExportService(config.EndpointUrl, config.AccessKey);
+
+                var request = new ExportRequest
+                {
+                    DatabaseId = config.DatabaseId,
+                    ContainerId = config.ContainerId,
+                    Query = new QueryDefinition(config.Query)
+                };
+
+                var results = await exportService.ExportData(request);
+
+                Console.WriteLine("Found {0} records", results.Count);
+
+                exportService.ExportToFile(results, config.Key, config.Filename);
+            }
+        }
+
+        private static IEnumerable<CosmosDbSettings> GetConfig()
+        {
+            var configurationRoot = new ConfigurationBuilder().AddJsonFile("appSettings.json")
+                .Build();
+
+            return configurationRoot.GetRequiredSection(CosmosDbSettings.SectionName)
+                .Get<List<CosmosDbSettings>>();
+        }
+    }
+}

--- a/utils/Cosmos/Dfc.CosmosToCsv/Services/ExportService.cs
+++ b/utils/Cosmos/Dfc.CosmosToCsv/Services/ExportService.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using CsvHelper;
+using Dfc.CosmosToCsv.Data;
+using Microsoft.Azure.Cosmos;
+using Newtonsoft.Json.Linq;
+
+namespace Dfc.CosmosToCsv.Services
+{
+    public class ExportService
+    {
+        private readonly CosmosClient _client;
+
+        public ExportService(string endpointUrl, string accessKey)
+        {
+            ArgumentNullException.ThrowIfNull(endpointUrl);
+            ArgumentNullException.ThrowIfNull(accessKey);
+
+            _client = new CosmosClient(endpointUrl, accessKey,
+                new CosmosClientOptions { ConnectionMode = ConnectionMode.Gateway });
+        }
+
+        public async Task<IList<JObject>> ExportData(ExportRequest request)
+        {
+            ArgumentNullException.ThrowIfNull(request.DatabaseId);
+            ArgumentNullException.ThrowIfNull(request.ContainerId);
+            ArgumentNullException.ThrowIfNull(request.Query);
+
+            var results = new List<JObject>();
+
+            var container = _client.GetContainer(request.DatabaseId, request.ContainerId);
+            var queryResults = container.GetItemQueryIterator<JObject>(request.Query);
+
+            while (queryResults.HasMoreResults)
+            {
+                var currentResults = await queryResults.ReadNextAsync();
+                results.AddRange(currentResults);
+                Console.WriteLine("Found {0}", results.Count);
+            }
+
+            return results;
+        }
+
+        public void ExportToFile(IList<JObject> data, string key, string outputFileName = "output.csv")
+        {
+            using var writer = new StreamWriter(outputFileName);
+            using var csv = new CsvWriter(writer, CultureInfo.InvariantCulture);
+            var headerRow = data.First()?.ToObject<Dictionary<string, object>>()?.Keys;
+            if (headerRow == null) return;
+            foreach (var header in headerRow) csv.WriteField(header);
+
+            csv.WriteField("Order");
+
+            csv.NextRecord();
+
+            var order = 0;
+            var previousKey = "";
+
+            foreach (var item in data)
+            {
+                var row = item.ToObject<Dictionary<string, object>>();
+
+                foreach (var header in headerRow)
+                    csv.WriteField(row.ContainsKey(header) ? row[header] : string.Empty);
+
+
+                if (row.ContainsKey(key) && row[key].ToString() == previousKey && previousKey != null)
+                    order++;
+                else
+                    order = 0;
+
+                csv.WriteField(order);
+
+                previousKey = row.ContainsKey(key) ? row[key].ToString() : null;
+
+
+                csv.NextRecord();
+            }
+        }
+    }
+}

--- a/utils/Cosmos/Dfc.CosmosToCsv/appsettings_template.json
+++ b/utils/Cosmos/Dfc.CosmosToCsv/appsettings_template.json
@@ -1,0 +1,13 @@
+{
+  "CosmosDb": [
+    {
+      "EndpointUrl": "[INSERT_COSMOS_ENDPOINT_URL]",
+      "AccessKey": "[INSERT_COSMOS_ACCESS_KEY]",
+      "ContainerId": "[INSERT_CONTAINER_NAME]",
+      "DatabaseId": "[INSERT_DATABASE_NAME]",
+      "Query": "[INSERT SQL QUERY AND ORDER BY FIELD TO CHECK FOR DUPLICATES]",
+      "Key": "[INSERT FIELD TO CHECK FOR DUPLICATES]",
+      "Filename": "output.csv"
+    }
+  ]
+}

--- a/utils/Cosmos/Dfc.CosmosToSQLScript/Dfc.CosmosToSQLScript.csproj
+++ b/utils/Cosmos/Dfc.CosmosToSQLScript/Dfc.CosmosToSQLScript.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <LangVersion>10.0</LangVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <LangVersion>10.0</LangVersion>
+  </PropertyGroup>
+
+</Project>

--- a/utils/Cosmos/Dfc.CosmosToSQLScript/Program.cs
+++ b/utils/Cosmos/Dfc.CosmosToSQLScript/Program.cs
@@ -1,0 +1,77 @@
+﻿using Microsoft.VisualBasic.FileIO;
+using System;
+using System.Reflection;
+
+internal class Program
+{
+
+    // select count(*) from [dss-actionplans] a where a.CustomerSatisfaction is null and a.DateActionPlanCreated > '2022-10-01'
+    // select count(*) from [dss-actions]  a where  a.DateActionAgreed > '2022-10-01'
+
+
+    private static void Main(string[] args)
+    {
+        var action = CreateDict("C:\\Git\\dfc-coursedirectory\\utils\\Cosmos\\Dfc.CosmosToCsv\\bin\\Debug\\net6.0\\Action.csv");
+        SQLScriptAction(action);
+        var actionPlans = CreateDict("C:\\Git\\dfc-coursedirectory\\utils\\Cosmos\\Dfc.CosmosToCsv\\bin\\Debug\\net6.0\\ActionPlans.csv");
+        SQLScriptActionPlans(actionPlans);
+    }
+    //Extracts cosmosDB from csv to dictionary
+    public static Dictionary<String, String> CreateDict(string path)
+    {
+        Dictionary<String, String> cosmosDB = new Dictionary<String, String>();
+        try
+        {
+            //add csv file to \dfc-coursedirectory\utils\Cosmos\Dfc.CosmosToSQLScript\bin\Debug\net6.0\
+            using (TextFieldParser parser = new TextFieldParser(path))
+            {
+                parser.SetDelimiters(new string[] { "," });
+                //skips first line of column names
+                parser.ReadLine();
+
+                while (!parser.EndOfData)
+                {
+                    string[] fields = parser.ReadFields();
+                    //set fields to what you need e.g. id and SignpostedToCategory
+                    cosmosDB.Add(key: fields[0], value: fields[1]);
+                }
+            }
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine(e.Message);
+        }
+        return cosmosDB;
+    }
+
+    //writes the SQL script to a text file
+    public static void SQLScriptAction(Dictionary<String, String> cosmosDB)
+    {
+        //outputs to \dfc-coursedirectory\utils\Cosmos\Dfc.CosmosToSQLScript\bin\Debug\net6.0\
+        using (StreamWriter writer = new StreamWriter("UPDATE_ACTIONS.sql"))
+        {
+            foreach (var record in cosmosDB)
+            {
+                {
+                    writer.WriteLine($"UPDATE [dss-actions] SET SignpostedToCategory = {record.Value} WHERE id ='{record.Key}' AND SignpostedToCategory is null  ");
+                }
+
+            }
+        }
+    }
+
+    public static void SQLScriptActionPlans(Dictionary<String, String> cosmosDB)
+    {
+        //outputs to \dfc-coursedirectory\utils\Cosmos\Dfc.CosmosToSQLScript\bin\Debug\net6.0\
+        using (StreamWriter writer = new StreamWriter("UPDATE_ACTIONPLANS.sql"))
+        {
+            foreach (var record in cosmosDB)
+            {
+                {
+                    writer.WriteLine($"UPDATE [dss-actionplans] SET CustomerSatisfaction = {record.Value} WHERE id ='{record.Key}' AND CustomerSatisfaction is null");
+                }
+
+            }
+        }
+    }
+}


### PR DESCRIPTION
* NCSLT-859 Cosmos Duplicate Detection Utils

Generic Cosmos DB utility to detect duplicates.

* NCSLT-859 Added example appsettings template

* NCSLT859 Initial version of Bulk update tool

* NSCLT-859 - Added delete service

* Updated version

* Refactor

* Added Patch operation

* Added extra logging

* Added bulk execution

* Added optional partition key

* Added Add Option

* Updated to add retry for rate limited requests.

* Added the ability to patch using a list of ids

* Adding CosmosDB csv to SQL script generator

Takes in a CSV created from Dfc.CosmosToCsv and generates SQL script to update a table and set SignpostedToCategory for a given id from the csv

* Updated CosmosToSql utils

---------

Co-authored-by: Amandeep Sandhu <purpleduckmedia@gmail.com>
Co-authored-by: Amandeep Sandhu <github@purpleduckmedia.com>
Co-authored-by: hnandra <32364605+hnandra@users.noreply.github.com>