### PR TITLE
Repoint dfc-devops repository reference to master.

### DIFF
--- a/Dfc.CourseDirectory/Resources/AzureDevops/azure-pipelines.yml
+++ b/Dfc.CourseDirectory/Resources/AzureDevops/azure-pipelines.yml
@@ -19,7 +19,7 @@ resources:
     type: github
     name: SkillsFundingAgency/dfc-devops
     endpoint: 'GitHub (ESFA)'
-    ref: refs/tags/v1.11.2
+    ref: master
 
 trigger:
   batch: true


### PR DESCRIPTION
Latest commit to dfc-devops to address Az module
import error only available in master branch.