### PR TITLE
Fixing webapp and functionapp name. Hyphen for

### DIFF
--- a/Dfc.CourseDirectory.Api/Resources/ArmTemplates/template.json
+++ b/Dfc.CourseDirectory.Api/Resources/ArmTemplates/template.json
@@ -71,7 +71,7 @@
   },
   "variables": {
     "deploymentUrlBase": "https://raw.githubusercontent.com/SkillsFundingAgency/dfc-devops/master/ArmTemplates/",
-    "webAppName": "[concat(parameters('webAppPrefix'),'-as-', parameters('webAppSuffix'))]",
+    "webAppName": "[concat(parameters('webAppPrefix'),'-as', parameters('webAppSuffix'))]",
     "appInsightName": "[concat(parameters('webAppPrefix'),'-ai')]"
   },
   "resources": [

--- a/Dfc.CourseDirectory.FindACourseApi/Resources/ArmTemplates/template.json
+++ b/Dfc.CourseDirectory.FindACourseApi/Resources/ArmTemplates/template.json
@@ -71,7 +71,7 @@
   },
   "variables": {
     "deploymentUrlBase": "https://raw.githubusercontent.com/SkillsFundingAgency/dfc-devops/master/ArmTemplates/",
-    "webAppName": "[concat(parameters('webAppPrefix'),'-as-',parameters('webAppSuffix'))]",
+    "webAppName": "[concat(parameters('webAppPrefix'),'-as',parameters('webAppSuffix'))]",
     "appInsightName": "[concat(parameters('webAppPrefix'),'-ai')]"
   },
   "resources": [

--- a/Dfc.CourseDirectory/Resources/ArmTemplates/template.json
+++ b/Dfc.CourseDirectory/Resources/ArmTemplates/template.json
@@ -265,8 +265,8 @@
   "variables": {
     "deploymentUrlBase": "https://raw.githubusercontent.com/SkillsFundingAgency/dfc-devops/master/ArmTemplates/",
     "appInsightsName": "[concat(variables('appServiceName'),'-ai')]",
-    "appServiceName": "[concat(parameters('projectPrefix'),'-as-',parameters('projectSuffix'))]",
-    "functionAppName": "[concat(parameters('projectPrefix'),'-fa-',parameters('projectSuffix'))]",
+    "appServiceName": "[concat(parameters('projectPrefix'),'-as',parameters('projectSuffix'))]",
+    "functionAppName": "[concat(parameters('projectPrefix'),'-fa',parameters('projectSuffix'))]",
     "functionAppInsightsName": "[concat(variables('functionAppName'),'-ai')]"
   },
   "resources": [


### PR DESCRIPTION
migrated app should come from the variables as
lower environments does not have a migrated version of the apps.