### PR TITLE
Added environment appsettings json for lab environment

### DIFF
--- a/src/Dfc.CourseDirectory.Web/appsettings.Environment.LAB.json
+++ b/src/Dfc.CourseDirectory.Web/appsettings.Environment.LAB.json
@@ -1,0 +1,11 @@
+{
+  "DfeSignInSettings": {
+    "ApiBaseUri": "https://test-api.signin.education.gov.uk/",
+    "ServiceId": "CCE5DB23-7588-4B6B-9CD8-3665A4709484"
+  },
+  "FeatureFlags": "CoursesDataManagement,VenuesDataManagement,ApprenticeshipsDataManagement,OpenData",
+  "GoogleAnalytics": {
+    "ClientId": "UA-139898085-1"
+  },
+  "ManageUsersUrl": "https://test-manage.signin.education.gov.uk/"
+}


### PR DESCRIPTION
I have added the environment specific appsettings to the repository which allows the sign in callback to be accepted and stops a 500 error from being raised